### PR TITLE
fix: CameraModeArea limits, they only works in the active scene

### DIFF
--- a/godot/src/decentraland_components/camera_mode_area.gd
+++ b/godot/src/decentraland_components/camera_mode_area.gd
@@ -8,3 +8,8 @@ func _ready():
 	var shape = BoxShape3D.new()
 	shape.set_size(area)
 	collision_shape_3d.set_shape(shape)
+	collision_shape_3d.set_disabled(true)
+
+
+func _on_scene_active(active: bool):
+	collision_shape_3d.set_disabled(!active)

--- a/godot/src/decentraland_components/camera_mode_area.tscn
+++ b/godot/src/decentraland_components/camera_mode_area.tscn
@@ -1,7 +1,8 @@
-[gd_scene load_steps=4 format=3 uid="uid://b18cq0sobskjn"]
+[gd_scene load_steps=5 format=3 uid="uid://b18cq0sobskjn"]
 
 [ext_resource type="Script" path="res://src/decentraland_components/camera_mode_area.gd" id="1_bo2c6"]
 [ext_resource type="PackedScene" uid="uid://ksn0qud7g0lq" path="res://src/helpers_components/force_global_scale_component.tscn" id="2_76k0e"]
+[ext_resource type="PackedScene" uid="uid://decs8rg0sccrx" path="res://src/helpers_components/on_active_scene.tscn" id="3_lqqmy"]
 
 [sub_resource type="BoxShape3D" id="BoxShape3D_dvgte"]
 
@@ -17,3 +18,7 @@ shape = SubResource("BoxShape3D_dvgte")
 
 [node name="ForceGlobalScaleComponent" parent="." node_paths=PackedStringArray("target") instance=ExtResource("2_76k0e")]
 target = NodePath("..")
+
+[node name="OnActiveScene" parent="." instance=ExtResource("3_lqqmy")]
+
+[connection signal="on_scene_active" from="OnActiveScene" to="." method="_on_scene_active"]

--- a/godot/src/helpers_components/on_active_scene.gd
+++ b/godot/src/helpers_components/on_active_scene.gd
@@ -1,0 +1,32 @@
+# It emits a signal when the scene gets active
+
+extends Node3D
+
+signal on_scene_active(active: bool)
+
+var _my_scene_id: int = 0
+
+
+func _search_scene_node(target: Node3D) -> DclSceneNode:
+	if target is DclSceneNode:
+		return target
+
+	var parent_node_3d = target.get_parent_node_3d()
+	if parent_node_3d == null:
+		return null
+
+	return _search_scene_node(parent_node_3d)
+
+
+func _ready():
+	var scene_node: DclSceneNode = _search_scene_node(self)
+	if scene_node.is_global():
+		self.queue_free()
+		return
+
+	_my_scene_id = scene_node.get_scene_id()
+	Global.scene_runner.on_change_scene_id.connect(self._on_change_scene_id)
+
+
+func _on_change_scene_id(scene_id: int):
+	on_scene_active.emit(scene_id == _my_scene_id)

--- a/godot/src/helpers_components/on_active_scene.tscn
+++ b/godot/src/helpers_components/on_active_scene.tscn
@@ -1,0 +1,6 @@
+[gd_scene load_steps=2 format=3 uid="uid://decs8rg0sccrx"]
+
+[ext_resource type="Script" path="res://src/helpers_components/on_active_scene.gd" id="1_j0y6u"]
+
+[node name="OnActiveScene" type="Node3D"]
+script = ExtResource("1_j0y6u")

--- a/rust/decentraland-godot-lib/src/godot_classes/dcl_scene_node.rs
+++ b/rust/decentraland-godot-lib/src/godot_classes/dcl_scene_node.rs
@@ -1,0 +1,42 @@
+use godot::engine::Node3D;
+use godot::prelude::*;
+
+#[derive(GodotClass)]
+#[class(init, base=Node3D)]
+pub struct DclSceneNode {
+    scene_id: u32,
+
+    is_global: bool,
+
+    #[base]
+    _base: Base<Node3D>,
+}
+
+#[godot_api]
+impl DclSceneNode {
+    pub fn new_alloc(scene_id: u32, is_global: bool) -> Gd<Self> {
+        let mut obj = Gd::with_base(|_base| {
+            // accepts the base and returns a constructed object containing it
+            DclSceneNode {
+                _base,
+                scene_id,
+                is_global,
+            }
+        });
+        obj.set_name(GodotString::from(format!(
+            "scene_id_{:?}",
+            scene_id.clone()
+        )));
+        obj
+    }
+
+    #[func]
+    fn get_scene_id(&self) -> u32 {
+        self.scene_id
+    }
+
+    #[func]
+    fn is_global(&self) -> bool {
+        self.is_global
+    }
+}

