### PR TITLE
feat: implement `send` and `sendBinary` over comms

### DIFF
--- a/rust/decentraland-godot-lib/src/comms/adapter/adapter_trait.rs
+++ b/rust/decentraland-godot-lib/src/comms/adapter/adapter_trait.rs
@@ -7,6 +7,7 @@ pub trait Adapter {
     fn clean(&mut self);
 
     fn consume_chats(&mut self) -> Vec<(H160, rfc4::Chat)>;
+    fn consume_scene_messages(&mut self, scene_id: &str) -> Vec<(H160, Vec<u8>)>;
     fn change_profile(&mut self, new_profile: UserProfile);
 
     fn send_rfc4(&mut self, packet: rfc4::Packet, unreliable: bool) -> bool;

--- a/rust/decentraland-godot-lib/src/dcl/js/comms.rs
+++ b/rust/decentraland-godot-lib/src/dcl/js/comms.rs
@@ -1,0 +1,106 @@
+use std::{cell::RefCell, rc::Rc};
+
+use deno_core::{op, JsBuffer, Op, OpDecl, OpState};
+use ethers::types::H160;
+
+use crate::dcl::scene_apis::RpcCall;
+
+#[derive(Default)]
+pub(crate) struct InternalPendingBinaryMessages {
+    pub messages: Vec<(H160, Vec<u8>)>,
+}
+
+// list of op declarations
+pub fn ops() -> Vec<OpDecl> {
+    vec![op_comms_send_string::DECL, op_comms_send_binary::DECL]
+}
+
+pub(crate) const COMMS_MSG_TYPE_STRING: u8 = 1;
+pub(crate) const COMMS_MSG_TYPE_BINARY: u8 = 2;
+
+#[op]
+async fn op_comms_send_string(
+    state: Rc<RefCell<OpState>>,
+    message: String,
+) -> Result<(), anyhow::Error> {
+    let mut message = message.into_bytes();
+    message.insert(0, COMMS_MSG_TYPE_STRING);
+    comms_send(state, vec![message]).await?;
+    Ok(())
+}
+
+#[op]
+async fn op_comms_send_binary(
+    state: Rc<RefCell<OpState>>,
+    messages: Vec<JsBuffer>,
+) -> Result<Vec<Vec<u8>>, anyhow::Error> {
+    let messages = messages
+        .iter()
+        .map(|m| {
+            let mut m = m.as_ref().to_vec();
+            m.insert(0, COMMS_MSG_TYPE_BINARY);
+            m
+        })
+        .collect();
+
+    comms_send(state.clone(), messages).await?;
+
+    // Get pending Binary messages
+    if let Some(pending_messages) = state
+        .borrow_mut()
+        .try_take::<InternalPendingBinaryMessages>()
+    {
+        // TODO: remove comms message type
+        // Ok(pending_messages.messages)
+        let messages = pending_messages
+            .messages
+            .into_iter()
+            .map(|(sender_address, mut data)| {
+                let sender_address_str = format!("{:#x}", sender_address);
+                let sender_address_str_bytes = sender_address_str.as_bytes();
+
+                // Remove the comms message type(-1 byte), add the sender address size (+1 byte)
+                //  and add the address in bytes (for H160=20 to string 2+40)
+                let sender_len = sender_address_str_bytes.len();
+                let original_data_len = data.len();
+                let new_data_size = original_data_len + 1 + sender_len - 1;
+
+                // Resize to fit the sender address
+                data.resize(new_data_size, 0);
+
+                // Shift the data to the right to fit the sender address
+                data.copy_within(1..original_data_len, sender_len + 1);
+
+                // Add the sender address size at the beginning of the data
+                data[0] = sender_len as u8;
+
+                // Add the sender address at the beginning of the data
+                data[1..=sender_len].copy_from_slice(sender_address_str_bytes);
+
+                data
+            })
+            .collect();
+        Ok(messages)
+    } else {
+        Ok(vec![])
+    }
+}
+
+async fn comms_send(
+    state: Rc<RefCell<OpState>>,
+    message: Vec<Vec<u8>>,
+) -> Result<(), anyhow::Error> {
+    let (sx, rx) = tokio::sync::oneshot::channel::<Result<(), String>>();
+
+    state
+        .borrow_mut()
+        .borrow_mut::<Vec<RpcCall>>()
+        .push(RpcCall::SendCommsMessage {
+            body: message,
+            response: sx.into(),
+        });
+
+    rx.await
+        .map_err(|e| anyhow::anyhow!(e))?
+        .map_err(anyhow::Error::msg)
+}

--- a/rust/decentraland-godot-lib/src/dcl/js/comms.rs
+++ b/rust/decentraland-godot-lib/src/dcl/js/comms.rs
@@ -50,8 +50,6 @@ async fn op_comms_send_binary(
         .borrow_mut()
         .try_take::<InternalPendingBinaryMessages>()
     {
-        // TODO: remove comms message type
-        // Ok(pending_messages.messages)
         let messages = pending_messages
             .messages
             .into_iter()

--- a/rust/decentraland-godot-lib/src/dcl/js/js_modules/CommunicationsController.js
+++ b/rust/decentraland-godot-lib/src/dcl/js/js_modules/CommunicationsController.js
@@ -1,2 +1,11 @@
-module.exports.send = async function (body) { return {} }
-module.exports.sendBinary = async function (body) { return { data: [] } }
+module.exports.send = async function (body) {
+    await Deno.core.ops.op_comms_send_string(body.message);
+    return {}
+}
+
+module.exports.sendBinary = async function (body) {
+    const data = (await Deno.core.ops.op_comms_send_binary([...body.data])).map((item) => new Uint8Array(item));
+    return {
+        data
+    }
+}

--- a/rust/decentraland-godot-lib/src/dcl/js/mod.rs
+++ b/rust/decentraland-godot-lib/src/dcl/js/mod.rs
@@ -1,13 +1,14 @@
-pub mod engine;
-pub mod ethereum_controller;
-pub mod events;
-pub mod fetch;
-pub mod players;
-pub mod portables;
-pub mod restricted_actions;
-pub mod runtime;
-pub mod testing;
-pub mod websocket;
+mod comms;
+mod engine;
+mod ethereum_controller;
+mod events;
+mod fetch;
+mod players;
+mod portables;
+mod restricted_actions;
+mod runtime;
+mod testing;
+mod websocket;
 
 use crate::auth::ephemeral_auth_chain::EphemeralAuthChain;
 use crate::auth::ethereum_provider::EthereumProvider;
@@ -49,7 +50,7 @@ pub fn create_runtime() -> deno_core::JsRuntime {
     // add core ops
     ext = ext.ops(vec![op_require::DECL, op_log::DECL, op_error::DECL]);
 
-    let op_sets: [Vec<deno_core::OpDecl>; 10] = [
+    let op_sets: [Vec<deno_core::OpDecl>; 11] = [
         engine::ops(),
         runtime::ops(),
         fetch::ops(),
@@ -60,6 +61,7 @@ pub fn create_runtime() -> deno_core::JsRuntime {
         events::ops(),
         testing::ops(),
         ethereum_controller::ops(),
+        comms::ops(),
     ];
 
     let mut op_map = HashMap::new();
@@ -130,13 +132,13 @@ pub(crate) fn scene_thread(
 
             let dirty = scene_crdt_state.take_dirty();
             thread_sender_to_main
-                .send(SceneResponse::Ok(
+                .send(SceneResponse::Ok {
                     scene_id,
-                    dirty,
-                    Vec::new(),
-                    0.0,
-                    Vec::new(),
-                ))
+                    dirty_crdt_state: dirty,
+                    logs: Vec::new(),
+                    delta: 0.0,
+                    rpc_calls: Vec::new(),
+                })
                 .expect("error sending scene response!!");
 
             scene_main_crdt = Some(buf);

--- a/rust/decentraland-godot-lib/src/dcl/mod.rs
+++ b/rust/decentraland-godot-lib/src/dcl/mod.rs
@@ -6,6 +6,7 @@ pub mod js;
 pub mod scene_apis;
 pub mod serialization;
 
+use ethers::types::H160;
 use godot::builtin::{Vector2, Vector3};
 
 use crate::{
@@ -40,7 +41,10 @@ impl SceneId {
 // data from renderer to scene
 #[derive(Debug)]
 pub enum RendererResponse {
-    Ok(DirtyCrdtState),
+    Ok {
+        dirty_crdt_state: Box<DirtyCrdtState>,
+        incoming_comms_message: Vec<(H160, Vec<u8>)>,
+    },
     Kill,
 }
 
@@ -48,13 +52,13 @@ pub enum RendererResponse {
 #[derive(Debug)]
 pub enum SceneResponse {
     Error(SceneId, String),
-    Ok(
-        SceneId,
-        DirtyCrdtState,
-        Vec<SceneLogMessage>,
-        f32,
-        Vec<RpcCall>,
-    ),
+    Ok {
+        scene_id: SceneId,
+        dirty_crdt_state: DirtyCrdtState,
+        logs: Vec<SceneLogMessage>,
+        delta: f32,
+        rpc_calls: Vec<RpcCall>,
+    },
     RemoveGodotScene(SceneId, Vec<SceneLogMessage>),
     TakeSnapshot {
         scene_id: SceneId,

--- a/rust/decentraland-godot-lib/src/dcl/scene_apis.rs
+++ b/rust/decentraland-godot-lib/src/dcl/scene_apis.rs
@@ -168,6 +168,10 @@ pub enum RpcCall {
         body: RPCSendableMessage,
         response: RpcResultSender<Result<serde_json::Value, String>>,
     },
+    SendCommsMessage {
+        body: Vec<Vec<u8>>,
+        response: RpcResultSender<Result<(), String>>,
+    },
 }
 
 #[derive(Debug)]

--- a/rust/decentraland-godot-lib/src/scene_runner/rpc_calls/mod.rs
+++ b/rust/decentraland-godot-lib/src/scene_runner/rpc_calls/mod.rs
@@ -97,6 +97,15 @@ pub fn process_rpcs(scene: &mut Scene, current_parcel_scene_id: &SceneId, rpc_ca
                     .bind()
                     .send_async(body, response);
             }
+            RpcCall::SendCommsMessage { body, response } => {
+                let scene_id = scene.scene_entity_definition.id.clone();
+                let mut comms = DclGlobal::singleton().bind().get_comms();
+                let mut communication_manager = comms.bind_mut();
+                for data in body {
+                    communication_manager.send_scene_message(scene_id.clone(), data);
+                }
+                response.send(Ok(()));
+            }
         }
     }
 }

--- a/rust/decentraland-godot-lib/src/scene_runner/scene_manager.rs
+++ b/rust/decentraland-godot-lib/src/scene_runner/scene_manager.rs
@@ -490,7 +490,13 @@ impl SceneManager {
                         arguments.push(GString::from(&msg).to_variant());
                         self.console.callv(arguments);
                     }
-                    SceneResponse::Ok(scene_id, dirty_crdt_state, logs, _, rpc_calls) => {
+                    SceneResponse::Ok {
+                        scene_id,
+                        dirty_crdt_state,
+                        logs,
+                        rpc_calls,
+                        delta: _,
+                    } => {
                         if let Some(scene) = self.scenes.get_mut(&scene_id) {
                             let dirty = Dirty {
                                 waiting_process: true,

--- a/rust/decentraland-godot-lib/src/scene_runner/update_scene.rs
+++ b/rust/decentraland-godot-lib/src/scene_runner/update_scene.rs
@@ -333,9 +333,18 @@ pub fn _process_scene(
                     pointer_events_result_component.append(entity, value);
                 }
 
+                let incoming_comms_message = DclGlobal::singleton()
+                    .bind_mut()
+                    .comms
+                    .bind_mut()
+                    .get_pending_messages(&scene.scene_entity_definition.id);
+
                 // Set renderer response to the scene
-                let dirty = crdt_state.take_dirty();
-                scene.current_dirty.renderer_response = Some(RendererResponse::Ok(dirty));
+                let dirty_crdt_state = crdt_state.take_dirty();
+                scene.current_dirty.renderer_response = Some(RendererResponse::Ok {
+                    dirty_crdt_state: Box::new(dirty_crdt_state),
+                    incoming_comms_message,
+                });
                 false
             }
             SceneUpdateState::ProcessRpcs => {


### PR DESCRIPTION
Fix #264 
- Implement `send` and `sendBinary`
- Also add `sceneStart` observable emit

## How to test?
1 Open the godot client and a second client (it might be the Foundation client)
2. Use `/changerealm https://leanmendoza.github.io/mannakia-dcl-scene/mannakia-dcl-scene` in both and wait until it's fully connected
3. After some seconds you have to see al the counter > 0 (in both clients)
![imagen](https://github.com/decentraland/godot-explorer/assets/8042536/36c0727d-e589-47a0-8b42-c5173c1b5540)
