### PR TITLE
feat: implement spawn points and fixes

### DIFF
--- a/godot/src/decentraland_components/gltf_container.gd
+++ b/godot/src/decentraland_components/gltf_container.gd
@@ -27,6 +27,7 @@ func async_load_gltf():
 	var promise = Global.content_provider.fetch_gltf(dcl_gltf_src, content_mapping)
 	if promise == null:
 		printerr("Fatal error on fetch gltf: promise == null")
+		dcl_gltf_loading_state = GltfContainerLoadingState.FINISHED_WITH_ERROR
 		return
 
 	if not promise.is_resolved():
@@ -35,6 +36,7 @@ func async_load_gltf():
 	var res = promise.get_data()
 	if res is PromiseError:
 		printerr("Error on fetch gltf: ", res.get_error())
+		dcl_gltf_loading_state = GltfContainerLoadingState.FINISHED_WITH_ERROR
 		return
 
 	var instance_promise: Promise = Global.content_provider.instance_gltf_colliders(
@@ -43,6 +45,7 @@ func async_load_gltf():
 	var res_instance = await PromiseUtils.async_awaiter(instance_promise)
 	if res_instance is PromiseError:
 		printerr("Error on fetch gltf: ", res_instance.get_error())
+		dcl_gltf_loading_state = GltfContainerLoadingState.FINISHED_WITH_ERROR
 		return
 
 	dcl_pending_node = res_instance

--- a/godot/src/global.gd
+++ b/godot/src/global.gd
@@ -1,6 +1,7 @@
 extends DclGlobal
 
 signal config_changed
+signal loading_finished
 
 enum CameraMode {
 	FIRST_PERSON = 0,

--- a/godot/src/ui/components/loading_screen/loading_screen.gd
+++ b/godot/src/ui/components/loading_screen/loading_screen.gd
@@ -47,6 +47,7 @@ func enable_loading_screen():
 
 
 func async_hide_loading_screen_effect():
+	Global.loading_finished.emit()
 	timer_check_progress_timeout.stop()
 	var tween = get_tree().create_tween()
 	background.use_parent_material = true  # disable material

--- a/godot/src/ui/components/loading_screen/loading_screen.tscn
+++ b/godot/src/ui/components/loading_screen/loading_screen.tscn
@@ -269,10 +269,13 @@ stretch_mode = 5
 
 [node name="Label" type="Label" parent="PopupWarning/MarginContainer/HBoxContainer/VBoxContainer/HBoxContainer_Title"]
 layout_mode = 2
+theme_override_colors/font_color = Color(1, 1, 1, 1)
+theme_override_font_sizes/font_size = 18
 text = "A Little Longer Than Expected..."
 
 [node name="Label2" type="Label" parent="PopupWarning/MarginContainer/HBoxContainer/VBoxContainer"]
 layout_mode = 2
+theme_override_colors/font_color = Color(1, 1, 1, 1)
 theme_override_font_sizes/font_size = 12
 text = "You can try to reload the experience or run it as it is."
 

--- a/godot/src/ui/components/pointer_tooltip/tooltip_label.gd
+++ b/godot/src/ui/components/pointer_tooltip/tooltip_label.gd
@@ -81,6 +81,9 @@ func set_action_text(text: String):
 
 
 func _physics_process(_delta):
+	if action_to_trigger == "ia_any":
+		return
+
 	var new_pressed = Input.is_action_pressed(action_to_trigger)
 	if last_state_pressed != new_pressed:
 		set_bg_color(BG_COLOR_PRESSED if new_pressed else BG_COLOR_NORMAL)

--- a/godot/src/ui/explorer.gd
+++ b/godot/src/ui/explorer.gd
@@ -58,6 +58,7 @@ func get_params_from_cmd():
 	var location_vector = null
 	var realm_in_place := args.find("--realm")
 	var location_in_place := args.find("--location")
+	var preview_mode := args.has("--preview")
 
 	if realm_in_place != -1 and args.size() > realm_in_place + 1:
 		realm_string = args[realm_in_place + 1]
@@ -69,7 +70,7 @@ func get_params_from_cmd():
 			location_vector = Vector2i(int(location_vector[0]), int(location_vector[1]))
 		else:
 			location_vector = null
-	return [realm_string, location_vector]
+	return [realm_string, location_vector, preview_mode]
 
 
 func _ready():
@@ -77,6 +78,9 @@ func _ready():
 	var cmd_params = get_params_from_cmd()
 	var cmd_realm = Global.FORCE_TEST_REALM if Global.FORCE_TEST else cmd_params[0]
 	var cmd_location = cmd_params[1]
+
+	if cmd_params[2]:
+		_on_control_menu_request_debug_panel(true)
 
 	virtual_joystick.mouse_filter = Control.MOUSE_FILTER_IGNORE
 	virtual_joystick_orig_position = virtual_joystick.get_position()

--- a/rust/decentraland-godot-lib/src/content/content_provider.rs
+++ b/rust/decentraland-godot-lib/src/content/content_provider.rs
@@ -57,7 +57,7 @@ impl INode for ContentProvider {
         ));
         Self {
             content_folder,
-            http_queue_requester: Arc::new(HttpQueueRequester::new(4)),
+            http_queue_requester: Arc::new(HttpQueueRequester::new(6)),
             cached: HashMap::new(),
             content_notificator: Arc::new(ContentNotificator::new()),
             godot_single_thread: Arc::new(Semaphore::new(1)),

--- a/rust/decentraland-godot-lib/src/godot_classes/dcl_scene_node.rs
+++ b/rust/decentraland-godot-lib/src/godot_classes/dcl_scene_node.rs
@@ -10,6 +10,10 @@ pub struct DclSceneNode {
 
     pub last_tick_number: i32,
 
+    // two properties to track the loading progress of the gltf
+    pub max_gltf_loaded_count: i32,
+    pub gltf_loading_count: i32,
+
     #[base]
     _base: Base<Node3D>,
 }
@@ -27,6 +31,8 @@ impl DclSceneNode {
                 scene_id,
                 is_global,
                 last_tick_number: -1,
+                max_gltf_loaded_count: 0,
+                gltf_loading_count: 0,
             }
         });
         obj.set_name(GString::from(format!("scene_id_{:?}", scene_id.clone())));