--- a/rust/decentraland-godot-lib/src/godot_classes/mod.rs
+++ b/rust/decentraland-godot-lib/src/godot_classes/mod.rs
@@ -5,6 +5,7 @@ pub mod dcl_camera_mode_area_3d;
 pub mod dcl_confirm_dialog;
 pub mod dcl_global;
 pub mod dcl_realm;
+pub mod dcl_scene_node;
 pub mod dcl_ui_background;
 pub mod dcl_ui_control;
 pub mod dcl_ui_dropdown;

--- a/rust/decentraland-godot-lib/src/scene_runner/godot_dcl_scene.rs
+++ b/rust/decentraland-godot-lib/src/scene_runner/godot_dcl_scene.rs
@@ -8,7 +8,7 @@ use crate::{
         },
         SceneDefinition, SceneId,
     },
-    godot_classes::dcl_ui_control::DclUiControl,
+    godot_classes::{dcl_scene_node::DclSceneNode, dcl_ui_control::DclUiControl},
 };
 use godot::prelude::*;
 use std::{
@@ -22,7 +22,7 @@ use super::components::ui::{scene_ui::UiResults, style::UiTransform};
 pub struct GodotDclScene {
     pub entities: HashMap<SceneEntityId, GodotEntityNode>,
 
-    pub root_node_3d: Gd<Node3D>,
+    pub root_node_3d: Gd<DclSceneNode>,
     pub hierarchy_dirty_3d: bool,
     pub unparented_entities_3d: HashSet<SceneEntityId>,
 
@@ -145,13 +145,13 @@ impl GodotDclScene {
         scene_id: &SceneId,
         parent_node_ui: Gd<DclUiControl>,
     ) -> Self {
-        let mut root_node_3d = Node3D::new_alloc();
+        let mut root_node_3d = DclSceneNode::new_alloc(scene_id.0, scene_definition.is_global);
+
         root_node_3d.set_position(Vector3 {
             x: 16.0 * scene_definition.base.x as f32,
             y: 0.0,
             z: 16.0 * -scene_definition.base.y as f32,
         });
-        root_node_3d.set_name(GodotString::from(format!("scene_id_{:?}", scene_id.0)));
 
         let mut root_node_ui_control = DclUiControl::new_alloc();
         root_node_ui_control.set_name(GodotString::from(format!("ui_scene_id_{:?}", scene_id.0)));
@@ -166,7 +166,10 @@ impl GodotDclScene {
 
         let entities = HashMap::from([(
             SceneEntityId::new(0, 0),
-            GodotEntityNode::new(Some(root_node_3d.clone()), Some(root_node_ui)),
+            GodotEntityNode::new(
+                Some(root_node_3d.clone().upcast::<Node3D>()),
+                Some(root_node_ui),
+            ),
         )]);
 
         GodotDclScene {

--- a/rust/decentraland-godot-lib/src/scene_runner/scene_manager.rs
+++ b/rust/decentraland-godot-lib/src/scene_runner/scene_manager.rs
@@ -563,7 +563,14 @@ impl SceneManager {
         }
 
         self.last_current_parcel_scene_id = self.current_parcel_scene_id;
+        self.base.emit_signal(
+            "on_change_scene_id".into(),
+            &[Variant::from(self.current_parcel_scene_id.0)],
+        );
     }
+
+    #[signal]
+    fn on_change_scene_id(scene_id: u32) {}
 }
 
 #[godot_api]


### PR DESCRIPTION
feat: new on_active_scene component that emits a signal when the scenes becames active or non-active

Fix https://github.com/decentraland/godot-explorer/issues/78

# How to use it?
- Add the `OnActiveScene.tscn` to your scene.
- Connects the signal `on_scene_active` to your code.
- Do whatever you want, when the scene became active.