### PR TITLE
fix: tween was not working when the entity didn't have a `TransformCo…

### DIFF
--- a/rust/decentraland-godot-lib/src/scene_runner/components/tween.rs
+++ b/rust/decentraland-godot-lib/src/scene_runner/components/tween.rs
@@ -6,6 +6,7 @@ use crate::{
             proto_components::sdk::components::{
                 pb_tween::Mode, EasingFunction, PbTween, PbTweenState, TweenStateStatus,
             },
+            transform_and_parent::DclTransformAndParent,
             SceneComponentId,
         },
         crdt::{
@@ -196,15 +197,11 @@ pub fn update_tween(scene: &mut Scene, crdt_state: &mut SceneCrdtState) {
         }
 
         // get entity transform from crdt state
-        let transform = crdt_state.get_transform_mut().get(entity);
-
-        let Some(transform) = transform else {
-            continue;
-        };
-
-        let Some(mut transform) = transform.value.clone() else {
-            continue;
-        };
+        let mut transform: DclTransformAndParent = crdt_state
+            .get_transform_mut()
+            .get(entity)
+            .and_then(|transform| transform.value.clone())
+            .unwrap_or_else(DclTransformAndParent::default);
 
         // calculate new transform with the tween
         let ease_value = (tween.ease_fn)(progress);

--- a/rust/decentraland-godot-lib/src/scene_runner/components/tween.rs
+++ b/rust/decentraland-godot-lib/src/scene_runner/components/tween.rs
@@ -201,7 +201,7 @@ pub fn update_tween(scene: &mut Scene, crdt_state: &mut SceneCrdtState) {
             .get_transform_mut()
             .get(entity)
             .and_then(|transform| transform.value.clone())
-            .unwrap_or_else(DclTransformAndParent::default);
+            .unwrap_or_default();
 
         // calculate new transform with the tween
         let ease_value = (tween.ease_fn)(progress);


### PR DESCRIPTION
…mponent`

Fix https://github.com/decentraland/godot-explorer/issues/167

Now, when the Entity doesn't have a `Transform` Component but has a' Tween, ' the `Tween` adds the `TransformComponent` for you.