### PR TITLE
chore: add -l/--link-libs to `cargo run -- run -l` to link libraries …

### DIFF
--- a/rust/xtask/src/copy_files.rs
+++ b/rust/xtask/src/copy_files.rs
@@ -1,0 +1,93 @@
+use std::{path::Path, io, fs, env};
+
+use crate::{consts::{
+    BIN_FOLDER, GODOT_PROJECT_FOLDER, RUST_LIB_PROJECT_FOLDER,
+}, path::adjust_canonicalization};
+
+pub fn copy_if_modified<P: AsRef<Path>, Q: AsRef<Path>>(src: P, dest: Q, link: bool) -> io::Result<()> {
+    let src_path = src.as_ref();
+    let dest_path = dest.as_ref();
+
+    // Obtain the metadata of the source and destination file
+    let metadata_src = fs::metadata(src_path);
+    let metadata_dest = fs::metadata(dest_path);
+
+    // If both files exist, we compare their modification times
+    if metadata_src.is_ok() && metadata_dest.is_ok() {
+        let time_src = metadata_src?.modified()?;
+        let time_dest = metadata_dest?.modified()?;
+
+        // If the destination file is more recent or equal to the source file, we do not copy
+        if time_dest >= time_src {
+            println!("Skip copy, equal file {}", dest_path.to_string_lossy());
+            return Ok(());
+        }
+    }
+
+    // If the destination file does not exist or is older, we copy the source file to the destination
+    // Only linux: If link=true, link the file instead of copying
+    if link && env::consts::OS == "linux" {
+        if dest_path.exists() {
+            fs::remove_file(dest_path).map(|_| println!("Remove {}", dest_path.to_string_lossy()))?;
+        }
+        fs::hard_link(src_path, dest_path).map(|_| println!("Link {}", dest_path.to_string_lossy()))?;
+    } else {
+        fs::copy(src_path, dest_path).map(|_| println!("Copying {}", dest_path.to_string_lossy()))?;
+    }
+    Ok(())
+}
+
+pub fn copy_library(debug_mode: bool, link_libs: bool) -> Result<(), anyhow::Error> {
+    let os = env::consts::OS;
+    let arch = env::consts::ARCH;
+    let file_name = match (os, arch) {
+        ("linux", _) => Some("libdecentraland_godot_lib.so".to_string()),
+        ("windows", _) => Some("decentraland_godot_lib.dll".to_string()),
+        ("macos", _) => Some("libdecentraland_godot_lib.dylib".to_string()),
+        _ => None,
+    }
+    .expect("Couldn't find a library for this platform");
+
+    let source_folder: &str = if debug_mode {
+        "target/debug/"
+    } else {
+        "target/release/"
+    };
+
+    let source_folder = format!("{RUST_LIB_PROJECT_FOLDER}{source_folder}");
+
+    let source_file =
+        adjust_canonicalization(fs::canonicalize(source_folder)?.join(file_name.clone()));
+
+    let lib_folder = format!("{GODOT_PROJECT_FOLDER}lib/");
+    let destination_file =
+        adjust_canonicalization(fs::canonicalize(lib_folder.as_str())?.join(file_name));
+    copy_if_modified(source_file, destination_file, link_libs)?;
+
+    copy_ffmpeg_libraries(lib_folder, link_libs)?;
+
+    Ok(())
+}
+
+pub fn copy_ffmpeg_libraries(dest_folder: String, link_libs: bool) -> Result<(), anyhow::Error> {
+    let os = env::consts::OS;
+    if os == "windows" {
+        // copy ffmpeg .dll
+        let ffmpeg_dll_folder = format!("{BIN_FOLDER}ffmpeg/ffmpeg-6.0-full_build-shared/bin");
+
+        // copy all dlls in ffmpeg_dll_folder to exports folder
+        for entry in fs::read_dir(ffmpeg_dll_folder)? {
+            let entry = entry?;
+            let ty = entry.file_type()?;
+            if ty.is_file() {
+                let file_name = entry.file_name().to_str().unwrap().to_string();
+
+                if file_name.ends_with(".dll") {
+                    let dest_path = format!("{dest_folder}{file_name}");
+                    copy_if_modified(entry.path(), dest_path, link_libs)?;
+                }
+            }
+        }
+    }
+    Ok(())
+}

