### PR TITLE
fix: content loading related crashes (android)

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -2,8 +2,8 @@ name: Android Build
 
 on:
   push:
-    # branches:
-    #   - main
+    branches:
+      - main
 
 jobs:
   build:

--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -2,8 +2,8 @@ name: Android Build
 
 on:
   push:
-    branches:
-      - main
+    # branches:
+    #   - main
 
 jobs:
   build:

--- a/godot/src/test/testing_api.gd
+++ b/godot/src/test/testing_api.gd
@@ -167,6 +167,10 @@ func async_take_and_compare_snapshot(
 		dcl_rpc_sender
 	)
 
+	var pending_promises := Global.content_provider.get_pending_promises()
+	if not pending_promises.is_empty():
+		await PromiseUtils.async_all(Global.content_provider.get_pending_promises())
+
 	# TODO: make this configurable
 	var hide_player := true
 

--- a/godot/src/ui/components/pointer_tooltip/tooltip_label.gd
+++ b/godot/src/ui/components/pointer_tooltip/tooltip_label.gd
@@ -14,11 +14,12 @@ func _ready():
 
 func set_tooltip_data(text: String, action: String):
 	var key: String
-	var index: int = InputMap.get_actions().find(action.to_lower(), 0)
+	var action_lower: String = action.to_lower()
+	var index: int = InputMap.get_actions().find(action_lower, 0)
 	if label_text:
-		if index != -1:
-			action_to_trigger = action.to_lower()
-			show()
+		if index == -1 and action_lower == "ia_any":
+			key = "Any"
+		elif index != -1:
 			var event = InputMap.action_get_events(InputMap.get_actions()[index])[0]
 			if event is InputEventKey:
 				key = char(event.unicode).to_upper()
@@ -29,15 +30,22 @@ func set_tooltip_data(text: String, action: String):
 					key = "Mouse Right Button"
 				if event.button_index == 0:
 					key = "Mouse Wheel Button"
+
+		if not key.is_empty():
+			show()
+			action_to_trigger = action_lower
 			label_action.text = key
 			label_text.text = text
 		else:
-			action_to_trigger = ""
 			hide()
+			action_to_trigger = ""
 			printerr("Action doesn't exist ", action)
 
 
 func mobile_on_panel_container_gui_input(event):
+	if action_to_trigger.is_empty():
+		return
+
 	if event is InputEventMouseButton:
 		if event.pressed:
 			Input.action_press(action_to_trigger)

--- a/rust/decentraland-godot-lib/src/auth/dcl_player_identity.rs
+++ b/rust/decentraland-godot-lib/src/auth/dcl_player_identity.rs
@@ -5,6 +5,7 @@ use rand::thread_rng;
 use tokio::task::JoinHandle;
 
 use crate::comms::profile::{LambdaProfiles, UserProfile};
+use crate::content::bytes::fast_create_packed_byte_array_from_vec;
 use crate::dcl::scene_apis::RpcResultSender;
 use crate::godot_classes::promise::Promise;
 use crate::http_request::request_response::{RequestResponse, ResponseEnum};
@@ -388,21 +389,7 @@ impl DclPlayerIdentity {
                     return;
                 };
 
-                // TODO: gdext should implement a packedByteArray constructor from &[u8] and not iteration
-                let body_payload = {
-                    let byte_length = body_payload.len();
-                    let mut param = PackedByteArray::new();
-                    param.resize(byte_length);
-                    let data_arr_ptr = param.as_mut_slice();
-
-                    unsafe {
-                        let dst_ptr = &mut data_arr_ptr[0] as *mut u8;
-                        let src_ptr = &body_payload[0] as *const u8;
-                        std::ptr::copy_nonoverlapping(src_ptr, dst_ptr, byte_length);
-                    }
-                    param
-                };
-
+                let body_payload = fast_create_packed_byte_array_from_vec(&body_payload);
                 let mut dict = Dictionary::default();
                 dict.set("content_type", content_type.to_variant());
                 dict.set("body_payload", body_payload.to_variant());

--- a/rust/decentraland-godot-lib/src/av/video_context.rs
+++ b/rust/decentraland-godot-lib/src/av/video_context.rs
@@ -7,9 +7,11 @@ use ffmpeg_next::software::scaling::{context::Context, flag::Flags};
 use ffmpeg_next::{decoder, format::context::Input, media::Type, util::frame, Packet};
 use godot::engine::image::Format;
 use godot::engine::{Image, ImageTexture};
-use godot::prelude::{Gd, PackedByteArray, Vector2};
+use godot::prelude::{Gd, Vector2};
 use thiserror::Error;
 use tracing::debug;
+
+use crate::content::bytes::fast_create_packed_byte_array_from_slice;
 
 use super::stream_processor::FfmpegContext;
 
