### PR TITLE
fix: add avatar components to primary player 

### DIFF
--- a/godot/src/logic/player/player.gd
+++ b/godot/src/logic/player/player.gd
@@ -72,7 +72,10 @@ func _ready():
 
 	floor_snap_length = 0.2
 
+	Global.avatars.update_primary_player_profile(Global.config.avatar_profile)
 	Global.comms.update_profile_avatar(Global.config.avatar_profile)
+	# TODO: check this, the comms method already emit the signal of profile changed
+	# 	so, maybe we don't need to call here, only wait the signal
 	avatar.update_avatar(Global.config.avatar_profile)
 
 	Global.config.param_changed.connect(self._on_param_changed)
@@ -81,6 +84,7 @@ func _ready():
 
 func _on_player_profile_changed(new_profile: Dictionary):
 	avatar.update_avatar(new_profile)
+	Global.avatars.update_primary_player_profile(new_profile)
 
 
 func _on_param_changed(_param):

--- a/godot/src/ui/components/advance_settings/advance_settings.tscn
+++ b/godot/src/ui/components/advance_settings/advance_settings.tscn
@@ -97,7 +97,7 @@ layout_mode = 2
 size_flags_horizontal = 3
 tooltip_text = "Select scene to load"
 focus_mode = 0
-item_count = 8
+item_count = 10
 popup/item_0/text = "mannakia.dcl.eth"
 popup/item_0/id = 0
 popup/item_1/text = "http://127.0.0.1:8000"
@@ -114,6 +114,10 @@ popup/item_6/text = "https://peer.decentraland.org"
 popup/item_6/id = 6
 popup/item_7/text = "shibu.dcl.eth"
 popup/item_7/id = 7
+popup/item_8/text = "https://leanmendoza.github.io/mannakia-dcl-scene/mannakia-dcl-scene"
+popup/item_8/id = 8
+popup/item_9/text = "https://sdilauro.github.io/dae-unit-tests/dae-unit-tests"
+popup/item_9/id = 9
 
 [node name="HSeparator4" type="HSeparator" parent="VBoxContainer/ColorRect_Background/HBoxContainer/VBoxContainer_General"]
 layout_mode = 2

--- a/rust/decentraland-godot-lib/src/comms/communication_manager.rs
+++ b/rust/decentraland-godot-lib/src/comms/communication_manager.rs
@@ -326,6 +326,7 @@ impl CommunicationManager {
         match &mut self.current_adapter {
             Adapter::None | Adapter::SignedLogin(_) => {}
             Adapter::Livekit(_livekit_room) => {
+                // TODO: implement
                 // livekit_room.change_profile(self.player_identity.clone());
             }
             Adapter::WsRoom(ws_room) => {

--- a/rust/decentraland-godot-lib/src/comms/livekit.rs
+++ b/rust/decentraland-godot-lib/src/comms/livekit.rs
@@ -212,7 +212,7 @@ impl LivekitRoom {
                                 continue;
                             }
 
-                            avatar_scene.update_avatar(
+                            avatar_scene.update_avatar_by_alias(
                                 peer.alias,
                                 &serialized_profile,
                                 &profile_response.base_url,

--- a/rust/decentraland-godot-lib/src/comms/ws_room.rs
+++ b/rust/decentraland-godot-lib/src/comms/ws_room.rs
@@ -494,7 +494,7 @@ impl WebSocketRoom {
                                 continue;
                             }
 
-                            self.avatars.bind_mut().update_avatar(
+                            self.avatars.bind_mut().update_avatar_by_alias(
                                 update.from_alias,
                                 &serialized_profile,
                                 &profile_response.base_url,


### PR DESCRIPTION
Now avatar components (PlayerIdentityData, AvatarBase, AvatarEquippedData) to Player Entity. It follows the ADR 245