### PR TITLE
feat: remove scenes with different scene_id when changing realm

### DIFF
--- a/godot/src/logic/realm.gd
+++ b/godot/src/logic/realm.gd
@@ -1,7 +1,7 @@
 class_name Realm
 extends DclRealm
 
-signal realm_changed
+signal realm_changed(force_reload: bool)
 
 var http_requester: RustHttpRequesterWrapper = Global.http_requester
 
@@ -70,7 +70,7 @@ static func parse_urn(urn: String):
 	return {"urn": matches.get_string(0), "entityId": matches.get_string(2), "baseUrl": base_url}
 
 
-func async_set_realm(new_realm_string: String) -> void:
+func async_set_realm(new_realm_string: String, force_reload: bool = false) -> void:
 	realm_string = new_realm_string
 	realm_url = Realm.ensure_ends_with_slash(Realm.resolve_realm_url(realm_string))
 	realm_url = Realm.ensure_starts_with_https(realm_url)
@@ -128,4 +128,4 @@ func async_set_realm(new_realm_string: String) -> void:
 		Global.config.last_realm_joined = realm_url
 		Global.config.save_to_settings_file()
 
-		emit_signal("realm_changed")
+		realm_changed.emit(force_reload)

--- a/godot/src/ui/explorer.gd
+++ b/godot/src/ui/explorer.gd
@@ -285,7 +285,7 @@ func _on_line_edit_command_submit_message(message: String):
 			)
 			Global.realm.async_set_realm(params[1])
 		elif command_str == "/reload":
-			Global.realm.async_set_realm(Global.realm.get_realm_string())
+			Global.realm.async_set_realm(Global.realm.get_realm_string(), true)
 		else:
 			pass
 			# TODO: unknown command

--- a/rust/decentraland-godot-lib/src/comms/communication_manager.rs
+++ b/rust/decentraland-godot-lib/src/comms/communication_manager.rs
@@ -208,7 +208,7 @@ impl CommunicationManager {
     }
 
     #[func]
-    fn _on_realm_changed(&mut self) {
+    fn _on_realm_changed(&mut self, _force_reload: bool) {
         self.base
             .call_deferred("_on_realm_changed_deferred".into(), &[]);
     }

--- a/rust/xtask/src/install_dependency.rs
+++ b/rust/xtask/src/install_dependency.rs
@@ -177,7 +177,14 @@ fn copy_if_modified<P: AsRef<Path>, Q: AsRef<Path>>(src: P, dest: Q) -> io::Resu
     }
 
     // If the destination file does not exist or is older, we copy the source file to the destination
-    fs::copy(src_path, dest_path).map(|_| println!("Copying {}", dest_path.to_string_lossy()))?;
+    if env::consts::OS == "linux" {
+        if dest_path.exists() {
+            fs::remove_file(dest_path).map(|_| println!("Remove {}", dest_path.to_string_lossy()))?;
+        }
+        fs::hard_link(src_path, dest_path).map(|_| println!("Link {}", dest_path.to_string_lossy()))?;
+    } else {
+        fs::copy(src_path, dest_path).map(|_| println!("Copying {}", dest_path.to_string_lossy()))?;
+    }
     Ok(())
 }
 


### PR DESCRIPTION
When changing the realm, only remove scenes that have different scene_id