@@ -150,17 +152,7 @@ impl FfmpegContext for VideoContext {
         // let data_arr = PackedByteArray::from(current_frame.data(0));
 
         let raw_data = current_frame.data(0);
-        let byte_length = raw_data.len();
-        let mut data_arr = PackedByteArray::new();
-        data_arr.resize(raw_data.len());
-
-        let data_arr_ptr = data_arr.as_mut_slice();
-
-        unsafe {
-            let dst_ptr = &mut data_arr_ptr[0] as *mut u8;
-            let src_ptr = &raw_data[0] as *const u8;
-            std::ptr::copy_nonoverlapping(src_ptr, dst_ptr, byte_length);
-        }
+        let data_arr = fast_create_packed_byte_array_from_slice(raw_data);
 
         let diff = self.last_frame_time.elapsed().as_secs_f32();
         debug!(

--- a/rust/decentraland-godot-lib/src/content/audio.rs
+++ b/rust/decentraland-godot-lib/src/content/audio.rs
@@ -1,84 +1,48 @@
 use godot::{
-    builtin::meta::ToGodot,
-    engine::{AudioStream, AudioStreamMp3, AudioStreamWav},
+    builtin::{meta::ToGodot, Variant},
+    engine::{AudioStream, AudioStreamMp3, AudioStreamOggVorbis, AudioStreamWav},
     obj::Gd,
 };
 use tokio::io::AsyncReadExt;
 
-use crate::godot_classes::promise::Promise;
-
 use super::{
-    bytes::fast_create_packed_byte_array_from_vec,
-    content_mapping::ContentMappingAndUrlRef,
-    content_provider::ContentProviderContext,
-    download::fetch_resource_or_wait,
-    file_string::get_extension,
-    thread_safety::{reject_promise, resolve_promise, GodotSingleThreadSafety},
+    bytes::fast_create_packed_byte_array_from_vec, content_mapping::ContentMappingAndUrlRef,
+    content_provider::ContentProviderContext, download::fetch_resource_or_wait,
+    file_string::get_extension, thread_safety::GodotSingleThreadSafety,
 };
 
 pub async fn load_audio(
     file_path: String,
     content_mapping: ContentMappingAndUrlRef,
-    get_promise: impl Fn() -> Option<Gd<Promise>>,
     ctx: ContentProviderContext,
-) {
+) -> Result<Option<Variant>, anyhow::Error> {
     let extension = get_extension(&file_path);
     if ["wav", "ogg", "mp3"].contains(&extension.as_str()) {
-        reject_promise(
-            get_promise,
-            format!("Audio {} unrecognized format", file_path),
-        );
-        return;
+        return Err(anyhow::Error::msg(format!(
+            "Audio {} unrecognized format",
+            file_path
+        )));
     }
 
-    let Some(file_hash) = content_mapping.content.get(&file_path) else {
-        reject_promise(
-            get_promise,
-            "File not found in the content mappings".to_string(),
-        );
-        return;
-    };
+    let file_hash = content_mapping
+        .content
+        .get(&file_path)
+        .ok_or(anyhow::Error::msg("File not found in the content mappings"))?;
 
     let url = format!("{}{}", content_mapping.base_url, file_hash);
     let absolute_file_path = format!("{}{}", ctx.content_folder, file_hash);
-    match fetch_resource_or_wait(&url, file_hash, &absolute_file_path, ctx.clone()).await {
-        Ok(_) => {}
-        Err(err) => {
-            reject_promise(
-                get_promise,
-                format!("Error downloading audio {file_hash}: {:?}", err),
-            );
-            return;
-        }
-    }
 
-    let mut file = match tokio::fs::File::open(&absolute_file_path).await {
-        Ok(file) => file,
-        Err(err) => {
-            reject_promise(
-                get_promise,
-                format!("Error opening audio file {}: {:?}", file_path, err),
-            );
-            return;
-        }
-    };
+    fetch_resource_or_wait(&url, file_hash, &absolute_file_path, ctx.clone())
+        .await
+        .map_err(anyhow::Error::msg)?;
 
+    let mut file = tokio::fs::File::open(&absolute_file_path).await?;
     let mut bytes_vec = Vec::new();
-    if let Err(err) = file.read_to_end(&mut bytes_vec).await {
-        reject_promise(
-            get_promise,
-            format!("Error reading audio file {}: {:?}", file_path, err),
-        );
-        return;
-    }
+    file.read_to_end(&mut bytes_vec).await?;
 
-    let Some(_thread_safe_check) = GodotSingleThreadSafety::acquire_owned(&ctx).await else {
-        reject_promise(
-            get_promise,
-            "Error loading gltf when acquiring thread safety".to_string(),
-        );
-        return;
-    };
+    let _thread_safe_check = GodotSingleThreadSafety::acquire_owned(&ctx)
+        .await
+        .ok_or(anyhow::Error::msg("Failed while trying to "))?;
 
     let bytes = fast_create_packed_byte_array_from_vec(&bytes_vec);
     let audio_stream: Option<Gd<AudioStream>> = match extension.as_str() {
@@ -87,11 +51,7 @@ pub async fn load_audio(
             audio_stream.set_data(bytes);
             Some(audio_stream.upcast())
         }
-        // ".ogg" => {
-        //     let audio_stream = AudioStreamOggVorbis::new();
-        //     // audio_stream.set_(bytes);
-        //     audio_stream.upcast()
-        // }
+        ".ogg" => AudioStreamOggVorbis::load_from_buffer(bytes).map(|value| value.upcast()),
         ".mp3" => {
             let mut audio_stream = AudioStreamMp3::new();
             audio_stream.set_data(bytes);
@@ -100,13 +60,6 @@ pub async fn load_audio(
         _ => None,
     };
 
-    let Some(audio_stream) = audio_stream else {
-        reject_promise(
-            get_promise,
-            format!("Error creating audio stream for {}", absolute_file_path),
-        );
-        return;
-    };
-
-    resolve_promise(get_promise, Some(audio_stream.to_variant()));
+    let audio_stream = audio_stream.ok_or(anyhow::Error::msg("Error creating audio stream"))?;
+    Ok(Some(audio_stream.to_variant()))
 }

--- a/rust/decentraland-godot-lib/src/content/bytes.rs
+++ b/rust/decentraland-godot-lib/src/content/bytes.rs
@@ -1,0 +1,21 @@
+use godot::builtin::PackedByteArray;
+
+// TODO: gdext should implement a packedByteArray constructor from &[u8] and not iteration
+pub fn fast_create_packed_byte_array_from_slice(bytes_slice: &[u8]) -> PackedByteArray {
+    let byte_length = bytes_slice.len();
+    let mut bytes = PackedByteArray::new();
+    bytes.resize(byte_length);
+
+    let data_arr_ptr = bytes.as_mut_slice();
+    unsafe {
+        let dst_ptr = &mut data_arr_ptr[0] as *mut u8;
+        let src_ptr = &bytes_slice[0] as *const u8;
+        std::ptr::copy_nonoverlapping(src_ptr, dst_ptr, byte_length);
+    }
+
+    bytes
+}
+
+pub fn fast_create_packed_byte_array_from_vec(bytes_vec: &Vec<u8>) -> PackedByteArray {
+    fast_create_packed_byte_array_from_slice(bytes_vec.as_slice())
+}

--- a/rust/decentraland-godot-lib/src/content/content_notificator.rs
+++ b/rust/decentraland-godot-lib/src/content/content_notificator.rs
@@ -45,13 +45,12 @@ impl ContentNotificator {
         ContentState::RequestOwner
     }
 
-    pub async fn resolve(&self, key: &String, result: Result<(), String>) {
+    pub async fn resolve(&self, key: &str, result: Result<(), String>) {
         let mut files = self.files.write().await;
-        if let Some(notify) = files.insert(key.clone(), ContentState::Released(result)) {
-            if let ContentState::Busy(notify) = notify {
-                notify.notify_waiters();
-            }
+        if let Some(ContentState::Busy(notify)) =
+            files.insert(key.to_owned(), ContentState::Released(result))
+        {
+            notify.notify_waiters();
         }
-        files.remove(key);
     }
 }

--- a/rust/decentraland-godot-lib/src/content/content_notificator.rs
+++ b/rust/decentraland-godot-lib/src/content/content_notificator.rs
@@ -2,8 +2,15 @@ use std::{collections::HashMap, sync::Arc};
 
 use tokio::sync::{Notify, RwLock};
 
+#[derive(Clone, Debug)]
+pub enum ContentState {
+    RequestOwner,
+    Busy(Arc<Notify>),
+    Released(Result<(), String>),
+}
+
 pub struct ContentNotificator {
-    files: RwLock<HashMap<String, Arc<Notify>>>,
+    files: RwLock<HashMap<String, ContentState>>,
 }
 
 impl Default for ContentNotificator {
@@ -19,24 +26,32 @@ impl ContentNotificator {
         }
     }
 
-    pub async fn get_or_create_notify(&self, key: String) -> (bool, Arc<Notify>) {
+    pub async fn get(&self, key: &String) -> Option<ContentState> {
+        let files = self.files.read().await;
+        files.get(key).cloned()
+    }
+
+    pub async fn get_or_create_notify(&self, key: &String) -> ContentState {
         {
             let files = self.files.read().await;
-            if let Some(notify) = files.get(&key) {
-                return (false, notify.clone());
+            if let Some(content_state) = files.get(key) {
+                return content_state.clone();
             }
         }
 
         let mut files = self.files.write().await;
-        let notify = Arc::new(Notify::new());
-        files.insert(key, notify.clone());
-        drop(files);
-
-        (true, notify)
+        let content_state = ContentState::Busy(Arc::new(Notify::new()));
+        files.insert(key.clone(), content_state.clone());
+        ContentState::RequestOwner
     }
 
-    pub async fn remove_notify(&mut self, key: String) {
+    pub async fn resolve(&self, key: &String, result: Result<(), String>) {
         let mut files = self.files.write().await;
-        files.remove(&key);
+        if let Some(notify) = files.insert(key.clone(), ContentState::Released(result)) {
+            if let ContentState::Busy(notify) = notify {
+                notify.notify_waiters();
+            }
+        }
+        files.remove(key);
     }
 }

--- a/rust/decentraland-godot-lib/src/content/content_provider.rs
+++ b/rust/decentraland-godot-lib/src/content/content_provider.rs
@@ -205,18 +205,16 @@ impl ContentProvider {
             return entry.promise.clone();
         }
 
-        let absolute_file_path = format!("{}{}", self.content_folder, file_hash);
-        let url = format!("{}{}", content_mapping.bind().get_base_url(), file_hash);
+        let url = format!(
+            "{}{}",
+            content_mapping.bind().get_base_url(),
+            file_hash.clone()
+        );
         let (promise, get_promise) = Promise::make_to_async();
         let content_provider_context = self.get_context();
+        let sent_file_hash = file_hash.clone();
         TokioRuntime::spawn(async move {
-            load_png_texture(
-                url,
-                absolute_file_path,
-                get_promise,
-                content_provider_context,
-            )
-            .await;
+            load_png_texture(url, sent_file_hash, get_promise, content_provider_context).await;
         });
 
         self.cached.insert(
@@ -236,17 +234,11 @@ impl ContentProvider {
             return entry.promise.clone();
         }
         let url = url.to_string();
-        let absolute_file_path = format!("{}{}", self.content_folder, file_hash);
         let (promise, get_promise) = Promise::make_to_async();
         let content_provider_context = self.get_context();
+        let sent_file_hash = file_hash.clone();
         TokioRuntime::spawn(async move {
-            load_png_texture(
-                url,
-                absolute_file_path,
-                get_promise,
-                content_provider_context,
-            )
-            .await;
+            load_png_texture(url, sent_file_hash, get_promise, content_provider_context).await;
         });
 
         self.cached.insert(

--- a/rust/decentraland-godot-lib/src/content/content_provider.rs
+++ b/rust/decentraland-godot-lib/src/content/content_provider.rs
@@ -20,7 +20,7 @@ use super::{
     content_notificator::ContentNotificator,
     gltf::{apply_update_set_mask_colliders, load_gltf},
     texture::{load_png_texture, TextureEntry},
-    thread_safety::{resolve_promise, set_thread_safety_checks_enabled},
+    thread_safety::{set_thread_safety_checks_enabled, then_promise},
     video::download_video,
     wearable_entities::request_wearables,
 };
@@ -64,6 +64,10 @@ impl INode for ContentProvider {
         }
     }
     fn ready(&mut self) {}
+    fn exit_tree(&mut self) {
+        self.cached.clear();
+        tracing::info!("ContentProvider::exit_tree");
+    }
 }
 
 #[godot_api]
@@ -91,13 +95,8 @@ impl ContentProvider {
         let gltf_file_path = file_path.to_string();
         let content_provider_context = self.get_context();
         TokioRuntime::spawn(async move {
-            load_gltf(
-                gltf_file_path,
-                content_mapping,
-                get_promise,
-                content_provider_context,
-            )
-            .await;
+            let result = load_gltf(gltf_file_path, content_mapping, content_provider_context).await;
+            then_promise(get_promise, result);
         });
 
         self.cached.insert(
@@ -123,16 +122,16 @@ impl ContentProvider {
         let gltf_node_instance_id = gltf_node.instance_id();
         let content_provider_context = self.get_context();
         TokioRuntime::spawn(async move {
-            apply_update_set_mask_colliders(
+            let result = apply_update_set_mask_colliders(
                 gltf_node_instance_id,
                 dcl_visible_cmask,
                 dcl_invisible_cmask,
                 dcl_scene_id,
                 dcl_entity_id,
-                get_promise,
                 content_provider_context,
             )
             .await;
+            then_promise(get_promise, result);
         });
 
         promise
@@ -161,13 +160,9 @@ impl ContentProvider {
         let audio_file_path = file_path.to_string();
         let content_provider_context = self.get_context();
         TokioRuntime::spawn(async move {
-            load_audio(
-                audio_file_path,
-                content_mapping,
-                get_promise,
-                content_provider_context,
-            )
-            .await;
+            let result =
+                load_audio(audio_file_path, content_mapping, content_provider_context).await;
+            then_promise(get_promise, result);
         });
 
         self.cached.insert(
@@ -214,7 +209,8 @@ impl ContentProvider {
         let content_provider_context = self.get_context();
         let sent_file_hash = file_hash.clone();
         TokioRuntime::spawn(async move {
-            load_png_texture(url, sent_file_hash, get_promise, content_provider_context).await;
+            let result = load_png_texture(url, sent_file_hash, content_provider_context).await;
+            then_promise(get_promise, result);
         });
 
         self.cached.insert(
@@ -238,7 +234,8 @@ impl ContentProvider {
         let content_provider_context = self.get_context();
         let sent_file_hash = file_hash.clone();
         TokioRuntime::spawn(async move {
-            load_png_texture(url, sent_file_hash, get_promise, content_provider_context).await;
+            let result = load_png_texture(url, sent_file_hash, content_provider_context).await;
+            then_promise(get_promise, result);
         });
 
         self.cached.insert(
@@ -295,13 +292,9 @@ impl ContentProvider {
         let video_file_hash = file_hash.clone();
         let content_provider_context = self.get_context();
         TokioRuntime::spawn(async move {
-            download_video(
-                video_file_hash,
-                content_mapping,
-                get_promise,
-                content_provider_context,
-            )
-            .await;
+            let result =
+                download_video(video_file_hash, content_mapping, content_provider_context).await;
+            then_promise(get_promise, result);
         });
 
         self.cached.insert(
@@ -348,7 +341,7 @@ impl ContentProvider {
 
             set_thread_safety_checks_enabled(true);
 
-            resolve_promise(get_promise, None);
+            then_promise(get_promise, Ok(None));
         });
 
         promise
@@ -397,14 +390,14 @@ impl ContentProvider {
             let content_base_url = format!("{}{extra_slash}", content_base_url);
             let ipfs_content_base_url = format!("{content_base_url}contents/");
             TokioRuntime::spawn(async move {
-                request_wearables(
+                let result = request_wearables(
                     content_base_url,
                     ipfs_content_base_url,
                     wearable_to_fetch.into_iter().collect(),
-                    get_promise,
                     content_provider_context,
                 )
                 .await;
+                then_promise(get_promise, result);
             });
             self.cached.insert(
                 "wearables".to_string(),

--- a/rust/decentraland-godot-lib/src/content/content_provider.rs
+++ b/rust/decentraland-godot-lib/src/content/content_provider.rs
@@ -429,6 +429,16 @@ impl ContentProvider {
         }
         Variant::nil()
     }
+
+    #[func]
+    pub fn get_pending_promises(&self) -> Array<Gd<Promise>> {
+        Array::from_iter(
+            self.cached
+                .iter()
+                .filter(|(_, entry)| !entry.promise.bind().is_resolved())
+                .map(|(_, entry)| entry.promise.clone()),
+        )
+    }
 }
 
 impl ContentProvider {

--- a/rust/decentraland-godot-lib/src/content/download.rs
+++ b/rust/decentraland-godot-lib/src/content/download.rs
@@ -1,0 +1,57 @@
+use godot::{builtin::GString, engine::FileAccess};
+
+use crate::http_request::request_response::{RequestOption, ResponseType};
+
+use super::{content_notificator::ContentState, content_provider::ContentProviderContext};
+
+pub async fn fetch_resource_or_wait(
+    url: &String,
+    file_hash: &String,
+    absolute_file_path: &String,
+    ctx: ContentProviderContext,
+) -> Result<(), String> {
+    let content_state = ctx
+        .content_notificator
+        .get_or_create_notify(&file_hash)
+        .await;
+
+    match content_state {
+        ContentState::Busy(notify) => {
+            notify.notified().await;
+            match ctx.content_notificator.get(&file_hash).await {
+                Some(ContentState::Released(result)) => result,
+                _ => Err("Double busy state ".to_string()),
+            }
+        }
+        ContentState::Released(result) => result,
+        ContentState::RequestOwner => {
+            if !FileAccess::file_exists(GString::from(&absolute_file_path)) {
+                let request = RequestOption::new(
+                    0,
+                    url.clone(),
+                    http::Method::GET,
+                    ResponseType::ToFile(absolute_file_path.clone()),
+                    None,
+                    None,
+                    None,
+                );
+
+                let result = match ctx.http_queue_requester.request(request, 0).await {
+                    Ok(_response) => Ok(()),
+                    Err(err) => Err(format!(
+                        "Error downloading content {url} ({absolute_file_path}): {:?}",
+                        err
+                    )),
+                };
+
+                ctx.content_notificator
+                    .resolve(&file_hash, result.clone())
+                    .await;
+                result
+            } else {
+                ctx.content_notificator.resolve(&file_hash, Ok(())).await;
+                Ok(())
+            }
+        }
+    }
+}

--- a/rust/decentraland-godot-lib/src/content/download.rs
+++ b/rust/decentraland-godot-lib/src/content/download.rs
@@ -1,5 +1,3 @@
-use godot::{builtin::GString, engine::FileAccess};
-
 use crate::http_request::request_response::{RequestOption, ResponseType};
 
 use super::{content_notificator::ContentState, content_provider::ContentProviderContext};
@@ -12,13 +10,13 @@ pub async fn fetch_resource_or_wait(
 ) -> Result<(), String> {
     let content_state = ctx
         .content_notificator
-        .get_or_create_notify(&file_hash)
+        .get_or_create_notify(file_hash)
         .await;
 
     match content_state {
         ContentState::Busy(notify) => {
             notify.notified().await;
-            match ctx.content_notificator.get(&file_hash).await {
+            match ctx.content_notificator.get(file_hash).await {
                 Some(ContentState::Released(result)) => result,
                 _ => Err("Double busy state ".to_string()),
             }
@@ -45,11 +43,11 @@ pub async fn fetch_resource_or_wait(
                 };
 
                 ctx.content_notificator
-                    .resolve(&file_hash, result.clone())
+                    .resolve(file_hash, result.clone())
                     .await;
                 result
             } else {
-                ctx.content_notificator.resolve(&file_hash, Ok(())).await;
+                ctx.content_notificator.resolve(file_hash, Ok(())).await;
                 Ok(())
             }
         }

--- a/rust/decentraland-godot-lib/src/content/download.rs
+++ b/rust/decentraland-godot-lib/src/content/download.rs
@@ -25,7 +25,7 @@ pub async fn fetch_resource_or_wait(
         }
         ContentState::Released(result) => result,
         ContentState::RequestOwner => {
-            if !FileAccess::file_exists(GString::from(&absolute_file_path)) {
+            if tokio::fs::metadata(&absolute_file_path).await.is_err() {
                 let request = RequestOption::new(
                     0,
                     url.clone(),

--- a/rust/decentraland-godot-lib/src/content/gltf.rs
+++ b/rust/decentraland-godot-lib/src/content/gltf.rs
@@ -236,6 +236,14 @@ fn get_dependencies(file_path: &String) -> Vec<String> {
         return dependencies;
     };
 
+    if p_file.get_error() != Error::OK {
+        return dependencies;
+    }
+
+    if p_file.get_length() < 20 {
+        return dependencies;
+    }
+
     p_file.seek(0);
 
     let magic = p_file.get_32();

--- a/rust/decentraland-godot-lib/src/content/gltf.rs
+++ b/rust/decentraland-godot-lib/src/content/gltf.rs
@@ -127,7 +127,7 @@ pub async fn load_gltf(
         return;
     }
 
-    let Some(thread_safe_check) = GodotSingleThreadSafety::acquire_owned(&ctx).await else {
+    let Some(_thread_safe_check) = GodotSingleThreadSafety::acquire_owned(&ctx).await else {
         reject_promise(
             get_promise,
             "Error loading gltf when acquiring thread safety".to_string(),
@@ -185,7 +185,6 @@ pub async fn load_gltf(
     create_colliders(node.clone().upcast());
 
     resolve_promise(get_promise, Some(node.to_variant()));
-    thread_safe_check.nop();
 }
 
 pub async fn apply_update_set_mask_colliders(
@@ -197,7 +196,7 @@ pub async fn apply_update_set_mask_colliders(
     get_promise: impl Fn() -> Option<Gd<Promise>>,
     ctx: ContentProviderContext,
 ) {
-    let Some(thread_safe_check) = GodotSingleThreadSafety::acquire_owned(&ctx).await else {
+    let Some(_thread_safe_check) = GodotSingleThreadSafety::acquire_owned(&ctx).await else {
         reject_promise(
             get_promise,
             "Error loading gltf when acquiring thread safety".to_string(),
@@ -228,7 +227,6 @@ pub async fn apply_update_set_mask_colliders(
     }
 
     resolve_promise(get_promise, Some(gltf_node.to_variant()));
-    thread_safe_check.nop();
 }
 
 async fn get_dependencies(file_path: &String) -> Result<Vec<String>, anyhow::Error> {

--- a/rust/decentraland-godot-lib/src/content/mod.rs
+++ b/rust/decentraland-godot-lib/src/content/mod.rs
@@ -2,6 +2,7 @@ mod audio;
 pub mod content_mapping;
 pub mod content_notificator;
 pub mod content_provider;
+mod download;
 mod file_string;
 mod gltf;
 mod texture;

--- a/rust/decentraland-godot-lib/src/content/mod.rs
+++ b/rust/decentraland-godot-lib/src/content/mod.rs
@@ -1,4 +1,5 @@
 mod audio;
+pub mod bytes;
 pub mod content_mapping;
 pub mod content_notificator;
 pub mod content_provider;

--- a/rust/decentraland-godot-lib/src/content/texture.rs
+++ b/rust/decentraland-godot-lib/src/content/texture.rs
@@ -1,19 +1,14 @@
+use super::{
+    bytes::fast_create_packed_byte_array_from_vec, content_provider::ContentProviderContext,
+    download::fetch_resource_or_wait, thread_safety::GodotSingleThreadSafety,
+};
 use godot::{
     bind::GodotClass,
-    builtin::{meta::ToGodot, GString},
+    builtin::{meta::ToGodot, GString, Variant},
     engine::{global::Error, DirAccess, Image, ImageTexture},
     obj::Gd,
 };
 use tokio::io::AsyncReadExt;
-
-use crate::godot_classes::promise::Promise;
-
-use super::{
-    bytes::fast_create_packed_byte_array_from_vec,
-    content_provider::ContentProviderContext,
-    download::fetch_resource_or_wait,
-    thread_safety::{reject_promise, resolve_promise, GodotSingleThreadSafety},
-};
 
 #[derive(GodotClass)]
 #[class(init, base=RefCounted)]
@@ -27,54 +22,20 @@ pub struct TextureEntry {
 pub async fn load_png_texture(
     url: String,
     file_hash: String,
-    get_promise: impl Fn() -> Option<Gd<Promise>>,
     ctx: ContentProviderContext,
-) {
+) -> Result<Option<Variant>, anyhow::Error> {
     let absolute_file_path = format!("{}{}", ctx.content_folder, file_hash);
-    match fetch_resource_or_wait(&url, &file_hash, &absolute_file_path, ctx.clone()).await {
-        Ok(_) => {}
-        Err(err) => {
-            reject_promise(
-                get_promise,
-                format!("Error downloading png texture {file_hash}: {:?}", err),
-            );
-            return;
-        }
-    }
+    fetch_resource_or_wait(&url, &file_hash, &absolute_file_path, ctx.clone())
+        .await
+        .map_err(anyhow::Error::msg)?;
 
-    let mut file = match tokio::fs::File::open(&absolute_file_path).await {
-        Ok(file) => file,
-        Err(err) => {
-            reject_promise(
-                get_promise,
-                format!(
-                    "Error opening texture file {}: {:?}",
-                    absolute_file_path, err
-                ),
-            );
-            return;
-        }
-    };
-
+    let mut file = tokio::fs::File::open(&absolute_file_path).await?;
     let mut bytes_vec = Vec::new();
-    if let Err(err) = file.read_to_end(&mut bytes_vec).await {
-        reject_promise(
-            get_promise,
-            format!(
-                "Error reading texture file {}: {:?}",
-                absolute_file_path, err
-            ),
-        );
-        return;
-    }
+    file.read_to_end(&mut bytes_vec).await?;
 
-    let Some(_thread_safe_check) = GodotSingleThreadSafety::acquire_owned(&ctx).await else {
-        reject_promise(
-            get_promise,
-            "Error loading gltf when acquiring thread safety".to_string(),
-        );
-        return;
-    };
+    let _thread_safe_check = GodotSingleThreadSafety::acquire_owned(&ctx)
+        .await
+        .ok_or(anyhow::Error::msg("Failed trying to get thread-safe check"))?;
 
     let bytes = fast_create_packed_byte_array_from_vec(&bytes_vec);
 
@@ -83,23 +44,18 @@ pub async fn load_png_texture(
     if err != Error::OK {
         DirAccess::remove_absolute(GString::from(&absolute_file_path));
         let err = err.to_variant().to::<i32>();
-        reject_promise(
-            get_promise,
-            format!("Error loading texture {absolute_file_path}: {}", err),
-        );
-        return;
+        return Err(anyhow::Error::msg(format!(
+            "Error loading texture {absolute_file_path}: {}",
+            err
+        )));
     }
 
-    let Some(mut texture) = ImageTexture::create_from_image(image.clone()) else {
-        reject_promise(
-            get_promise,
-            format!("Error creating texture from image {}", absolute_file_path),
-        );
-        return;
-    };
-
+    let mut texture = ImageTexture::create_from_image(image.clone()).ok_or(anyhow::Error::msg(
+        format!("Error creating texture from image {}", absolute_file_path),
+    ))?;
     texture.set_name(GString::from(&url));
 
     let texture_entry = Gd::from_init_fn(|_base| TextureEntry { texture, image });
-    resolve_promise(get_promise, Some(texture_entry.to_variant()));
+
+    Ok(Some(texture_entry.to_variant()))
 }

--- a/rust/decentraland-godot-lib/src/content/thread_safety.rs
+++ b/rust/decentraland-godot-lib/src/content/thread_safety.rs
@@ -37,7 +37,7 @@ pub fn set_thread_safety_checks_enabled(enabled: bool) {
     );
 }
 
-pub fn reject_promise(get_promise: impl Fn() -> Option<Gd<Promise>>, reason: String) -> bool {
+fn reject_promise(get_promise: impl Fn() -> Option<Gd<Promise>>, reason: String) -> bool {
     if let Some(mut promise) = get_promise() {
         promise.call_deferred("reject".into(), &[reason.to_variant()]);
         true
@@ -46,10 +46,7 @@ pub fn reject_promise(get_promise: impl Fn() -> Option<Gd<Promise>>, reason: Str
     }
 }
 
-pub fn resolve_promise(
-    get_promise: impl Fn() -> Option<Gd<Promise>>,
-    value: Option<Variant>,
-) -> bool {
+fn resolve_promise(get_promise: impl Fn() -> Option<Gd<Promise>>, value: Option<Variant>) -> bool {
     if let Some(mut promise) = get_promise() {
         if let Some(value) = value {
             promise.call_deferred("resolve_with_data".into(), &[value]);
@@ -60,4 +57,14 @@ pub fn resolve_promise(
     } else {
         false
     }
+}
+
+pub fn then_promise(
+    get_promise: impl Fn() -> Option<Gd<Promise>>,
+    result: Result<Option<Variant>, anyhow::Error>,
+) {
+    match result {
+        Ok(value) => resolve_promise(get_promise, value),
+        Err(reason) => reject_promise(get_promise, reason.to_string()),
+    };
 }

--- a/rust/decentraland-godot-lib/src/content/thread_safety.rs
+++ b/rust/decentraland-godot-lib/src/content/thread_safety.rs
@@ -18,9 +18,6 @@ impl GodotSingleThreadSafety {
         set_thread_safety_checks_enabled(false);
         Some(Self { _guard: guard })
     }
-
-    pub fn nop(&self) { /* nop */
-    }
 }
 
 impl Drop for GodotSingleThreadSafety {

--- a/rust/decentraland-godot-lib/src/content/video.rs
+++ b/rust/decentraland-godot-lib/src/content/video.rs
@@ -1,17 +1,11 @@
-use godot::{
-    builtin::GString,
-    engine::{file_access::ModeFlags, FileAccess},
-    obj::Gd,
-};
+use godot::obj::Gd;
 
-use crate::{
-    godot_classes::promise::Promise,
-    http_request::request_response::{RequestOption, ResponseType},
-};
+use crate::godot_classes::promise::Promise;
 
 use super::{
     content_mapping::ContentMappingAndUrlRef,
     content_provider::ContentProviderContext,
+    download::fetch_resource_or_wait,
     thread_safety::{reject_promise, resolve_promise},
 };
 
@@ -21,37 +15,18 @@ pub async fn download_video(
     get_promise: impl Fn() -> Option<Gd<Promise>>,
     ctx: ContentProviderContext,
 ) {
+    let url = format!("{}{}", content_mapping.base_url, file_hash);
     let absolute_file_path = format!("{}{}", ctx.content_folder, file_hash);
-    if !FileAccess::file_exists(GString::from(&absolute_file_path)) {
-        let request = RequestOption::new(
-            0,
-            format!("{}{}", content_mapping.base_url, file_hash),
-            http::Method::GET,
-            ResponseType::ToFile(absolute_file_path.clone()),
-            None,
-            None,
-            None,
-        );
-
-        match ctx.http_queue_requester.request(request, 0).await {
-            Ok(_response) => {}
-            Err(err) => {
-                reject_promise(
-                    get_promise,
-                    format!("Error downloading video {file_hash}: {:?}", err),
-                );
-                return;
-            }
+    match fetch_resource_or_wait(&url, &file_hash, &absolute_file_path, ctx.clone()).await {
+        Ok(_) => {}
+        Err(err) => {
+            reject_promise(
+                get_promise,
+                format!("Error downloading video {file_hash}: {:?}", err),
+            );
+            return;
         }
     }
-
-    let Some(_file) = FileAccess::open(GString::from(&absolute_file_path), ModeFlags::READ) else {
-        reject_promise(
-            get_promise,
-            format!("Error opening video file {}", absolute_file_path),
-        );
-        return;
-    };
 
     resolve_promise(get_promise, None);
 }

--- a/rust/decentraland-godot-lib/src/content/video.rs
+++ b/rust/decentraland-godot-lib/src/content/video.rs
@@ -1,32 +1,18 @@
-use godot::obj::Gd;
-
-use crate::godot_classes::promise::Promise;
-
 use super::{
-    content_mapping::ContentMappingAndUrlRef,
-    content_provider::ContentProviderContext,
+    content_mapping::ContentMappingAndUrlRef, content_provider::ContentProviderContext,
     download::fetch_resource_or_wait,
-    thread_safety::{reject_promise, resolve_promise},
 };
+use godot::builtin::Variant;
 
 pub async fn download_video(
     file_hash: String,
     content_mapping: ContentMappingAndUrlRef,
-    get_promise: impl Fn() -> Option<Gd<Promise>>,
     ctx: ContentProviderContext,
-) {
+) -> Result<Option<Variant>, anyhow::Error> {
     let url = format!("{}{}", content_mapping.base_url, file_hash);
     let absolute_file_path = format!("{}{}", ctx.content_folder, file_hash);
-    match fetch_resource_or_wait(&url, &file_hash, &absolute_file_path, ctx.clone()).await {
-        Ok(_) => {}
-        Err(err) => {
-            reject_promise(
-                get_promise,
-                format!("Error downloading video {file_hash}: {:?}", err),
-            );
-            return;
-        }
-    }
-
-    resolve_promise(get_promise, None);
+    fetch_resource_or_wait(&url, &file_hash, &absolute_file_path, ctx.clone())
+        .await
+        .map_err(anyhow::Error::msg)?;
+    Ok(None)
 }

--- a/rust/decentraland-godot-lib/src/dcl/js/engine.rs
+++ b/rust/decentraland-godot-lib/src/dcl/js/engine.rs
@@ -30,6 +30,7 @@ pub fn ops() -> Vec<OpDecl> {
     vec![
         op_crdt_send_to_renderer::DECL,
         op_crdt_recv_from_renderer::DECL,
+        op_run_async::DECL,
     ]
 }
 
@@ -77,6 +78,11 @@ fn op_crdt_send_to_renderer(op_state: Rc<RefCell<OpState>>, messages: &[u8]) {
             rpc_calls,
         ))
         .expect("error sending scene response!!")
+}
+
+#[op(v8)]
+async fn op_run_async(op_state: Rc<RefCell<OpState>>) {
+    let _ = op_state.borrow_mut();
 }
 
 #[op(v8)]

--- a/rust/decentraland-godot-lib/src/dcl/js/js_modules/CommunicationsController.js
+++ b/rust/decentraland-godot-lib/src/dcl/js/js_modules/CommunicationsController.js
@@ -1,1 +1,2 @@
 module.exports.send = async function (body) { return {} }
+module.exports.sendBinary = async function (body) { return { data: [] } }

--- a/rust/decentraland-godot-lib/src/dcl/js/js_modules/utils.js
+++ b/rust/decentraland-godot-lib/src/dcl/js/js_modules/utils.js
@@ -1,0 +1,3 @@
+module.exports.run_async = async function () {
+    await Deno.core.ops.op_run_async();
+}

--- a/rust/decentraland-godot-lib/src/dcl/js/mod.rs
+++ b/rust/decentraland-godot-lib/src/dcl/js/mod.rs
@@ -261,6 +261,10 @@ pub(crate) fn scene_thread(
         return;
     }
 
+    rt.block_on(async {
+        let _ = runtime.run_event_loop(false).await;
+    });
+
     let start_time = std::time::SystemTime::now();
     let mut elapsed = Duration::default();
 

--- a/rust/decentraland-godot-lib/src/godot_classes/dcl_ui_background.rs
+++ b/rust/decentraland-godot-lib/src/godot_classes/dcl_ui_background.rs
@@ -23,6 +23,7 @@ pub struct DclUiBackground {
 
     waiting_hash: GString,
     texture_loaded: bool,
+    first_texture_load_shot: bool,
 }
 
 #[godot_api]
@@ -33,6 +34,7 @@ impl INode for DclUiBackground {
             current_value: PbUiBackground::default(),
             waiting_hash: GString::default(),
             texture_loaded: false,
+            first_texture_load_shot: false,
         }
     }
 
@@ -100,7 +102,11 @@ impl DclUiBackground {
             .bind_mut()
             .get_texture_from_hash(self.waiting_hash.clone())
         else {
-            tracing::error!("trying to set texture not found: {}", self.waiting_hash);
+            if self.first_texture_load_shot {
+                self.first_texture_load_shot = false;
+            } else {
+                tracing::error!("trying to set texture not found: {}", self.waiting_hash);
+            }
             return;
         };
         self.texture_loaded = true;
@@ -232,6 +238,7 @@ impl DclUiBackground {
                             );
                         }
 
+                        self.first_texture_load_shot = true;
                         self.base.call_deferred("_on_texture_loaded".into(), &[]);
                     }
                     DclSourceTex::VideoTexture(_) => {

--- a/rust/decentraland-godot-lib/src/scene_runner/components/ui/scene_ui.rs
+++ b/rust/decentraland-godot-lib/src/scene_runner/components/ui/scene_ui.rs
@@ -255,6 +255,12 @@ pub fn update_scene_ui(
         && dirty_lww_components
             .get(&SceneComponentId::UI_TEXT)
             .is_none()
+        && dirty_lww_components
+            .get(&SceneComponentId::UI_DROPDOWN)
+            .is_none()
+        && dirty_lww_components
+            .get(&SceneComponentId::UI_INPUT)
+            .is_none()
         && !need_update_ui_canvas;
 
     if need_update_ui_canvas {


### PR DESCRIPTION
# What?
Avoid duplicating to load the same resource more than once, with `ContentNotificator` applied to the downloads all the shared dependencies awaits the first request.
Use `tokio::fs` instead of `godot::FileAccess` (crashing when multiple file handlers in the same file)

- feat: add content notification to hold futures of downloads 
- fix: move to std::fs/tokio::fs instead of godot FileAccess

## Minor
- fix: now it waits until promises are resolved before take snapshot
- fix: tooltip when action=any
- chore: move PackedByteArray conversion from Vec to a bytes module  
- fix: race condition when `getUserData` is called after `onStart` but it's not resolved by the `async` engine
- chore: remove nop()
- mock ~system/CommunicationsController::sendBinary
- fix: remove error message when texture loading failed at first time (before ensuring is fetched)
- use tokio::fs to wrtie files 