### PR TITLE
fix: crashes with content loading 

### DIFF
--- a/godot/src/decentraland_components/gltf_container.gd
+++ b/godot/src/decentraland_components/gltf_container.gd
@@ -71,6 +71,9 @@ func _async_on_gltf_loaded():
 
 func async_deferred_add_child(new_gltf_node):
 	# Corner case, when the scene is unloaded before the gltf is loaded
+	if not is_inside_tree():
+		return
+
 	var main_tree = get_tree()
 	if not is_instance_valid(main_tree):
 		dcl_gltf_loading_state = GltfContainerLoadingState.FINISHED_WITH_ERROR

--- a/godot/src/decentraland_components/gltf_container.gd
+++ b/godot/src/decentraland_components/gltf_container.gd
@@ -72,6 +72,7 @@ func _async_on_gltf_loaded():
 func async_deferred_add_child(new_gltf_node):
 	# Corner case, when the scene is unloaded before the gltf is loaded
 	if not is_inside_tree():
+		dcl_gltf_loading_state = GltfContainerLoadingState.FINISHED_WITH_ERROR
 		return
 
 	var main_tree = get_tree()

--- a/rust/decentraland-godot-lib/src/scene_runner/tokio_runtime.rs
+++ b/rust/decentraland-godot-lib/src/scene_runner/tokio_runtime.rs
@@ -16,8 +16,7 @@ impl INode for TokioRuntime {
     fn init(_base: Base<Node>) -> Self {
         let rt = tokio::runtime::Builder::new_multi_thread()
             .enable_all()
-            .worker_threads(1)
-            .thread_name("content-thread-loading")
+            .thread_name("dcl-godot-tokio")
             .build();
         match rt {
             Ok(rt) => Self {

--- a/rust/decentraland-godot-lib/src/scene_runner/tokio_runtime.rs
+++ b/rust/decentraland-godot-lib/src/scene_runner/tokio_runtime.rs
@@ -14,7 +14,12 @@ pub struct TokioRuntime {
 #[godot_api]
 impl INode for TokioRuntime {
     fn init(_base: Base<Node>) -> Self {
-        match Runtime::new() {
+        let rt = tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .worker_threads(1)
+            .thread_name("content-thread-loading")
+            .build();
+        match rt {
             Ok(rt) => Self {
                 runtime: Some(Arc::new(rt)),
             },


### PR DESCRIPTION
- limit to 1 thread for content loading
- fix shared animation resource set loop property to all the instances

Note, the non-shared animation resources increases the memory consuming:
```
# 1000 birds
- without duplicating animations: 120.3MB to 153.3MB

# 1000 birds
- with duplicating animations: 120.3MB to 168.0MB
```

Fixes https://github.com/decentraland/godot-explorer/issues/162 and https://github.com/decentraland/godot-explorer/issues/161