### PR TITLE
fix: re-render ui layout when input/dropdown changes

### DIFF
--- a/rust/decentraland-godot-lib/src/scene_runner/components/ui/scene_ui.rs
+++ b/rust/decentraland-godot-lib/src/scene_runner/components/ui/scene_ui.rs
@@ -255,6 +255,12 @@ pub fn update_scene_ui(
         && dirty_lww_components
             .get(&SceneComponentId::UI_TEXT)
             .is_none()
+        && dirty_lww_components
+            .get(&SceneComponentId::UI_DROPDOWN)
+            .is_none()
+        && dirty_lww_components
+            .get(&SceneComponentId::UI_INPUT)
+            .is_none()
         && !need_update_ui_canvas;
 
     if need_update_ui_canvas {


### PR DESCRIPTION
Changing options or value from scene-side it wasn't being reflected in the UI