--- a/rust/xtask/src/export.rs
+++ b/rust/xtask/src/export.rs
@@ -3,9 +3,9 @@ use std::{fs, io, path::Path};
 use crate::{
     consts::{BIN_FOLDER, EXPORTS_FOLDER, GODOT4_EXPORT_TEMPLATES_BASE_URL, GODOT_PROJECT_FOLDER},
     install_dependency::{
-        self, copy_ffmpeg_libraries, download_and_extract_zip, set_executable_permission,
+        self, download_and_extract_zip, set_executable_permission,
     },
-    path::adjust_canonicalization,
+    path::adjust_canonicalization, copy_files::copy_ffmpeg_libraries,
 };
 
 #[allow(dead_code)]
@@ -121,7 +121,7 @@ pub fn export() -> Result<(), anyhow::Error> {
         set_executable_permission(Path::new(output_rel_path.as_str()))?;
     }
 
-    copy_ffmpeg_libraries(EXPORTS_FOLDER.to_string())?;
+    copy_ffmpeg_libraries(EXPORTS_FOLDER.to_string(), false)?;
 
     Ok(())
 }

--- a/rust/xtask/src/install_dependency.rs
+++ b/rust/xtask/src/install_dependency.rs
@@ -12,9 +12,9 @@ use crate::download_file::download_file;
 use crate::export::prepare_templates;
 
 use crate::consts::{
-    BIN_FOLDER, GODOT4_BIN_BASE_URL, GODOT_PROJECT_FOLDER, PROTOC_BASE_URL, RUST_LIB_PROJECT_FOLDER,
+    BIN_FOLDER, GODOT4_BIN_BASE_URL, PROTOC_BASE_URL, RUST_LIB_PROJECT_FOLDER,
 };
