### PR TITLE
fix: avoid deno vm stop working on unhandled promises

### DIFF
--- a/rust/decentraland-godot-lib/src/dcl/js/js_modules/main.js
+++ b/rust/decentraland-godot-lib/src/dcl/js/js_modules/main.js
@@ -115,3 +115,8 @@ globalThis._internal_console = _internal_console;
 
 globalThis.fetch = require('fetch').fetch;
 globalThis.WebSocket = require('ws').WebSocket;
+
+Deno.core.ops.op_set_promise_reject_callback((type, promise, reason) => {
+    console.error('Unhandled promise: ', reason)
+    Deno.core.ops.op_promise_reject();
+})


### PR DESCRIPTION
Fix https://github.com/decentraland/godot-explorer/issues/43