### PR TITLE
feat: sdk7 apis

### DIFF
--- a/godot/src/logic/realm.gd
+++ b/godot/src/logic/realm.gd
@@ -120,6 +120,7 @@ func async_set_realm(new_realm_string: String) -> void:
 		)
 
 		realm_name = configuration.get("realmName", "no_realm_name")
+		network_id = int(configuration.get("networkId", 1))  # 1=Ethereum
 
 		content_base_url = Realm.ensure_ends_with_slash(
 			realm_about.get("content", {}).get("publicUrl")

--- a/godot/src/logic/scene_fetcher.gd
+++ b/godot/src/logic/scene_fetcher.gd
@@ -270,6 +270,10 @@ func async_load_scene(scene_entity_id: String, entity: Dictionary):
 			)
 			return false
 
+	# the scene was removed while it was loading...
+	if not loaded_scenes.has(scene_entity_id):
+		return false
+
 	if is_sdk7:
 		_on_try_spawn_scene(
 			loaded_scenes[scene_entity_id], local_main_js_path, local_main_crdt_path

--- a/godot/src/logic/scene_fetcher.gd
+++ b/godot/src/logic/scene_fetcher.gd
@@ -322,7 +322,8 @@ func _on_try_spawn_scene(scene, local_main_js_path, local_main_crdt_path):
 		"visible": true,
 		"parcels": scene.parcels,
 		"title": title,
-		"entity_id": scene.id
+		"entity_id": scene.id,
+		"metadata": scene.entity.metadata
 	}
 
 	var scene_number_id: int = Global.scene_runner.start_scene(scene_definition, content_mapping)

--- a/godot/src/ui/components/chat/chat.gd
+++ b/godot/src/ui/components/chat/chat.gd
@@ -26,6 +26,9 @@ func on_chats_arrived(chats: Array):
 		#var _timestamp: float = chat[2]
 		var message: StringName = chat[3]
 		var avatar = Global.avatars.get_avatar_by_address(address)
+		var avatar_name = (
+			avatar.avatar_name if avatar != null else DclEther.shorten_eth_address(address)
+		)
 
 		if message.begins_with(EMOTE):
 			message = message.substr(1)  # Remove prefix
@@ -36,9 +39,7 @@ func on_chats_arrived(chats: Array):
 		elif message.begins_with(ACK):
 			pass  # TODO: Calculate ping
 		else:
-			var text = (
-				"[b][color=#1cc]%s[/color] > [color=#fff]%s[/color]" % [avatar.avatar_name, message]
-			)
+			var text = "[b][color=#1cc]%s[/color] > [color=#fff]%s[/color]" % [avatar_name, message]
 			add_chat_message(text)
 
 

--- a/godot/src/ui/explorer.gd
+++ b/godot/src/ui/explorer.gd
@@ -291,7 +291,9 @@ func _on_line_edit_command_submit_message(message: String):
 			# TODO: unknown command
 	else:
 		Global.comms.send_chat(message)
-		panel_chat.on_chats_arrived([["0xNULL", "Godot User", 0, message]])
+		panel_chat.on_chats_arrived(
+			[[player.avatar.avatar_id, player.avatar.avatar_name, 0, message]]
+		)
 
 
 func _on_control_menu_request_pause_scenes(enabled):

