### PR TITLE
feat: add `~system/Players` and some `sendBatch` events

### DIFF
--- a/rust/decentraland-godot-lib/build.rs
+++ b/rust/decentraland-godot-lib/build.rs
@@ -13,7 +13,8 @@ struct Component {
 
 const PROTO_FILES_BASE_DIR: &str = "src/dcl/components/proto/";
 const COMPONENT_BASE_DIR: &str = "src/dcl/components/proto/decentraland/sdk/components/";
-const GROW_ONLY_SET_COMPONENTS: [&str; 2] = ["PointerEventsResult", "VideoEvent"];
+const GROW_ONLY_SET_COMPONENTS: [&str; 3] =
+    ["PointerEventsResult", "VideoEvent", "AvatarEmoteCommand"];
 
 pub fn snake_to_pascal(input: &str) -> String {
     input

--- a/rust/decentraland-godot-lib/src/common/mod.rs
+++ b/rust/decentraland-godot-lib/src/common/mod.rs
@@ -1,1 +1,0 @@
-pub mod rpc;

--- a/rust/decentraland-godot-lib/src/dcl/crdt/entity.rs
+++ b/rust/decentraland-godot-lib/src/dcl/crdt/entity.rs
@@ -1,5 +1,7 @@
-use crate::dcl::{components::SceneEntityId, DirtyEntities};
+use crate::dcl::components::SceneEntityId;
 use std::collections::HashSet;
+
+use super::DirtyEntities;
 
 #[derive(Debug)]
 pub struct SceneEntityContainer {

--- a/rust/decentraland-godot-lib/src/dcl/crdt/grow_only_set.rs
+++ b/rust/decentraland-godot-lib/src/dcl/crdt/grow_only_set.rs
@@ -29,7 +29,7 @@ pub trait GenericGrowOnlySetComponent {
 
 pub trait GenericGrowOnlySetComponentOperation<T: 'static + FromDclReader + ToDclWriter> {
     fn append(&mut self, entity: SceneEntityId, value: T);
-    fn get(&self, entity: SceneEntityId) -> Option<&VecDeque<T>>;
+    fn get(&self, entity: &SceneEntityId) -> Option<&VecDeque<T>>;
 }
 
 impl<T> GrowOnlySet<T> {
@@ -104,8 +104,8 @@ impl<T: 'static + FromDclReader + ToDclWriter> GenericGrowOnlySetComponentOperat
         *dirty_count += 1;
     }
 
-    fn get(&self, entity: SceneEntityId) -> Option<&VecDeque<T>> {
-        self.values.get(&entity)
+    fn get(&self, entity: &SceneEntityId) -> Option<&VecDeque<T>> {
+        self.values.get(entity)
     }
 }
 

--- a/rust/decentraland-godot-lib/src/dcl/crdt/message.rs
+++ b/rust/decentraland-godot-lib/src/dcl/crdt/message.rs
@@ -102,6 +102,7 @@ pub fn process_many_messages(stream: &mut DclReader, scene_crdt_state: &mut Scen
     }
 }
 
+const CRDT_DELETE_ENTITY_HEADER_SIZE: usize = CRDT_HEADER_SIZE + 4;
 const CRDT_PUT_COMPONENT_HEADER_SIZE: usize = CRDT_HEADER_SIZE + 20;
 const CRDT_DELETE_COMPONENT_HEADER_SIZE: usize = CRDT_HEADER_SIZE + 16;
 
@@ -152,7 +153,7 @@ pub fn append_gos_component(
     scene_crdt_state: &SceneCrdtState,
     entity_id: &SceneEntityId,
     component_id: &SceneComponentId,
-    elements_count: usize,
+    elements_count: &usize,
     writer: &mut DclWriter,
 ) -> Result<(), String> {
     let Some(component_definition) = scene_crdt_state.get_gos_component_definition(*component_id)
@@ -160,7 +161,7 @@ pub fn append_gos_component(
         return Err("Component not found".into());
     };
 
-    for i in 0..elements_count {
+    for i in 0..*elements_count {
         // TODO: this can be improved by using the same writer, we don't know the component_data_length in advance to write the right length
         //  but if we have the position written we can overwrite then
         let mut component_buf = Vec::new();
@@ -181,4 +182,10 @@ pub fn append_gos_component(
     }
 
     Ok(())
+}
+
+pub fn delete_entity(entity_id: &SceneEntityId, writer: &mut DclWriter) {
+    writer.write_u32(CRDT_DELETE_ENTITY_HEADER_SIZE as u32);
+    writer.write(&CrdtMessageType::DeleteEntity);
+    writer.write(entity_id);
 }

--- a/rust/decentraland-godot-lib/src/dcl/js/engine.rs
+++ b/rust/decentraland-godot-lib/src/dcl/js/engine.rs
@@ -6,20 +6,24 @@ use std::{
 
 use deno_core::{op, Op, OpDecl, OpState};
 
-use crate::{
-    common::rpc::RpcCalls,
-    dcl::{
-        crdt::{
-            message::{append_gos_component, process_many_messages, put_or_delete_lww_component},
-            SceneCrdtState,
+use crate::dcl::{
+    crdt::{
+        message::{
+            append_gos_component, delete_entity, process_many_messages, put_or_delete_lww_component,
         },
-        js::{SceneDying, SceneMainCrdtFileContent},
-        serialization::{reader::DclReader, writer::DclWriter},
-        RendererResponse, SceneId, SceneResponse, SharedSceneCrdtState,
+        SceneCrdtState,
     },
+    js::{SceneDying, SceneMainCrdtFileContent},
+    scene_apis::{LocalCall, RpcCall},
+    serialization::{reader::DclReader, writer::DclWriter},
+    RendererResponse, SceneId, SceneResponse, SharedSceneCrdtState,
 };
 
-use super::{SceneElapsedTime, SceneLogs};
+use super::{
+    events::process_events,
+    players::{get_player_data, get_players},
+    SceneElapsedTime, SceneLogs,
+};
 
 // list of op declarations
 pub fn ops() -> Vec<OpDecl> {
@@ -60,7 +64,7 @@ fn op_crdt_send_to_renderer(op_state: Rc<RefCell<OpState>>, messages: &[u8]) {
     op_state.put(mutex_scene_crdt_state);
     op_state.put(scene_id);
 
-    let rpc_calls = std::mem::take(op_state.borrow_mut::<RpcCalls>());
+    let rpc_calls = std::mem::take(op_state.borrow_mut::<Vec<RpcCall>>());
 
     let sender = op_state.borrow_mut::<std::sync::mpsc::SyncSender<SceneResponse>>();
 
@@ -90,23 +94,22 @@ async fn op_crdt_recv_from_renderer(op_state: Rc<RefCell<OpState>>) -> Vec<Vec<u
     let mut op_state = op_state.borrow_mut();
     op_state.put(receiver);
 
+    let local_api_calls = op_state.take::<Vec<LocalCall>>();
     let mutex_scene_crdt_state = op_state.take::<Arc<Mutex<SceneCrdtState>>>();
     let cloned_scene_crdt = mutex_scene_crdt_state.clone();
     let scene_crdt_state = cloned_scene_crdt.lock().unwrap();
 
     let data = match response {
-        Some(RendererResponse::Ok(data)) => {
-            let (_dirty_entities, dirty_lww_components, dirty_gos_components) = data;
-
+        Some(RendererResponse::Ok(dirty)) => {
             let mut data_buf = Vec::new();
             let mut data_writter = DclWriter::new(&mut data_buf);
 
-            for (component_id, entities) in dirty_lww_components {
+            for (component_id, entities) in dirty.lww.iter() {
                 for entity_id in entities {
                     if let Err(err) = put_or_delete_lww_component(
                         &scene_crdt_state,
-                        &entity_id,
-                        &component_id,
+                        entity_id,
+                        component_id,
                         &mut data_writter,
                     ) {
                         tracing::info!("error writing crdt message: {err}");
@@ -114,12 +117,12 @@ async fn op_crdt_recv_from_renderer(op_state: Rc<RefCell<OpState>>) -> Vec<Vec<u
                 }
             }
 
-            for (component_id, entities) in dirty_gos_components {
+            for (component_id, entities) in dirty.gos.iter() {
                 for (entity_id, element_count) in entities {
                     if let Err(err) = append_gos_component(
                         &scene_crdt_state,
-                        &entity_id,
-                        &component_id,
+                        entity_id,
+                        component_id,
                         element_count,
                         &mut data_writter,
                     ) {
@@ -127,6 +130,13 @@ async fn op_crdt_recv_from_renderer(op_state: Rc<RefCell<OpState>>) -> Vec<Vec<u
                     }
                 }
             }
+
+            for entity_id in dirty.entities.died.iter() {
+                delete_entity(entity_id, &mut data_writter);
+            }
+
+            process_local_api_calls(local_api_calls, &scene_crdt_state);
+            process_events(&mut op_state, &scene_crdt_state, &dirty);
 
             data_buf
         }
@@ -148,4 +158,20 @@ async fn op_crdt_recv_from_renderer(op_state: Rc<RefCell<OpState>>) -> Vec<Vec<u
     }
     ret.push(data);
     ret
+}
+
+fn process_local_api_calls(local_api_calls: Vec<LocalCall>, crdt_state: &SceneCrdtState) {
+    for local_call in local_api_calls {
+        match local_call {
+            LocalCall::PlayersGetPlayerData { user_id, response } => {
+                response.send(get_player_data(user_id, crdt_state));
+            }
+            LocalCall::PlayersGetPlayersInScene { response } => {
+                response.send(get_players(crdt_state, true));
+            }
+            LocalCall::PlayersGetConnectedPlayers { response } => {
+                response.send(get_players(crdt_state, false));
+            }
+        }
+    }
 }

--- a/rust/decentraland-godot-lib/src/dcl/js/events.rs
+++ b/rust/decentraland-godot-lib/src/dcl/js/events.rs
@@ -1,0 +1,565 @@
+use crate::dcl::{
+    components::{
+        proto_components::sdk::components::common::{InputAction, PointerEventType, RaycastHit},
+        SceneComponentId, SceneEntityId,
+    },
+    crdt::{
+        grow_only_set::GenericGrowOnlySetComponentOperation, DirtyCrdtState, SceneCrdtState,
+        SceneCrdtStateProtoComponents,
+    },
+};
+use deno_core::{op, Op, OpDecl, OpState};
+use serde::Serialize;
+use std::{
+    collections::{HashMap, HashSet},
+    marker::PhantomData,
+};
+
+pub fn ops() -> Vec<OpDecl> {
+    vec![
+        op_subscribe::DECL,
+        op_unsubscribe::DECL,
+        op_send_batch::DECL,
+    ]
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct EventBodyUserId {
+    user_id: String,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct EventBodyExpressionId {
+    expression_id: String,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct EventBodyProfileChanged {
+    eth_address: String,
+    version: i32,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct EventBodyRealmChanged {
+    domain: String,
+    room: String,
+    server_name: String,
+    display_name: String,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct EventBodyPlayerClicked {
+    user_id: String,
+    ray: EventBodyRay,
+}
+
+#[derive(Serialize)]
+struct EventBodyRay {
+    origin: EventBodyVector3,
+    direction: EventBodyVector3,
+    distance: f32,
+}
+
+#[derive(Serialize)]
+struct EventBodyVector3 {
+    x: f32,
+    y: f32,
+    z: f32,
+}
+
+impl From<Option<&RaycastHit>> for EventBodyRay {
+    fn from(ray: Option<&RaycastHit>) -> Self {
+        if let Some(ray) = ray {
+            Self {
+                origin: EventBodyVector3 {
+                    x: ray.global_origin.as_ref().map(|v| v.x).unwrap_or_default(),
+                    y: ray.global_origin.as_ref().map(|v| v.y).unwrap_or_default(),
+                    z: ray.global_origin.as_ref().map(|v| v.z).unwrap_or_default(),
+                },
+                direction: EventBodyVector3 {
+                    x: ray.direction.as_ref().map(|v| v.x).unwrap_or_default(),
+                    y: ray.direction.as_ref().map(|v| v.y).unwrap_or_default(),
+                    z: ray.direction.as_ref().map(|v| v.z).unwrap_or_default(),
+                },
+                distance: ray.length,
+            }
+        } else {
+            Self {
+                origin: EventBodyVector3 {
+                    x: 0.0,
+                    y: 0.0,
+                    z: 0.0,
+                },
+                direction: EventBodyVector3 {
+                    x: 0.0,
+                    y: 0.0,
+                    z: 0.0,
+                },
+                distance: 0.0,
+            }
+        }
+    }
+}
+
+trait EventType {
+    fn label() -> &'static str;
+}
+
+macro_rules! impl_event {
+    ($name: ident, $label: expr) => {
+        #[derive(Debug)]
+        struct $name;
+        impl EventType for $name {
+            fn label() -> &'static str {
+                $label
+            }
+        }
+    };
+}
+
+impl_event!(PlayerConnected, "playerConnected");
+impl_event!(PlayerDisconnected, "playerDisconnected");
+impl_event!(PlayerEnteredScene, "onEnterScene");
+impl_event!(PlayerLeftScene, "onLeaveScene");
+impl_event!(SceneReady, "sceneStart");
+impl_event!(PlayerExpression, "playerExpression");
+impl_event!(ProfileChanged, "profileChanged");
+impl_event!(RealmChanged, "onRealmChanged");
+impl_event!(PlayerClicked, "playerClicked");
+impl_event!(MessageBus, "comms");
+
+struct EventReceiver<T: EventType> {
+    inner: tokio::sync::mpsc::UnboundedReceiver<String>,
+    _p: PhantomData<fn() -> T>,
+}
+
+struct EventSender<T: EventType> {
+    inner: tokio::sync::mpsc::UnboundedSender<String>,
+    _p: PhantomData<fn() -> T>,
+}
+
+#[op]
+fn op_subscribe(state: &mut OpState, id: &str) {
+    macro_rules! register {
+        ($id: expr, $state: expr, $marker: ty) => {{
+            if id == <$marker as EventType>::label() {
+                if $state.has::<EventReceiver<$marker>>() {
+                    return;
+                }
+                let (sx, rx) = tokio::sync::mpsc::unbounded_channel::<String>();
+
+                state.put(EventReceiver::<$marker> {
+                    inner: rx,
+                    _p: Default::default(),
+                });
+                state.put(EventSender::<$marker> {
+                    inner: sx,
+                    _p: Default::default(),
+                });
+
+                tracing::debug!("subscribed to {}", <$marker as EventType>::label());
+                return;
+            }
+        }};
+    }
+
+    register!(id, state, PlayerConnected);
+    register!(id, state, PlayerDisconnected);
+    register!(id, state, PlayerEnteredScene);
+    register!(id, state, PlayerLeftScene);
+    register!(id, state, SceneReady);
+    register!(id, state, PlayerExpression);
+    register!(id, state, ProfileChanged);
+    register!(id, state, RealmChanged);
+    register!(id, state, PlayerClicked);
+    register!(id, state, MessageBus);
+
+    tracing::warn!("subscribe to unrecognised event {id}");
+}
+
+#[op]
+fn op_unsubscribe(state: &mut OpState, id: &str) {
+    macro_rules! unregister {
+        ($id: expr, $state: expr, $marker: ty) => {{
+            if id == <$marker as EventType>::label() {
+                // removing the receiver will cause the sender to error so it can be cleaned up at the sender side
+                state.try_take::<EventReceiver<$marker>>();
+                state.try_take::<EventSender<$marker>>();
+                return;
+            }
+        }};
+    }
+
+    unregister!(id, state, PlayerConnected);
+    unregister!(id, state, PlayerDisconnected);
+    unregister!(id, state, PlayerEnteredScene);
+    unregister!(id, state, PlayerLeftScene);
+    unregister!(id, state, SceneReady);
+    unregister!(id, state, PlayerExpression);
+    unregister!(id, state, ProfileChanged);
+    unregister!(id, state, RealmChanged);
+    unregister!(id, state, PlayerClicked);
+    unregister!(id, state, MessageBus);
+
+    tracing::warn!("unsubscribe for unrecognised event {id}");
+}
+
+#[derive(Serialize)]
+struct Event {
+    generic: EventGeneric,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct EventGeneric {
+    event_id: String,
+    event_data: String,
+}
+
+#[op]
+fn op_send_batch(state: &mut OpState) -> Vec<Event> {
+    let mut results = Vec::default();
+
+    macro_rules! poll {
+        ($state: expr, $marker: ty, $id: expr) => {{
+            if let Some(receiver) = state.try_borrow_mut::<EventReceiver<$marker>>() {
+                while let Ok(event_data) = receiver.inner.try_recv() {
+                    tracing::debug!("received {} event", <$marker as EventType>::label());
+                    results.push(Event {
+                        generic: EventGeneric {
+                            event_id: $id.to_owned(),
+                            event_data,
+                        },
+                    });
+                }
+            }
+        }};
+    }
+
+    poll!(state, PlayerConnected, "playerConnected");
+    poll!(state, PlayerDisconnected, "playerDisconnected");
+    poll!(state, PlayerEnteredScene, "onEnterScene");
+    poll!(state, PlayerLeftScene, "onLeaveScene");
+    poll!(state, PlayerClicked, "playerClicked");
+    poll!(state, PlayerExpression, "playerExpression");
+    poll!(state, ProfileChanged, "profileChanged");
+
+    poll!(state, RealmChanged, "onRealmChanged");
+    poll!(state, MessageBus, "comms");
+    poll!(state, SceneReady, "sceneStart");
+
+    results
+}
+
+pub fn process_events(
+    op_state: &mut OpState,
+    crdt_state: &SceneCrdtState,
+    dirty_crdt_state: &DirtyCrdtState,
+) {
+    process_events_players_stateful(op_state, crdt_state, dirty_crdt_state);
+    process_events_players_stateless(op_state, crdt_state, dirty_crdt_state);
+
+    // TODO: RealmChanged, it needs to add a new component to the crdt (realmInfo or something)
+    // TODO: MessageBus, sender should be on the main thread side
+    // TODO: SceneReady, in the tick == 4, send the event
+}
+
+struct EventPlayerState {
+    current_players: HashMap<SceneEntityId, String>,
+    inside_scene: HashSet<SceneEntityId>,
+}
+
+impl EventPlayerState {
+    fn new(crdt_state: &SceneCrdtState) -> Self {
+        let player_identity_data_component =
+            SceneCrdtStateProtoComponents::get_player_identity_data(crdt_state);
+        let transform_component = crdt_state.get_transform();
+
+        let current_players =
+            HashMap::from_iter(player_identity_data_component.values.iter().filter_map(
+                |(entity_id, value)| {
+                    value
+                        .value
+                        .as_ref()
+                        .map(|value| (*entity_id, value.address.clone()))
+                },
+            ));
+
+        let inside_scene = HashSet::from_iter(transform_component.values.iter().filter_map(
+            |(entity_id, value)| {
+                if value.value.is_some() {
+                    Some(*entity_id)
+                } else {
+                    None
+                }
+            },
+        ));
+        Self {
+            current_players,
+            inside_scene,
+        }
+    }
+}
+
+pub fn process_events_players_stateless(
+    op_state: &mut OpState,
+    crdt_state: &SceneCrdtState,
+    dirty_crdt_state: &DirtyCrdtState,
+) {
+    let player_identity_data_component =
+        SceneCrdtStateProtoComponents::get_player_identity_data(crdt_state);
+
+    if let Some(player_clicked_sender) = op_state.try_take::<EventSender<PlayerClicked>>() {
+        let pointer_events_result_component =
+            SceneCrdtStateProtoComponents::get_pointer_events_result(crdt_state);
+
+        if let Some(pointer_event_results) = dirty_crdt_state
+            .gos
+            .get(&SceneComponentId::POINTER_EVENTS_RESULT)
+        {
+            for (entity_id, elements_count) in pointer_event_results {
+                let Some(user_id) = player_identity_data_component
+                    .values
+                    .get(entity_id)
+                    .and_then(|value| value.value.as_ref())
+                    .map(|value| value.address.clone())
+                else {
+                    continue;
+                };
+                let Some(grow_only_set) = pointer_events_result_component.values.get(entity_id)
+                else {
+                    continue;
+                };
+
+                for i in 0..*elements_count {
+                    let Some(value) = grow_only_set.get(i) else {
+                        continue;
+                    };
+                    if value.button() == InputAction::IaPointer
+                        && value.state() == PointerEventType::PetDown
+                    {
+                        player_clicked_sender
+                            .inner
+                            .send(
+                                serde_json::to_string(&EventBodyPlayerClicked {
+                                    user_id: user_id.clone(),
+                                    ray: EventBodyRay::from(value.hit.as_ref()),
+                                })
+                                .expect("fail json serialize"),
+                            )
+                            .unwrap();
+                    }
+                }
+            }
+        }
+
+        op_state.put(player_clicked_sender);
+    }
+
+    // Note: The player expression event is only for the current player, not foreign players
+    if let Some(player_expression_sender) = op_state.try_take::<EventSender<PlayerExpression>>() {
+        let avatar_emote_command_component =
+            SceneCrdtStateProtoComponents::get_avatar_emote_command(crdt_state);
+
+        let new_values_count = {
+            if let Some(dirty_crdt_state) = dirty_crdt_state
+                .gos
+                .get(&SceneComponentId::AVATAR_EMOTE_COMMAND)
+            {
+                *dirty_crdt_state.get(&SceneEntityId::PLAYER).unwrap_or(&0)
+            } else {
+                0
+            }
+        };
+
+        if new_values_count > 0 {
+            if let Some(emote_command) = avatar_emote_command_component.get(&SceneEntityId::PLAYER)
+            {
+                for i in 0..new_values_count {
+                    let Some(value) = emote_command.get(i) else {
+                        continue;
+                    };
+
+                    player_expression_sender
+                        .inner
+                        .send(
+                            serde_json::to_string(&EventBodyExpressionId {
+                                expression_id: value
+                                    .emote_command
+                                    .as_ref()
+                                    .map(|v| v.emote_urn.clone())
+                                    .unwrap_or_default(),
+                            })
+                            .expect("fail json serialize"),
+                        )
+                        .unwrap();
+                }
+            }
+        }
+
+        op_state.put(player_expression_sender);
+    }
+
+    if let Some(profile_changed_sender) = op_state.try_take::<EventSender<ProfileChanged>>() {
+        op_state.put(profile_changed_sender);
+    }
+}
+
+pub fn process_events_players_stateful(
+    op_state: &mut OpState,
+    crdt_state: &SceneCrdtState,
+    dirty_crdt_state: &DirtyCrdtState,
+) {
+    let is_subscribed = op_state.has::<EventSender<PlayerConnected>>()
+        || op_state.has::<EventSender<PlayerDisconnected>>()
+        || op_state.has::<EventSender<PlayerEnteredScene>>()
+        || op_state.has::<EventSender<PlayerLeftScene>>();
+
+    if !is_subscribed {
+        // When it's not subscribed, clean the state if it'exists
+        let _ = op_state.try_take::<EventPlayerState>();
+        return;
+    }
+
+    let mut events_state = {
+        if let Some(events_state) = op_state.try_take::<EventPlayerState>() {
+            events_state
+        } else {
+            // First tick after subscription
+            EventPlayerState::new(crdt_state)
+        }
+    };
+
+    let player_identity_data_component =
+        SceneCrdtStateProtoComponents::get_player_identity_data(crdt_state);
+
+    let player_identity_data_component_dirty = dirty_crdt_state
+        .lww
+        .get(&SceneComponentId::PLAYER_IDENTITY_DATA);
+
+    let player_connected_sender = op_state.try_take::<EventSender<PlayerConnected>>();
+    let player_disconnected_sender = op_state.try_take::<EventSender<PlayerDisconnected>>();
+
+    if let Some(player_identity_data_component_dirty) = player_identity_data_component_dirty {
+        for entity_id in player_identity_data_component_dirty {
+            let existing_value = {
+                if let Some(value) = player_identity_data_component
+                    .values
+                    .get(entity_id)
+                    .as_ref()
+                {
+                    value.value.as_ref()
+                } else {
+                    None
+                }
+            };
+
+            if let Some(player_identity_value) = existing_value {
+                events_state
+                    .current_players
+                    .insert(*entity_id, player_identity_value.address.clone());
+                if let Some(player_connected_sender) = player_connected_sender.as_ref() {
+                    player_connected_sender
+                        .inner
+                        .send(
+                            serde_json::to_string(&EventBodyUserId {
+                                user_id: player_identity_value.address.clone(),
+                            })
+                            .expect("fail json serialize"),
+                        )
+                        .unwrap();
+                }
+            } else {
+                let address = events_state.current_players.remove(entity_id);
+
+                if let Some(user_id) = address {
+                    if let Some(player_disconnected_sender) = player_disconnected_sender.as_ref() {
+                        player_disconnected_sender
+                            .inner
+                            .send(
+                                serde_json::to_string(&EventBodyUserId { user_id })
+                                    .expect("fail json serialize"),
+                            )
+                            .unwrap();
+                    }
+                }
+            }
+        }
+    }
+
+    if let Some(player_connected_sender) = player_connected_sender {
+        op_state.put(player_connected_sender);
+    }
+    if let Some(player_disconnected_sender) = player_disconnected_sender {
+        op_state.put(player_disconnected_sender);
+    }
+
+    let player_entered_scene_sender = op_state.try_take::<EventSender<PlayerEnteredScene>>();
+    let player_left_scene_sender = op_state.try_take::<EventSender<PlayerLeftScene>>();
+
+    let transform_component_dirty = dirty_crdt_state.lww.get(&SceneComponentId::TRANSFORM);
+    let transform_component = crdt_state.get_transform();
+
+    if let Some(transform_component_dirty) = transform_component_dirty {
+        for entity_id in transform_component_dirty {
+            let value_exists = {
+                if let Some(value) = transform_component.values.get(entity_id).as_ref() {
+                    value.value.is_some()
+                } else {
+                    false
+                }
+            };
+            let entity_is_inside = events_state.inside_scene.contains(entity_id);
+
+            if value_exists != entity_is_inside {
+                if value_exists {
+                    events_state.inside_scene.insert(*entity_id);
+
+                    if let Some(user_id) = events_state.current_players.get(entity_id).cloned() {
+                        if let Some(player_entered_scene_sender) =
+                            player_entered_scene_sender.as_ref()
+                        {
+                            player_entered_scene_sender
+                                .inner
+                                .send(
+                                    serde_json::to_string(&EventBodyUserId { user_id })
+                                        .expect("fail json serialize"),
+                                )
+                                .unwrap();
+                        }
+                    }
+                } else {
+                    events_state.inside_scene.remove(entity_id);
+
+                    if let Some(user_id) = events_state.current_players.get(entity_id).cloned() {
+                        if let Some(player_left_scene_sender) = player_left_scene_sender.as_ref() {
+                            player_left_scene_sender
+                                .inner
+                                .send(
+                                    serde_json::to_string(&EventBodyUserId { user_id })
+                                        .expect("fail json serialize"),
+                                )
+                                .unwrap();
+                        }
+                    } else {
+                        tracing::error!("entity left scene but no player identity data found");
+                    }
+                }
+            }
+        }
+    }
+
+    if let Some(player_entered_scene_sender) = player_entered_scene_sender {
+        op_state.put(player_entered_scene_sender);
+    }
+    if let Some(player_left_scene_sender) = player_left_scene_sender {
+        op_state.put(player_left_scene_sender);
+    }
+
+    op_state.put(events_state);
+}

--- a/rust/decentraland-godot-lib/src/dcl/js/js_modules/EngineApi.js
+++ b/rust/decentraland-godot-lib/src/dcl/js/js_modules/EngineApi.js
@@ -16,7 +16,7 @@ module.exports.crdtGetState = async function () {
 }
 
 
-module.exports.isServer = async function() {
+module.exports.isServer = async function () {
     return {
         isServer: false
     }
@@ -26,18 +26,22 @@ module.exports.isServer = async function() {
  * @deprecated this is an SDK6 API.
  * This function subscribe to an event from the renderer
  */
-module.exports.subscribe = async function(message) {}
+module.exports.subscribe = async function (message) {
+    Deno.core.ops.op_subscribe(message.eventId);
+}
 
 /**
  * @deprecated this is an SDK6 API.
  * This function unsubscribe to an event from the renderer
  */
-module.exports.unsubscribe = async function(message) {}
+module.exports.unsubscribe = async function (message) {
+    Deno.core.ops.op_subscribe(message.eventId);
+}
 
 /**
  * @deprecated this is an SDK6 API.
  * This function polls events from the renderer
  */
-module.exports.sendBatch = async function() {
-    return { events: [] }
+module.exports.sendBatch = async function () {
+    return { events: Deno.core.ops.op_send_batch() }
 }

--- a/rust/decentraland-godot-lib/src/dcl/js/js_modules/Players.js
+++ b/rust/decentraland-godot-lib/src/dcl/js/js_modules/Players.js
@@ -1,3 +1,20 @@
-module.exports.getPlayerData = async function (body) { return {} }
-module.exports.getPlayersInScene = async function (body) { return {} }
-module.exports.getConnectedPlayers = async function (body) { return {} }
+module.exports.getPlayerData = async function (body) {
+    let res = await Deno.core.ops.op_get_player_data(body.userId);
+    return {
+        data: res
+    };
+}
+
+module.exports.getPlayersInScene = async function (body) {
+    let res = await Deno.core.ops.op_get_players_in_scene();
+    return {
+        players: res.map((address) => ({ userId: address }))
+    }
+}
+
+module.exports.getConnectedPlayers = async function (body) {
+    let res = await Deno.core.ops.op_get_connected_players();
+    return {
+        players: res.map((address) => ({ userId: address }))
+    }
+}

--- a/rust/decentraland-godot-lib/src/dcl/js/mod.rs
+++ b/rust/decentraland-godot-lib/src/dcl/js/mod.rs
@@ -1,11 +1,13 @@
 pub mod engine;
+pub mod events;
 pub mod fetch;
+pub mod players;
 pub mod portables;
 pub mod restricted_actions;
 pub mod runtime;
 pub mod websocket;
 
-use crate::common::rpc::RpcCalls;
+use crate::dcl::scene_apis::{LocalCall, RpcCall};
 use crate::wallet::Wallet;
 
 use super::{
@@ -62,13 +64,15 @@ pub fn create_runtime() -> deno_core::JsRuntime {
     // add core ops
     ext = ext.ops(vec![op_require::DECL, op_log::DECL, op_error::DECL]);
 
-    let op_sets: [Vec<deno_core::OpDecl>; 6] = [
+    let op_sets: [Vec<deno_core::OpDecl>; 8] = [
         engine::ops(),
         runtime::ops(),
         fetch::ops(),
         websocket::ops(),
         restricted_actions::ops(),
         portables::ops(),
+        players::ops(),
+        events::ops(),
     ];
 
     let mut op_map = HashMap::new();
@@ -142,7 +146,7 @@ pub(crate) fn scene_thread(
                     dirty,
                     Vec::new(),
                     0.0,
-                    RpcCalls::default(),
+                    Vec::new(),
                 ))
                 .expect("error sending scene response!!");
 
@@ -187,7 +191,8 @@ pub(crate) fn scene_thread(
 
     state.borrow_mut().put(wallet);
 
-    state.borrow_mut().put(RpcCalls::default());
+    state.borrow_mut().put(Vec::<RpcCall>::new());
+    state.borrow_mut().put(Vec::<LocalCall>::new());
 
     if let Some(scene_main_crdt) = scene_main_crdt {
         state.borrow_mut().put(scene_main_crdt);

--- a/rust/decentraland-godot-lib/src/dcl/js/players.rs
+++ b/rust/decentraland-godot-lib/src/dcl/js/players.rs
@@ -1,0 +1,149 @@
+use std::{cell::RefCell, rc::Rc};
+
+use deno_core::{
+    anyhow::{self},
+    error::AnyError,
+    op, Op, OpDecl, OpState,
+};
+
+use crate::dcl::{
+    crdt::{SceneCrdtState, SceneCrdtStateProtoComponents},
+    scene_apis::{LocalCall, UserData},
+};
+
+pub fn ops() -> Vec<OpDecl> {
+    vec![
+        op_get_player_data::DECL,
+        op_get_connected_players::DECL,
+        op_get_players_in_scene::DECL,
+    ]
+}
+
+#[op]
+async fn op_get_player_data(
+    op_state: Rc<RefCell<OpState>>,
+    user_id: String,
+) -> Result<Option<UserData>, AnyError> {
+    let (sx, rx) = tokio::sync::oneshot::channel::<Option<UserData>>();
+
+    op_state
+        .borrow_mut()
+        .borrow_mut::<Vec<LocalCall>>()
+        .push(LocalCall::PlayersGetPlayerData {
+            user_id,
+            response: sx.into(),
+        });
+
+    rx.await.map_err(|e| anyhow::anyhow!(e))
+}
+
+#[op]
+async fn op_get_players_in_scene(op_state: Rc<RefCell<OpState>>) -> Result<Vec<String>, AnyError> {
+    let (sx, rx) = tokio::sync::oneshot::channel::<Vec<String>>();
+
+    op_state.borrow_mut().borrow_mut::<Vec<LocalCall>>().push(
+        LocalCall::PlayersGetPlayersInScene {
+            response: sx.into(),
+        },
+    );
+
+    rx.await.map_err(|e| anyhow::anyhow!(e))
+}
+
+#[op]
+async fn op_get_connected_players(op_state: Rc<RefCell<OpState>>) -> Result<Vec<String>, AnyError> {
+    let (sx, rx) = tokio::sync::oneshot::channel::<Vec<String>>();
+
+    op_state.borrow_mut().borrow_mut::<Vec<LocalCall>>().push(
+        LocalCall::PlayersGetConnectedPlayers {
+            response: sx.into(),
+        },
+    );
+
+    rx.await.map_err(|e| anyhow::anyhow!(e))
+}
+
+pub fn get_players(crdt_state: &SceneCrdtState, only_in_scene: bool) -> Vec<String> {
+    let player_identity_data_component =
+        SceneCrdtStateProtoComponents::get_player_identity_data(crdt_state);
+    let transform_component = crdt_state.get_transform();
+
+    player_identity_data_component
+        .values
+        .iter()
+        .filter(|(entity_id, entry)| {
+            let Some(_) = entry.value.as_ref() else {
+                return false;
+            };
+            let Some(transform_entry) = transform_component.values.get(entity_id) else {
+                return false;
+            };
+            if only_in_scene {
+                let Some(_) = transform_entry.value.as_ref() else {
+                    return false;
+                };
+            }
+            true
+        })
+        .map(|v| {
+            v.1.value
+                .as_ref()
+                .expect("previously acceded to filter")
+                .address
+                .clone()
+        })
+        .collect::<Vec<String>>()
+}
+
+pub fn get_player_data(user_id: String, crdt_state: &SceneCrdtState) -> Option<UserData> {
+    let player_identity_data_component =
+        SceneCrdtStateProtoComponents::get_player_identity_data(crdt_state);
+    let avatar_base_component = SceneCrdtStateProtoComponents::get_avatar_base(crdt_state);
+    let avatar_equipped_data_component =
+        SceneCrdtStateProtoComponents::get_avatar_equipped_data(crdt_state);
+
+    let (player_entity_id, player_entry) =
+        player_identity_data_component
+            .values
+            .iter()
+            .find(|(_entity_id, entry)| {
+                if let Some(data) = entry.value.as_ref() {
+                    return data.address == user_id;
+                }
+                false
+            })?;
+
+    let player_identity_data_value = player_entry.value.as_ref()?;
+    let avatar_base_value = avatar_base_component
+        .values
+        .get(player_entity_id)?
+        .value
+        .as_ref()?;
+    let _avatar_equipped_data_value = avatar_equipped_data_component
+        .values
+        .get(player_entity_id)?
+        .value
+        .as_ref()?;
+
+    let user_data = UserData {
+        display_name: avatar_base_value.name.clone(),
+        public_key: if player_identity_data_value.is_guest {
+            None
+        } else {
+            Some(player_identity_data_value.address.clone())
+        },
+        has_connected_web3: !player_identity_data_value.is_guest,
+        user_id: player_identity_data_value.address.clone(),
+        version: 0, // TODO: how to get this?
+        avatar: None,
+        // avatar: Some(AvatarForUserData {
+        //     body_shape: avatar_base_value.body_shape_urn.clone(),
+        //     skin_color: avatar_base_value.skin_color.clone().unwrap_or(Color3).to_string(),
+        //     hair_color: String,
+        //     eye_color: String,
+        //     wearables: Vec<String>,
+        //     snapshots: Option<Snapshots>
+        // }),
+    };
+    Some(user_data)
+}

--- a/rust/decentraland-godot-lib/src/dcl/js/portables.rs
+++ b/rust/decentraland-godot-lib/src/dcl/js/portables.rs
@@ -5,9 +5,7 @@ use deno_core::{
 };
 use std::{cell::RefCell, rc::Rc};
 
-use crate::common::rpc::{PortableLocation, RpcCall, SpawnResponse};
-
-use super::RpcCalls;
+use crate::dcl::scene_apis::{PortableLocation, RpcCall, SpawnResponse};
 
 // list of op declarations
 pub fn ops() -> Vec<OpDecl> {
@@ -34,7 +32,7 @@ async fn op_portable_spawn(
 
     state
         .borrow_mut()
-        .borrow_mut::<RpcCalls>()
+        .borrow_mut::<Vec<RpcCall>>()
         .push(RpcCall::SpawnPortable {
             location,
             response: sx.into(),
@@ -53,7 +51,7 @@ async fn op_portable_kill(state: Rc<RefCell<OpState>>, pid: String) -> Result<bo
 
     state
         .borrow_mut()
-        .borrow_mut::<RpcCalls>()
+        .borrow_mut::<Vec<RpcCall>>()
         .push(RpcCall::KillPortable {
             location: PortableLocation::Urn(pid.clone()),
             response: sx.into(),
@@ -68,7 +66,7 @@ async fn op_portable_list(state: Rc<RefCell<OpState>>) -> Vec<SpawnResponse> {
 
     state
         .borrow_mut()
-        .borrow_mut::<RpcCalls>()
+        .borrow_mut::<Vec<RpcCall>>()
         .push(RpcCall::ListPortables {
             response: sx.into(),
         });

--- a/rust/decentraland-godot-lib/src/dcl/js/restricted_actions.rs
+++ b/rust/decentraland-godot-lib/src/dcl/js/restricted_actions.rs
@@ -6,7 +6,7 @@ use deno_core::{
     op, Op, OpDecl, OpState,
 };
 
-use crate::common::rpc::{RpcCall, RpcCalls};
+use crate::dcl::scene_apis::RpcCall;
 
 pub fn ops() -> Vec<OpDecl> {
     vec![
@@ -28,7 +28,7 @@ async fn op_change_realm(
 
     op_state
         .borrow_mut()
-        .borrow_mut::<RpcCalls>()
+        .borrow_mut::<Vec<RpcCall>>()
         .push(RpcCall::ChangeRealm {
             to: realm,
             message,
@@ -50,7 +50,7 @@ async fn op_move_player_to(
 
     op_state
         .borrow_mut()
-        .borrow_mut::<RpcCalls>()
+        .borrow_mut::<Vec<RpcCall>>()
         .push(RpcCall::MovePlayerTo {
             position_target,
             camera_target,
@@ -71,7 +71,7 @@ async fn op_teleport_to(
 
     op_state
         .borrow_mut()
-        .borrow_mut::<RpcCalls>()
+        .borrow_mut::<Vec<RpcCall>>()
         .push(RpcCall::TeleportTo {
             world_coordinates,
             response: sx.into(),
@@ -91,7 +91,7 @@ async fn op_trigger_emote(
 
     op_state
         .borrow_mut()
-        .borrow_mut::<RpcCalls>()
+        .borrow_mut::<Vec<RpcCall>>()
         .push(RpcCall::TriggerEmote {
             emote_id,
             response: sx.into(),
@@ -112,7 +112,7 @@ async fn op_trigger_scene_emote(
 
     op_state
         .borrow_mut()
-        .borrow_mut::<RpcCalls>()
+        .borrow_mut::<Vec<RpcCall>>()
         .push(RpcCall::TriggerSceneEmote {
             emote_src,
             looping,

--- a/rust/decentraland-godot-lib/src/dcl/scene_apis.rs
+++ b/rust/decentraland-godot-lib/src/dcl/scene_apis.rs
@@ -115,4 +115,16 @@ pub enum RpcCall {
     },
 }
 
-pub type RpcCalls = Vec<RpcCall>;
+#[derive(Debug)]
+pub enum LocalCall {
+    PlayersGetPlayerData {
+        user_id: String,
+        response: RpcResultSender<Option<UserData>>,
+    },
+    PlayersGetPlayersInScene {
+        response: RpcResultSender<Vec<String>>,
+    },
+    PlayersGetConnectedPlayers {
+        response: RpcResultSender<Vec<String>>,
+    },
+}

--- a/rust/decentraland-godot-lib/src/godot_classes/portables/mod.rs
+++ b/rust/decentraland-godot-lib/src/godot_classes/portables/mod.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use godot::engine::Node;
 use godot::prelude::*;
 
-use crate::common::rpc::{PortableLocation, RpcResultSender, SpawnResponse};
+use crate::dcl::scene_apis::{PortableLocation, RpcResultSender, SpawnResponse};
 use crate::dcl::SceneId;
 
 #[derive(Clone)]

--- a/rust/decentraland-godot-lib/src/lib.rs
+++ b/rust/decentraland-godot-lib/src/lib.rs
@@ -8,7 +8,6 @@ use godot::prelude::*;
 
 pub mod av;
 pub mod avatars;
-pub mod common;
 pub mod comms;
 pub mod dcl;
 pub mod godot_classes;

--- a/rust/decentraland-godot-lib/src/scene_runner/rpc_calls/handle_restricted_actions.rs
+++ b/rust/decentraland-godot-lib/src/scene_runner/rpc_calls/handle_restricted_actions.rs
@@ -1,6 +1,5 @@
 use crate::{
-    common::rpc::RpcResultSender,
-    dcl::SceneId,
+    dcl::{scene_apis::RpcResultSender, SceneId},
     godot_classes::dcl_confirm_dialog::DclConfirmDialog,
     scene_runner::{
         global_get_node_helper::{

--- a/rust/decentraland-godot-lib/src/scene_runner/rpc_calls/mod.rs
+++ b/rust/decentraland-godot-lib/src/scene_runner/rpc_calls/mod.rs
@@ -1,10 +1,7 @@
 mod handle_restricted_actions;
 mod portables;
 
-use crate::{
-    common::rpc::{RpcCall, RpcCalls},
-    dcl::SceneId,
-};
+use crate::dcl::{scene_apis::RpcCall, SceneId};
 
 use self::{
     handle_restricted_actions::{
@@ -15,7 +12,7 @@ use self::{
 
 use super::scene::Scene;
 
-pub fn process_rpcs(scene: &Scene, current_parcel_scene_id: &SceneId, rpc_calls: RpcCalls) {
+pub fn process_rpcs(scene: &Scene, current_parcel_scene_id: &SceneId, rpc_calls: Vec<RpcCall>) {
     for rpc_call in rpc_calls {
         match rpc_call {
             RpcCall::ChangeRealm {

--- a/rust/decentraland-godot-lib/src/scene_runner/rpc_calls/portables.rs
+++ b/rust/decentraland-godot-lib/src/scene_runner/rpc_calls/portables.rs
@@ -1,5 +1,5 @@
 use crate::{
-    common::rpc::{PortableLocation, RpcResultSender, SpawnResponse},
+    dcl::scene_apis::{PortableLocation, RpcResultSender, SpawnResponse},
     godot_classes::dcl_global::DclGlobal,
     scene_runner::scene::Scene,
 };

--- a/rust/decentraland-godot-lib/src/scene_runner/scene.rs
+++ b/rust/decentraland-godot-lib/src/scene_runner/scene.rs
@@ -6,7 +6,6 @@ use std::{
 use godot::prelude::{Dictionary, Gd};
 
 use crate::{
-    common::rpc::RpcCalls,
     dcl::{
         components::{
             material::DclMaterial,
@@ -17,12 +16,11 @@ use crate::{
             transform_and_parent::DclTransformAndParent,
             SceneEntityId,
         },
+        crdt::{DirtyEntities, DirtyGosComponents, DirtyLwwComponents},
         js::SceneLogMessage,
+        scene_apis::RpcCall,
         // js::js_runtime::SceneLogMessage,
         DclScene,
-        DirtyEntities,
-        DirtyGosComponents,
-        DirtyLwwComponents,
         RendererResponse,
         SceneDefinition,
         SceneId,
@@ -43,7 +41,7 @@ pub struct Dirty {
     pub logs: Vec<SceneLogMessage>,
     pub renderer_response: Option<RendererResponse>,
     pub update_state: SceneUpdateState,
-    pub rpc_calls: RpcCalls,
+    pub rpc_calls: Vec<RpcCall>,
 }
 
 pub enum SceneState {
@@ -246,7 +244,7 @@ impl Scene {
                 logs: Vec::new(),
                 renderer_response: None,
                 update_state: SceneUpdateState::None,
-                rpc_calls: RpcCalls::default(),
+                rpc_calls: Vec::new(),
             },
             enqueued_dirty: Vec::new(),
             distance: 0.0,
@@ -300,7 +298,7 @@ impl Scene {
                 logs: Vec::new(),
                 renderer_response: None,
                 update_state: SceneUpdateState::None,
-                rpc_calls: RpcCalls::default(),
+                rpc_calls: Vec::new(),
             },
             distance: 0.0,
             next_tick_us: 0,

--- a/rust/decentraland-godot-lib/src/scene_runner/scene_manager.rs
+++ b/rust/decentraland-godot-lib/src/scene_runner/scene_manager.rs
@@ -421,19 +421,13 @@ impl SceneManager {
                         arguments.push(GodotString::from(&msg).to_variant());
                         self.console.callv(arguments);
                     }
-                    SceneResponse::Ok(
-                        scene_id,
-                        (dirty_entities, dirty_lww_components, dirty_gos_components),
-                        logs,
-                        _,
-                        rpc_calls,
-                    ) => {
+                    SceneResponse::Ok(scene_id, dirty_crdt_state, logs, _, rpc_calls) => {
                         if let Some(scene) = self.scenes.get_mut(&scene_id) {
                             let dirty = Dirty {
                                 waiting_process: true,
-                                entities: dirty_entities,
-                                lww_components: dirty_lww_components,
-                                gos_components: dirty_gos_components,
+                                entities: dirty_crdt_state.entities,
+                                lww_components: dirty_crdt_state.lww,
+                                gos_components: dirty_crdt_state.gos,
                                 logs,
                                 renderer_response: None,
                                 update_state: SceneUpdateState::None,

--- a/rust/decentraland-godot-lib/src/scene_runner/update_scene.rs
+++ b/rust/decentraland-godot-lib/src/scene_runner/update_scene.rs
@@ -30,7 +30,6 @@ use super::{
     scene::{Dirty, Scene, SceneType, SceneUpdateState},
 };
 use crate::{
-    common::rpc::RpcCalls,
     dcl::{
         components::{
             proto_components::sdk::components::{
@@ -318,7 +317,7 @@ pub fn _process_scene(
                         logs: Vec::new(),
                         renderer_response: None,
                         update_state: SceneUpdateState::Processed,
-                        rpc_calls: RpcCalls::default(),
+                        rpc_calls: Vec::new(),
                     });
 
                     return true;


### PR DESCRIPTION
- change AvatarEmoteCommand as growonlyset
- move Rpc module as scene_api to DCL (remove common)
- entity_id as reference when it's forward it with references
- MISSING fix: add delete_entity crdt message
- change tuple to descriptive struct for dirty crdt state
- add local api calls vec to op_state