@@ -46,5 +52,13 @@ impl DclSceneNode {
     #[func]
     fn get_last_tick_number(&self) -> i32 {
         self.last_tick_number
+    }
+
+    #[func]
+    fn get_gltf_loading_progress(&self) -> f32 {
+        if self.max_gltf_loaded_count == 0 {
+            return 1.0;
+        }
+        1.0 - (self.gltf_loading_count as f32 / self.max_gltf_loaded_count as f32)
     }
 }

--- a/rust/decentraland-godot-lib/src/scene_runner/update_scene.rs
+++ b/rust/decentraland-godot-lib/src/scene_runner/update_scene.rs
@@ -93,8 +93,14 @@ pub fn _process_scene(
 
                 // fix: if the scene is loading, we need to wait until it finishes before spawn the next tick
                 // tick 0 => onStart() => tick=1 => first onUpdate() => tick=2 => second onUpdate() => tick= 3
-                if tick_number < 3 && !scene.gltf_loading.is_empty() {
+                if tick_number <= 3 && !scene.gltf_loading.is_empty() {
                     sync_gltf_loading_state(scene, crdt_state, ref_time, end_time_us);
+
+                    let mut scene_node = scene.godot_dcl_scene.root_node_3d.bind_mut();
+                    scene_node.gltf_loading_count = scene.gltf_loading.len() as i32;
+                    scene_node.max_gltf_loaded_count = scene_node
+                        .gltf_loading_count
+                        .max(scene_node.max_gltf_loaded_count);
                     return false;
                 }
 


### PR DESCRIPTION
Fix #186 
It was required: https://github.com/decentraland/sdk7-adaption-layer/commit/f3a47d74562366427d014162831923d13ad71839

# What?
- feat: add more loading steps in functions of gltf loaded
- chore: `--preview` cmd arg enables the debug panel
- chore: increase parallel downloads from 4 to 6
- fix: include `tick_number=3` in the pending loading state
- fix: gltf_loading gets stuck when failing
- fix: loading timeout popup colors
- fix: false-positive when only empty parcels is detected
- fix: trying to get input state of `any`