### PR TITLE
fix: jump in background smoothing now is full screen and the teleport…

### DIFF
--- a/godot/src/ui/components/discover/discover.tscn
+++ b/godot/src/ui/components/discover/discover.tscn
@@ -198,10 +198,11 @@ layout_mode = 2
 theme_override_constants/separation = 128
 theme_override_styles/separator = SubResource("StyleBoxEmpty_w46h5")
 
-[node name="JumpIn" parent="TextureRect" instance=ExtResource("9_gh6mh")]
+[node name="CanvasLayer" type="CanvasLayer" parent="."]
+
+[node name="JumpIn" parent="CanvasLayer" instance=ExtResource("9_gh6mh")]
 unique_name_in_owner = true
 visible = false
-layout_mode = 1
 
 [connection signal="visibility_changed" from="." to="." method="_on_visibility_changed"]
-[connection signal="jump_in" from="TextureRect/JumpIn" to="." method="_on_jump_in_jump_in"]
+[connection signal="jump_in" from="CanvasLayer/JumpIn" to="." method="_on_jump_in_jump_in"]

--- a/godot/src/ui/components/discover/jump_in/jump_in.tscn
+++ b/godot/src/ui/components/discover/jump_in/jump_in.tscn
@@ -73,7 +73,6 @@ offset_right = 310.0
 offset_bottom = 250.0
 grow_horizontal = 2
 grow_vertical = 2
-mouse_filter = 1
 theme_override_styles/panel = SubResource("StyleBoxFlat_dsiqj")
 
 [node name="VBoxContainer" type="VBoxContainer" parent="JumpIn"]


### PR DESCRIPTION
… panel don't close on click on the panel itself

Fix https://github.com/decentraland/godot-explorer/issues/240
And now the Jump In Popup is full screen on the Menu