-use crate::path::adjust_canonicalization;
+
 
 fn create_directory_all(path: &Path) -> io::Result<()> {
     if let Some(parent) = path.parent() {
@@ -154,86 +154,6 @@ pub fn get_godot_executable_path() -> Option<String> {
     }?;
 
     Some(os_url)
-}
-
-fn copy_if_modified<P: AsRef<Path>, Q: AsRef<Path>>(src: P, dest: Q) -> io::Result<()> {
-    let src_path = src.as_ref();
-    let dest_path = dest.as_ref();
-
-    // Obtain the metadata of the source and destination file
-    let metadata_src = fs::metadata(src_path);
-    let metadata_dest = fs::metadata(dest_path);
-
-    // If both files exist, we compare their modification times
-    if metadata_src.is_ok() && metadata_dest.is_ok() {
-        let time_src = metadata_src?.modified()?;
-        let time_dest = metadata_dest?.modified()?;
-
-        // If the destination file is more recent or equal to the source file, we do not copy
-        if time_dest >= time_src {
-            println!("Skip copy, equal file {}", dest_path.to_string_lossy());
-            return Ok(());
-        }
-    }
-
-    // If the destination file does not exist or is older, we copy the source file to the destination
-    fs::copy(src_path, dest_path).map(|_| println!("Copying {}", dest_path.to_string_lossy()))?;
-    Ok(())
-}
-
-pub fn copy_library(debug_mode: bool) -> Result<(), anyhow::Error> {
-    let os = env::consts::OS;
-    let arch = env::consts::ARCH;
-    let file_name = match (os, arch) {
-        ("linux", _) => Some("libdecentraland_godot_lib.so".to_string()),
-        ("windows", _) => Some("decentraland_godot_lib.dll".to_string()),
-        ("macos", _) => Some("libdecentraland_godot_lib.dylib".to_string()),
-        _ => None,
-    }
-    .expect("Couldn't find a library for this platform");
-
-    let source_folder: &str = if debug_mode {
-        "target/debug/"
-    } else {
-        "target/release/"
-    };
-
-    let source_folder = format!("{RUST_LIB_PROJECT_FOLDER}{source_folder}");
-
-    let source_file =
-        adjust_canonicalization(fs::canonicalize(source_folder)?.join(file_name.clone()));
-
-    let lib_folder = format!("{GODOT_PROJECT_FOLDER}lib/");
-    let destination_file =
-        adjust_canonicalization(fs::canonicalize(lib_folder.as_str())?.join(file_name));
-    copy_if_modified(source_file, destination_file)?;
-
-    copy_ffmpeg_libraries(lib_folder)?;
-
-    Ok(())
-}
-
-pub fn copy_ffmpeg_libraries(dest_folder: String) -> Result<(), anyhow::Error> {
-    let os = env::consts::OS;
-    if os == "windows" {
-        // copy ffmpeg .dll
-        let ffmpeg_dll_folder = format!("{BIN_FOLDER}ffmpeg/ffmpeg-6.0-full_build-shared/bin");
-
-        // copy all dlls in ffmpeg_dll_folder to exports folder
-        for entry in fs::read_dir(ffmpeg_dll_folder)? {
-            let entry = entry?;
-            let ty = entry.file_type()?;
-            if ty.is_file() {
-                let file_name = entry.file_name().to_str().unwrap().to_string();
-
-                if file_name.ends_with(".dll") {
-                    let dest_path = format!("{dest_folder}{file_name}");
-                    copy_if_modified(entry.path(), dest_path)?;
-                }
-            }
-        }
-    }
-    Ok(())
 }
 
 pub fn install(skip_download_templates: bool) -> Result<(), anyhow::Error> {

--- a/rust/xtask/src/main.rs
+++ b/rust/xtask/src/main.rs
@@ -12,6 +12,7 @@ mod export;
 mod install_dependency;
 mod path;
 mod run;
+mod copy_files;
 
 fn main() -> Result<(), anyhow::Error> {
     let cli = Command::new("xtask")
@@ -86,6 +87,12 @@ fn main() -> Result<(), anyhow::Error> {
                         .long("only-build")
                         .help("skip the run")
                         .takes_value(false),
+                )
+                .arg(
+                    Arg::new("link-libs")
+                        .short('l')
+                        .help("link libs instead of copying (only linux)")
+                        .takes_value(false),
                 ),
         );
     let matches = cli.get_matches();
@@ -107,6 +114,7 @@ fn main() -> Result<(), anyhow::Error> {
             sm.is_present("release"),
             sm.is_present("itest"),
             sm.is_present("only-build"),
+            sm.is_present("link-libs"),
         ),
         ("export", _m) => export::export(),
         ("coverage", sm) => coverage_with_itest(sm.is_present("dev")),

--- a/rust/xtask/src/run.rs
+++ b/rust/xtask/src/run.rs
@@ -3,7 +3,7 @@ use std::io::{BufRead, BufReader};
 use crate::{
     consts::{BIN_FOLDER, GODOT_PROJECT_FOLDER, RUST_LIB_PROJECT_FOLDER},
     install_dependency,
-    path::adjust_canonicalization,
+    path::adjust_canonicalization, copy_files::copy_library,
 };
 
 pub fn run(
@@ -11,6 +11,7 @@ pub fn run(
     release_mode: bool,
     itest: bool,
     only_build: bool,
+    link_libs: bool,
 ) -> Result<(), anyhow::Error> {
     let program = adjust_canonicalization(
         std::fs::canonicalize(format!(
@@ -52,7 +53,7 @@ pub fn run(
         ));
     }
 
-    match install_dependency::copy_library(!release_mode) {
+    match copy_library(!release_mode, link_libs) {
         Ok(_) => Ok(()),
         Err(e) => Err(anyhow::anyhow!("copy the library failed: {}", e)),
     }?;


### PR DESCRIPTION
…instead of copying those (only linux)

Faster compile. `libdecentraland_godot_lib.so` is 910mb right now (debug symbols + unoptimized). And it takes his time to copy.