--- a/rust/decentraland-godot-lib/src/comms/communication_manager.rs
+++ b/rust/decentraland-godot-lib/src/comms/communication_manager.rs
@@ -29,6 +29,7 @@ pub struct CommunicationManager {
     #[base]
     base: Base<Node>,
     current_adapter: Adapter,
+    current_adapter_conn_str: String,
     tls_client: Option<Gd<TlsOptions>>,
     player_identity: Arc<PlayerIdentity>,
     last_index: u64,
@@ -40,6 +41,7 @@ impl NodeVirtual for CommunicationManager {
         CommunicationManager {
             base,
             current_adapter: Adapter::None,
+            current_adapter_conn_str: String::default(),
             tls_client: None,
             player_identity: Arc::new(PlayerIdentity::new()),
             last_index: 0,
@@ -250,6 +252,11 @@ impl CommunicationManager {
         self.change_adapter(comms_fixed_adapter_str);
     }
 
+    #[func]
+    pub fn get_current_adapter_conn_str(&self) -> GodotString {
+        GodotString::from(self.current_adapter_conn_str.clone())
+    }
+
     fn change_adapter(&mut self, comms_fixed_adapter_str: String) {
         let Some((protocol, address)) = comms_fixed_adapter_str.as_str().split_once(':') else {
             tracing::warn!("unrecognised fixed adapter string: {comms_fixed_adapter_str}");
@@ -258,6 +265,7 @@ impl CommunicationManager {
 
         let avatar_scene = DclGlobal::singleton().bind().get_avatars();
         self.current_adapter = Adapter::None;
+        self.current_adapter_conn_str = comms_fixed_adapter_str.clone();
 
         tracing::info!("change_adapter to protocol {protocol} and address {address}");
 

--- a/rust/decentraland-godot-lib/src/dcl/js/js_modules/EnvironmentApi.js
+++ b/rust/decentraland-godot-lib/src/dcl/js/js_modules/EnvironmentApi.js
@@ -1,7 +1,57 @@
-module.exports.getBootstrapData = async function (body) { return {} }
-module.exports.isPreviewMode = async function (body) { return {} }
-module.exports.getPlatform = async function (body) { return {} }
-module.exports.areUnsafeRequestAllowed = async function (body) { return {} }
-module.exports.getCurrentRealm = async function (body) { return {} }
-module.exports.getExplorerConfiguration = async function (body) { return {} }
-module.exports.getDecentralandTime = async function (body) { return {} }
+module.exports.getBootstrapData = async function (body) {
+    const sceneInfo = await Deno.core.ops.op_get_scene_information()
+    sceneInfo.content = sceneInfo.content.map(item => ({
+        hash: item.hash,
+        file: item.file
+    }))    
+    return {
+        id: sceneInfo.urn,
+        baseUrl: sceneInfo.baseUrl,
+        entity: {
+            content: sceneInfo.content,
+            metadataJson: sceneInfo.metadataJson
+        },
+        useFPSThrottling: false,
+    }
+}
+module.exports.isPreviewMode = async function (body) {
+    const realm = await Deno.core.ops.op_get_realm()
+    return {
+        isPreview: realm.isPreview
+    }
+}
+module.exports.getPlatform = async function (body) {
+    return {
+        platform: 'desktop' // TODO: Implement `vr`, `web`, `mobile` it's ready
+    }
+}
+module.exports.areUnsafeRequestAllowed = async function (body) {
+    return {
+        status: false
+    }
+}
+module.exports.getCurrentRealm = async function (body) {
+    const realm = await Deno.core.ops.op_get_realm()
+    return {
+        currentRealm: {
+            protocol: 'v3',
+            layer: '', // layer doesn't exists anymore
+            room: '',
+            serverName: realm.realmName,
+            displayName: realm.realmName,
+            domain: realm.baseUrl,
+        }
+    }
+}
+module.exports.getExplorerConfiguration = async function (body) {
+    return {
+        clientUri: '',
+        configurations: {}
+    }
+}
+module.exports.getDecentralandTime = async function (body) {
+    const seconds = 60 * 60 * 12 // noon time in seconds
+    return {
+        seconds
+    }
+}

--- a/rust/decentraland-godot-lib/src/dcl/js/js_modules/RestrictedActions.js
+++ b/rust/decentraland-godot-lib/src/dcl/js/js_modules/RestrictedActions.js
@@ -41,6 +41,8 @@ module.exports.openNftDialog = async function (body) {
     body.urn,
   );
 };
+
+// Reference Client doesn't have it. No implement it until decide what to do with it...
 module.exports.setCommunicationsAdapter = async function (body) {
   return {};
 };

--- a/rust/decentraland-godot-lib/src/dcl/js/js_modules/RestrictedActions.js
+++ b/rust/decentraland-godot-lib/src/dcl/js/js_modules/RestrictedActions.js
@@ -32,7 +32,9 @@ module.exports.changeRealm = async function (body) {
   );
 };
 module.exports.openExternalUrl = async function (body) {
-  return {};
+  return await Deno.core.ops.op_open_external_url(
+    body.url,
+  );
 };
 module.exports.openNftDialog = async function (body) {
   return await Deno.core.ops.op_open_nft_dialog(

--- a/rust/decentraland-godot-lib/src/dcl/js/js_modules/Runtime.js
+++ b/rust/decentraland-godot-lib/src/dcl/js/js_modules/Runtime.js
@@ -4,7 +4,8 @@ module.exports.getRealm = async function (body) {
     }
 }
 module.exports.getWorldTime = async function (body) {
-    const seconds = 60 * 60 * 12 // noon seconds
+    // TODO: Implement time when skybox feature has time
+    const seconds = 60 * 60 * 12 // noon time in seconds
     return {
         seconds
     }

--- a/rust/decentraland-godot-lib/src/dcl/js/js_modules/Runtime.js
+++ b/rust/decentraland-godot-lib/src/dcl/js/js_modules/Runtime.js
@@ -1,12 +1,6 @@
 module.exports.getRealm = async function (body) {
     return {
-        realmInfo: {
-            baseUrl: "https://localhost:8000",
-            realName: "LocalPreview",
-            networkId: 1,
-            commsAdapter: "offline",
-            isPreview: true,
-        }
+        realmInfo: await Deno.core.ops.op_get_realm()
     }
 }
 module.exports.getWorldTime = async function (body) {
@@ -16,9 +10,7 @@ module.exports.getWorldTime = async function (body) {
     }
 }
 
-// sync implementation
 module.exports.readFile = async function (body) {
-    // body.fileName
     const { hash, url } = Deno.core.ops.op_get_file_url(body.fileName)
     const response = await fetch(url)
     const bytes = await response.bytes()
@@ -28,4 +20,12 @@ module.exports.readFile = async function (body) {
         hash
     }
 }
-module.exports.getSceneInformation = async function (body) { return {} }
+
+module.exports.getSceneInformation = async function (body) {
+    return {
+        urn: "", // this is either the entityId or the full URN of the scene that is running
+        content: [], // contents of the deployed entities
+        metadataJson: "", // JSON serialization of the entity.metadata field
+        baseUrl: "" // baseUrl used to resolve all content files
+    }
+}

--- a/rust/decentraland-godot-lib/src/dcl/js/js_modules/Runtime.js
+++ b/rust/decentraland-godot-lib/src/dcl/js/js_modules/Runtime.js
@@ -22,10 +22,12 @@ module.exports.readFile = async function (body) {
 }
 
 module.exports.getSceneInformation = async function (body) {
+    const sceneInfo = await Deno.core.ops.op_get_scene_information()
+    sceneInfo.content = sceneInfo.content.map(item => ({
+        hash: item.hash,
+        file: item.file
+    }))    
     return {
-        urn: "", // this is either the entityId or the full URN of the scene that is running
-        content: [], // contents of the deployed entities
-        metadataJson: "", // JSON serialization of the entity.metadata field
-        baseUrl: "" // baseUrl used to resolve all content files
+        ...sceneInfo,
     }
 }

--- a/rust/decentraland-godot-lib/src/dcl/js/js_modules/Runtime.js
+++ b/rust/decentraland-godot-lib/src/dcl/js/js_modules/Runtime.js
@@ -9,7 +9,12 @@ module.exports.getRealm = async function (body) {
         }
     }
 }
-module.exports.getWorldTime = async function (body) { return {} }
+module.exports.getWorldTime = async function (body) {
+    const seconds = 60 * 60 * 12 // noon seconds
+    return {
+        seconds
+    }
+}
 
 // sync implementation
 module.exports.readFile = async function (body) {

--- a/rust/decentraland-godot-lib/src/dcl/js/js_modules/Scene.js
+++ b/rust/decentraland-godot-lib/src/dcl/js/js_modules/Scene.js
@@ -1,1 +1,13 @@
-module.exports.getSceneInfo = async function (body) { return {} }
+module.exports.getSceneInfo = async function (body) {
+    const sceneInfo = await Deno.core.ops.op_get_scene_information()
+    sceneInfo.content = sceneInfo.content.map(item => ({
+        hash: item.hash,
+        file: item.file
+    }))    
+    return {
+        cid: sceneInfo.urn,
+        contents: sceneInfo.content,
+        metadata: sceneInfo.metadataJson,
+        baseUrl: sceneInfo.baseUrl
+    }
+}

--- a/rust/decentraland-godot-lib/src/dcl/js/runtime.rs
+++ b/rust/decentraland-godot-lib/src/dcl/js/runtime.rs
@@ -3,12 +3,16 @@ use serde::Serialize;
 
 use std::{cell::RefCell, rc::Rc};
 
-use crate::dcl::scene_apis::{GetRealmResponse, RpcCall};
+use crate::dcl::scene_apis::{GetRealmResponse, GetSceneInformationResponse, RpcCall};
 
 use super::SceneContentMapping;
 
 pub fn ops() -> Vec<OpDecl> {
-    vec![op_get_file_url::DECL, op_get_realm::DECL]
+    vec![
+        op_get_file_url::DECL,
+        op_get_realm::DECL,
+        op_get_scene_information::DECL,
+    ]
 }
 
 #[derive(Serialize)]
@@ -46,6 +50,22 @@ async fn op_get_realm(op_state: Rc<RefCell<OpState>>) -> Result<GetRealmResponse
         .borrow_mut()
         .borrow_mut::<Vec<RpcCall>>()
         .push(RpcCall::GetRealm {
+            response: sx.into(),
+        });
+
+    rx.await.map_err(|e| anyhow!(e))
+}
+
+#[op]
+async fn op_get_scene_information(
+    op_state: Rc<RefCell<OpState>>,
+) -> Result<GetSceneInformationResponse, AnyError> {
+    let (sx, rx) = tokio::sync::oneshot::channel::<GetSceneInformationResponse>();
+
+    op_state
+        .borrow_mut()
+        .borrow_mut::<Vec<RpcCall>>()
+        .push(RpcCall::GetSceneInformation {
             response: sx.into(),
         });
 

--- a/rust/decentraland-godot-lib/src/dcl/mod.rs
+++ b/rust/decentraland-godot-lib/src/dcl/mod.rs
@@ -37,6 +37,7 @@ pub struct SceneDefinition {
 
     pub parcels: Vec<godot::prelude::Vector2i>,
     pub is_global: bool,
+    pub metadata: String,
 }
 // data from renderer to scene
 #[derive(Debug)]

--- a/rust/decentraland-godot-lib/src/dcl/scene_apis.rs
+++ b/rust/decentraland-godot-lib/src/dcl/scene_apis.rs
@@ -56,6 +56,22 @@ pub struct GetRealmResponse {
     pub is_preview: bool,
 }
 
+#[derive(Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct ContentMapping {
+    pub file: String,
+    pub hash: String,
+}
+
+#[derive(Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct GetSceneInformationResponse {
+    pub urn: String,
+    pub content: Vec<ContentMapping>,
+    pub metadata_json: String,
+    pub base_url: String,
+}
+
 #[derive(Debug, Clone)]
 pub struct RpcResultSender<T>(Arc<RwLock<Option<tokio::sync::oneshot::Sender<T>>>>);
 
@@ -125,6 +141,9 @@ pub enum RpcCall {
     // Runtime
     GetRealm {
         response: RpcResultSender<GetRealmResponse>,
+    },
+    GetSceneInformation {
+        response: RpcResultSender<GetSceneInformationResponse>,
     },
     // Portable Experiences
     SpawnPortable {

--- a/rust/decentraland-godot-lib/src/dcl/scene_apis.rs
+++ b/rust/decentraland-godot-lib/src/dcl/scene_apis.rs
@@ -1,5 +1,6 @@
 use std::sync::{Arc, RwLock};
 
+use http::Uri;
 use serde::Serialize;
 
 #[derive(Debug, Clone, PartialEq)]
@@ -95,6 +96,10 @@ pub enum RpcCall {
     },
     OpenNftDialog {
         urn: String,
+        response: RpcResultSender<Result<(), String>>,
+    },
+    OpenExternalUrl {
+        url: Uri,
         response: RpcResultSender<Result<(), String>>,
     },
     TriggerEmote {

--- a/rust/decentraland-godot-lib/src/dcl/scene_apis.rs
+++ b/rust/decentraland-godot-lib/src/dcl/scene_apis.rs
@@ -46,6 +46,16 @@ pub struct UserData {
     pub avatar: Option<AvatarForUserData>,
 }
 
+#[derive(Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct GetRealmResponse {
+    pub base_url: String,
+    pub realm_name: String,
+    pub network_id: i32,
+    pub comms_adapter: String,
+    pub is_preview: bool,
+}
+
 #[derive(Debug, Clone)]
 pub struct RpcResultSender<T>(Arc<RwLock<Option<tokio::sync::oneshot::Sender<T>>>>);
 
@@ -80,6 +90,7 @@ impl<T: 'static> From<tokio::sync::oneshot::Sender<T>> for RpcResultSender<T> {
 
 #[derive(Debug)]
 pub enum RpcCall {
+    // Restricted Actions
     ChangeRealm {
         to: String,
         message: Option<String>,
@@ -111,6 +122,11 @@ pub enum RpcCall {
         looping: bool,
         response: RpcResultSender<Result<(), String>>,
     },
+    // Runtime
+    GetRealm {
+        response: RpcResultSender<GetRealmResponse>,
+    },
+    // Portable Experiences
     SpawnPortable {
         location: PortableLocation,
         response: RpcResultSender<Result<SpawnResponse, String>>,

--- a/rust/decentraland-godot-lib/src/godot_classes/dcl_global.rs
+++ b/rust/decentraland-godot-lib/src/godot_classes/dcl_global.rs
@@ -28,6 +28,8 @@ pub struct DclGlobal {
     pub realm: Gd<DclRealm>,
     #[var]
     pub portable_experience_controller: Gd<DclPortableExperienceController>,
+    #[var]
+    pub preview_mode: bool,
 }
 
 #[godot_api]
@@ -63,6 +65,7 @@ impl NodeVirtual for DclGlobal {
             tokio_runtime,
             realm: Gd::new_default(),
             portable_experience_controller: Gd::new_default(),
+            preview_mode: false,
         }
     }
 }

--- a/rust/decentraland-godot-lib/src/godot_classes/dcl_realm.rs
+++ b/rust/decentraland-godot-lib/src/godot_classes/dcl_realm.rs
@@ -18,6 +18,8 @@ pub struct DclRealm {
     #[var]
     realm_name: GodotString,
     #[var]
+    network_id: i32,
+    #[var]
     realm_scene_urns: Array<Dictionary>,
     #[var]
     realm_global_scene_urns: Array<Dictionary>,

--- a/rust/decentraland-godot-lib/src/scene_runner/godot_dcl_scene.rs
+++ b/rust/decentraland-godot-lib/src/scene_runner/godot_dcl_scene.rs
@@ -10,7 +10,7 @@ use crate::{
     },
     godot_classes::{dcl_scene_node::DclSceneNode, dcl_ui_control::DclUiControl},
 };
-use godot::prelude::*;
+use godot::{engine::Json, prelude::*};
 use std::{
     cell::RefCell,
     collections::{HashMap, HashSet},
@@ -105,6 +105,9 @@ impl SceneDefinition {
             .collect::<Result<Vec<_>, VariantConversionError>>()
             .map_err(|v| v.to_string())?;
 
+        let metadata =
+            Json::stringify(dict.get("metadata").unwrap_or_default().to_variant()).to_string();
+
         Ok(Self {
             main_crdt_path: main_crdt_path.to::<GodotString>().to_string(),
             path: path.to::<GodotString>().to_string(),
@@ -114,6 +117,7 @@ impl SceneDefinition {
             is_global: is_global.to::<bool>(),
             title: title.to::<GodotString>().to_string(),
             entity_id: entity_id.to::<GodotString>().to_string(),
+            metadata,
         })
     }
 }

--- a/rust/decentraland-godot-lib/src/scene_runner/rpc_calls/handle_restricted_actions.rs
+++ b/rust/decentraland-godot-lib/src/scene_runner/rpc_calls/handle_restricted_actions.rs
@@ -13,6 +13,7 @@ use godot::{
     builtin::meta::ToGodot,
     prelude::{GodotString, PackedScene, Variant, Vector2i, Vector3},
 };
+use http::Uri;
 
 fn _player_is_inside_scene(scene: &Scene, current_parcel_scene_id: &SceneId) -> bool {
     // Check if player is inside the scene that requested the move
@@ -32,7 +33,7 @@ pub fn change_realm(
 ) {
     // Check if player is inside the scene that requested the move
     if !_player_is_inside_scene(scene, current_parcel_scene_id) {
-        response.send(Err("Player position is outside the scene".to_string()));
+        response.send(Err("Primary Player is outside the scene".to_string()));
         return;
     }
 
@@ -83,6 +84,59 @@ pub fn change_realm(
     );
 }
 
+pub fn open_external_url(
+    scene: &Scene,
+    current_parcel_scene_id: &SceneId,
+    url: &Uri,
+    response: &RpcResultSender<Result<(), String>>,
+) {
+    // Check if player is inside the scene that requested the move
+    if !_player_is_inside_scene(scene, current_parcel_scene_id) {
+        response.send(Err("Primary Player is outside the scene".to_string()));
+        return;
+    }
+
+    // Get nodes
+    let mut dialog_stack = get_dialog_stack_node(scene);
+
+    let confirm_dialog =
+        godot::engine::load::<PackedScene>("res://src/ui/dialogs/confirm_dialog.tscn")
+            .instantiate()
+            .expect("ConfirmDialog instantiate error");
+
+    // Setup confirm dialog
+    dialog_stack.add_child(confirm_dialog.clone());
+
+    // Setup confirm Dialog
+    let mut confirm_dialog = confirm_dialog.cast::<DclConfirmDialog>();
+    let mut confirm_dialog = confirm_dialog.bind_mut();
+
+    let description = format!(
+        "You are about to open a link from the community. External links can be unsafe and lead to unverified content. Proceed with caution.
+        Do you still want to open the URL?\n\nURL:\n {}",
+        url
+    );
+
+    // clone data that is going to the callback
+    let response = response.clone();
+    let godot_url = GodotString::from(url.to_string());
+
+    confirm_dialog.setup(
+        "Open External URL",
+        description.as_str(),
+        "Open Url",
+        "No thanks",
+        move |ok| {
+            if ok {
+                godot::engine::Os::singleton().shell_open(godot_url);
+                response.send(Ok(()));
+            } else {
+                response.send(Err("User rejected to open the url".to_string()));
+            }
+        },
+    );
+}
+
 pub fn open_nft_dialog(
     scene: &Scene,
     current_parcel_scene_id: &SceneId,
@@ -91,7 +145,7 @@ pub fn open_nft_dialog(
 ) {
     // Check if player is inside the scene that requested the move
     if !_player_is_inside_scene(scene, current_parcel_scene_id) {
-        response.send(Err("Player position is outside the scene".to_string()));
+        response.send(Err("Primary Player is outside the scene".to_string()));
         return;
     }
 
@@ -121,7 +175,7 @@ pub fn move_player_to(
 ) {
     // Check if player is inside the scene that requested the move
     if !_player_is_inside_scene(scene, current_parcel_scene_id) {
-        response.send(Err("Player position is outside the scene".to_string()));
+        response.send(Err("Primary Player is outside the scene".to_string()));
         return;
     }
 
@@ -174,7 +228,7 @@ pub fn teleport_to(
 ) {
     // Check if player is inside the scene that requested the move
     if !_player_is_inside_scene(scene, current_parcel_scene_id) {
-        response.send(Err("Player position is outside the scene".to_string()));
+        response.send(Err("Primary Player is outside the scene".to_string()));
         return;
     }
 
@@ -229,7 +283,7 @@ pub fn trigger_emote(
 ) {
     // Check if player is inside the scene that requested the move
     if !_player_is_inside_scene(scene, current_parcel_scene_id) {
-        response.send(Err("Player position is outside the scene".to_string()));
+        response.send(Err("Primary Player is outside the scene".to_string()));
         return;
     }
 
@@ -247,7 +301,7 @@ pub fn trigger_scene_emote(
 ) {
     // Check if player is inside the scene that requested the move
     if !_player_is_inside_scene(scene, current_parcel_scene_id) {
-        response.send(Err("Player position is outside the scene".to_string()));
+        response.send(Err("Primary Player is outside the scene".to_string()));
         return;
     }
 

--- a/rust/decentraland-godot-lib/src/scene_runner/rpc_calls/handle_runtime.rs
+++ b/rust/decentraland-godot-lib/src/scene_runner/rpc_calls/handle_runtime.rs
@@ -1,6 +1,11 @@
+use godot::builtin::{meta::FromGodot, Dictionary};
+
 use crate::{
-    dcl::scene_apis::{GetRealmResponse, RpcResultSender},
+    dcl::scene_apis::{
+        ContentMapping, GetRealmResponse, GetSceneInformationResponse, RpcResultSender,
+    },
     godot_classes::dcl_global::DclGlobal,
+    scene_runner::scene::Scene,
 };
 
 pub fn get_realm(response: &RpcResultSender<GetRealmResponse>) {
@@ -25,5 +30,29 @@ pub fn get_realm(response: &RpcResultSender<GetRealmResponse>) {
         network_id,
         comms_adapter,
         is_preview,
+    })
+}
+
+pub fn get_scene_information(
+    scene: &Scene,
+    response: &RpcResultSender<GetSceneInformationResponse>,
+) {
+    let base_url = scene.content_mapping.get("base_url").unwrap().to_string();
+
+    let content_dictionary =
+        Dictionary::from_variant(&scene.content_mapping.get("content").unwrap());
+    let content: Vec<ContentMapping> = content_dictionary
+        .iter_shared()
+        .map(|(file_name, file_hash)| ContentMapping {
+            file: file_name.to_string(),
+            hash: file_hash.to_string(),
+        })
+        .collect();
+
+    response.send(GetSceneInformationResponse {
+        urn: scene.definition.entity_id.clone(),
+        content,
+        metadata_json: scene.definition.metadata.clone(),
+        base_url,
     })
 }

--- a/rust/decentraland-godot-lib/src/scene_runner/rpc_calls/handle_runtime.rs
+++ b/rust/decentraland-godot-lib/src/scene_runner/rpc_calls/handle_runtime.rs
@@ -1,0 +1,29 @@
+use crate::{
+    dcl::scene_apis::{GetRealmResponse, RpcResultSender},
+    godot_classes::dcl_global::DclGlobal,
+};
+
+pub fn get_realm(response: &RpcResultSender<GetRealmResponse>) {
+    let realm = DclGlobal::singleton().bind().realm.clone();
+    let realm = realm.bind();
+    let realm_name = realm.get_realm_name().to_string();
+    let base_url = realm.get_realm_url().to_string();
+    let network_id = realm.get_network_id();
+
+    let is_preview = DclGlobal::singleton().bind().get_preview_mode();
+
+    let comms_adapter = DclGlobal::singleton()
+        .bind()
+        .comms
+        .bind()
+        .get_current_adapter_conn_str()
+        .to_string();
+
+    response.send(GetRealmResponse {
+        base_url,
+        realm_name,
+        network_id,
+        comms_adapter,
+        is_preview,
+    })
+}

--- a/rust/decentraland-godot-lib/src/scene_runner/rpc_calls/mod.rs
+++ b/rust/decentraland-godot-lib/src/scene_runner/rpc_calls/mod.rs
@@ -5,8 +5,8 @@ use crate::dcl::{scene_apis::RpcCall, SceneId};
 
 use self::{
     handle_restricted_actions::{
-        change_realm, move_player_to, open_nft_dialog, teleport_to, trigger_emote,
-        trigger_scene_emote,
+        change_realm, move_player_to, open_external_url, open_nft_dialog, teleport_to,
+        trigger_emote, trigger_scene_emote,
     },
     portables::{kill_portable, list_portables, spawn_portable},
 };
@@ -25,6 +25,9 @@ pub fn process_rpcs(scene: &Scene, current_parcel_scene_id: &SceneId, rpc_calls:
             }
             RpcCall::OpenNftDialog { urn, response } => {
                 open_nft_dialog(scene, current_parcel_scene_id, &urn, &response);
+            }
+            RpcCall::OpenExternalUrl { url, response } => {
+                open_external_url(scene, current_parcel_scene_id, &url, &response);
             }
             RpcCall::MovePlayerTo {
                 position_target,

--- a/rust/decentraland-godot-lib/src/scene_runner/rpc_calls/mod.rs
+++ b/rust/decentraland-godot-lib/src/scene_runner/rpc_calls/mod.rs
@@ -9,7 +9,7 @@ use self::{
         change_realm, move_player_to, open_external_url, open_nft_dialog, teleport_to,
         trigger_emote, trigger_scene_emote,
     },
-    handle_runtime::get_realm,
+    handle_runtime::{get_realm, get_scene_information},
     portables::{kill_portable, list_portables, spawn_portable},
 };
 
@@ -68,8 +68,9 @@ pub fn process_rpcs(scene: &Scene, current_parcel_scene_id: &SceneId, rpc_calls:
                 &looping,
                 &response,
             ),
-            RpcCall::GetRealm { response } => get_realm(&response),
             // Runtime
+            RpcCall::GetRealm { response } => get_realm(&response),
+            RpcCall::GetSceneInformation { response } => get_scene_information(scene, &response),
             // Portable Experiences
             RpcCall::SpawnPortable { location, response } => {
                 spawn_portable(scene, location, response)

--- a/rust/decentraland-godot-lib/src/scene_runner/rpc_calls/mod.rs
+++ b/rust/decentraland-godot-lib/src/scene_runner/rpc_calls/mod.rs
@@ -1,4 +1,5 @@
 mod handle_restricted_actions;
+mod handle_runtime;
 mod portables;
 
 use crate::dcl::{scene_apis::RpcCall, SceneId};
@@ -8,6 +9,7 @@ use self::{
         change_realm, move_player_to, open_external_url, open_nft_dialog, teleport_to,
         trigger_emote, trigger_scene_emote,
     },
+    handle_runtime::get_realm,
     portables::{kill_portable, list_portables, spawn_portable},
 };
 
@@ -16,6 +18,7 @@ use super::scene::Scene;
 pub fn process_rpcs(scene: &Scene, current_parcel_scene_id: &SceneId, rpc_calls: Vec<RpcCall>) {
     for rpc_call in rpc_calls {
         match rpc_call {
+            // Restricted Actions
             RpcCall::ChangeRealm {
                 to,
                 message,
@@ -65,6 +68,9 @@ pub fn process_rpcs(scene: &Scene, current_parcel_scene_id: &SceneId, rpc_calls:
                 &looping,
                 &response,
             ),
+            RpcCall::GetRealm { response } => get_realm(&response),
+            // Runtime
+            // Portable Experiences
             RpcCall::SpawnPortable { location, response } => {
                 spawn_portable(scene, location, response)
             }


### PR DESCRIPTION
- [x] RestrictedActions.openExternalUrl
- [x] Runtime.getRealm
- [x] Runtime.getWorldTime (return noon in seconds (60\*60\*12), this will be implemented better with the skybox)
- [x] Runtime.getSceneInformation

(deprecated API, support it)
- [x] Scene.getSceneInfo (reuse Runtime.getSceneInformation)
- [x] EnvironmentApi.getBootstrapData (not documented, sdk7 exposed, reuse Runtime.getSceneInformation)
- [x] EnvironmentApi.isPreviewMode (can reuse Runtime.getRealm, just mapping data)
- [x] EnvironmentApi.getPlatform (return { platform: 'desktop' })
- [x] EnvironmentApi.areUnsafeRequestAllowed (return { status: false })
- [x] EnvironmentApi.getCurrentRealm (can reuse Runtime.getRealm, just mapping)
- [x] EnvironmentApi.getExplorerConfiguration (return default values and empty map)
- [x] EnvironmentApi.getDecentralandTime (reuse RuntimeService.getWorldTime)