### PR TITLE
feat: hide loading screen on double click on the header

### DIFF
--- a/godot/src/ui/components/loading_screen/loading_screen.gd
+++ b/godot/src/ui/components/loading_screen/loading_screen.gd
@@ -16,6 +16,8 @@ var progress: float = 0.0
 var last_progress_change := Time.get_ticks_msec()
 var popup_warning_pos_y: int = 0
 
+var last_hide_click := 0.0
+
 @onready var loading_progress = %ColorRect_LoadingProgress
 @onready var loading_progress_label = %Label_LoadingProgress
 
@@ -163,3 +165,13 @@ func _on_loading_screen_progress_logic_loading_show_requested():
 	last_progress_change = Time.get_ticks_msec()
 	popup_warning.hide()
 	timer_check_progress_timeout.start()
+
+
+# For dev purposes
+func _on_color_rect_header_gui_input(event):
+	if event is InputEventScreenTouch:
+		if event.pressed:
+			var elapsed_time = Time.get_ticks_msec() - last_hide_click
+			if elapsed_time <= 500:
+				self.hide()
+			last_hide_click = Time.get_ticks_msec()

--- a/godot/src/ui/components/loading_screen/loading_screen.tscn
+++ b/godot/src/ui/components/loading_screen/loading_screen.tscn
@@ -299,6 +299,7 @@ layout_mode = 2
 theme_type_variation = &"GrayButton"
 text = "RUN ANYWAY"
 
+[connection signal="gui_input" from="VBox_Loading/VBox_Header/ColorRect_Header" to="." method="_on_color_rect_header_gui_input"]
 [connection signal="gui_input" from="VBox_Loading/ColorRect_Background/Control_Discover/VBoxContainer/HBoxContainer_Content/Control_Left/TextureRect_LeftArrow" to="." method="_on_texture_rect_left_arrow_gui_input"]
 [connection signal="gui_input" from="VBox_Loading/ColorRect_Background/Control_Discover/VBoxContainer/HBoxContainer_Content/Control_Right/TextureRect_RightArrow" to="." method="_on_texture_rect_right_arrow_gui_input"]
 [connection signal="timeout" from="Timer_AutoMoveCarousel" to="." method="_on_timer_auto_move_carousel_timeout"]


### PR DESCRIPTION
For dev purposes, hide the loading screen on double click on the header