### PR TITLE
fix: comms sender blocks the javascript runtime

### DIFF
--- a/godot/src/decentraland_components/avatar/avatar_emote_controller.gd
+++ b/godot/src/decentraland_components/avatar/avatar_emote_controller.gd
@@ -88,8 +88,10 @@ func _init(_avatar: Avatar, _animation_player: AnimationPlayer, _animation_tree:
 
 	# Idle Anim Duplication (so it makes mutable and non-shared-reference)
 	var idle_animation_library = animation_player.get_animation_library("idle")
-	idle_animation_library = idle_animation_library.duplicate(true)
-	idle_anim = idle_animation_library.get_animation("Anim")
+	idle_animation_library = idle_animation_library.duplicate(false)
+	idle_anim = idle_animation_library.get_animation("Anim").duplicate()
+	idle_animation_library.remove_animation("Anim")
+	idle_animation_library.add_animation("Anim", idle_anim)
 	animation_player.remove_animation_library("idle")
 	animation_player.add_animation_library("idle", idle_animation_library)
 

--- a/godot/src/logic/scene_fetcher.gd
+++ b/godot/src/logic/scene_fetcher.gd
@@ -359,7 +359,7 @@ func _on_try_spawn_scene(
 		return false
 
 	var scene_number_id: int = Global.scene_runner.start_scene(
-		local_main_js_path, local_main_crdt_path, scene_item.scene_entity_definition
+		local_main_js_path, local_main_crdt_path, scene_item.scene_entity_definition, false
 	)
 	scene_item.scene_number_id = scene_number_id
 

--- a/rust/decentraland-godot-lib/Cargo.toml
+++ b/rust/decentraland-godot-lib/Cargo.toml
@@ -39,6 +39,9 @@ log-panics = { version = "2", features = ["with-backtrace"]}
 
 v8 = { version = "0.74.3", optional = true }
 deno_core = { version = "0.197", optional = true }
+uuid = { version = "1.3.0", features = ["v4"], optional = true }
+fastwebsockets = { version = "0.3.1", features = ["upgrade"], optional = true }
+hyper1 = { package = "hyper", version = "0.14.26", features = ["server","runtime", "http1"], optional = true }
 num-traits = "0.2"
 num-derive = "0.3"
 num = "0.4"
@@ -74,6 +77,7 @@ default = ["use_ffmpeg", "use_livekit", "use_deno"]
 use_ffmpeg = ["dep:ffmpeg-next", "dep:cpal"]
 use_livekit = ["use_ffmpeg", "dep:livekit"]
 use_deno = ["dep:deno_core", "dep:v8"]
+enable_inspector = ["use_deno", "dep:uuid", "dep:fastwebsockets", "dep:hyper1"]
 
 [build-dependencies]
 webrtc-sys-build = "0.2.0"

--- a/rust/decentraland-godot-lib/src/avatars/item.rs
+++ b/rust/decentraland-godot-lib/src/avatars/item.rs
@@ -294,7 +294,6 @@ impl DclItemEntityDefinition {
         let Some(item) = value else {
             return false;
         };
-        tracing::info!("is_valid_wearable: {:?}", item.bind().inner.id);
         let internal_check = item
             .bind()
             ._is_valid_wearable(body_shape_id.as_str(), skip_content_integrity);

--- a/rust/decentraland-godot-lib/src/comms/adapter/livekit.rs
+++ b/rust/decentraland-godot-lib/src/comms/adapter/livekit.rs
@@ -424,7 +424,6 @@ fn spawn_livekit_task(
         'stream: loop {
             tokio::select!(
                 incoming = network_rx.recv() => {
-                    tracing::debug!("in: {:?}", incoming);
                     let Some(incoming) = incoming else {
                         tracing::debug!("network pipe broken, exiting loop");
                         break 'stream;
@@ -444,7 +443,6 @@ fn spawn_livekit_task(
                                     tracing::warn!("received empty packet body");
                                     continue;
                                 };
-                                tracing::warn!("received packet {message:?} from {address}");
                                 if let Err(e) = sender.send(IncomingMessage {
                                     message: ToSceneMessage::Rfc4(message),
                                     address,

--- a/rust/decentraland-godot-lib/src/dcl/common/mod.rs
+++ b/rust/decentraland-godot-lib/src/dcl/common/mod.rs
@@ -9,7 +9,6 @@ pub mod scene;
 pub mod string;
 pub mod wearable;
 
-pub struct SceneJsFileContent(pub String);
 pub struct SceneMainCrdtFileContent(pub Vec<u8>);
 
 pub struct SceneStartTime(pub std::time::SystemTime);

--- a/rust/decentraland-godot-lib/src/dcl/js/comms.rs
+++ b/rust/decentraland-godot-lib/src/dcl/js/comms.rs
@@ -88,17 +88,10 @@ async fn comms_send(
     state: Rc<RefCell<OpState>>,
     message: Vec<Vec<u8>>,
 ) -> Result<(), anyhow::Error> {
-    let (sx, rx) = tokio::sync::oneshot::channel::<Result<(), String>>();
-
     state
         .borrow_mut()
         .borrow_mut::<Vec<RpcCall>>()
-        .push(RpcCall::SendCommsMessage {
-            body: message,
-            response: sx.into(),
-        });
+        .push(RpcCall::SendCommsMessage { body: message });
 
-    rx.await
-        .map_err(|e| anyhow::anyhow!(e))?
-        .map_err(anyhow::Error::msg)
+    Ok(())
 }

--- a/rust/decentraland-godot-lib/src/dcl/js/events.rs
+++ b/rust/decentraland-godot-lib/src/dcl/js/events.rs
@@ -283,14 +283,14 @@ pub fn process_events(
         .collect::<Vec<_>>();
 
     if !messages.is_empty() {
-        if let Some(player_clicked_sender) = op_state.try_take::<EventSender<MessageBus>>() {
+        if let Some(message_bus_sender) = op_state.try_take::<EventSender<MessageBus>>() {
             messages.into_iter().for_each(|message| {
-                player_clicked_sender
+                message_bus_sender
                     .inner
                     .send(serde_json::to_string(&message).unwrap())
                     .unwrap();
             });
-            op_state.put(player_clicked_sender);
+            op_state.put(message_bus_sender);
         }
     }
 

--- a/rust/decentraland-godot-lib/src/dcl/js/inspector.rs
+++ b/rust/decentraland-godot-lib/src/dcl/js/inspector.rs
@@ -1,0 +1,425 @@
+// Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
+
+// Alias for the future `!` type.
+use core::convert::Infallible as Never;
+use deno_core::futures::channel::mpsc;
+use deno_core::futures::channel::mpsc::UnboundedReceiver;
+use deno_core::futures::channel::mpsc::UnboundedSender;
+use deno_core::futures::channel::oneshot;
+use deno_core::futures::future;
+use deno_core::futures::future::Future;
+use deno_core::futures::prelude::*;
+use deno_core::futures::select;
+use deno_core::futures::stream::StreamExt;
+use deno_core::futures::task::Poll;
+use deno_core::serde_json;
+use deno_core::serde_json::json;
+use deno_core::serde_json::Value;
+use deno_core::task::spawn;
+use deno_core::InspectorMsg;
+use deno_core::InspectorSessionProxy;
+use deno_core::JsRuntime;
+use fastwebsockets::Frame;
+use fastwebsockets::OpCode;
+use fastwebsockets::WebSocket;
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::convert::Infallible;
+use std::net::SocketAddr;
+use std::pin::pin;
+use std::process;
+use std::rc::Rc;
+use std::thread;
+use uuid::Uuid;
+
+/// Websocket server that is used to proxy connections from
+/// devtools to the inspector.
+pub struct InspectorServer {
+    pub host: SocketAddr,
+    register_inspector_tx: UnboundedSender<InspectorInfo>,
+    shutdown_server_tx: Option<oneshot::Sender<()>>,
+    thread_handle: Option<thread::JoinHandle<()>>,
+}
+
+fn create_basic_runtime() -> tokio::runtime::Runtime {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_io()
+        .enable_time()
+        .max_blocking_threads(32)
+        .build()
+        .unwrap()
+}
+
+impl InspectorServer {
+    pub fn new(host: SocketAddr, name: &'static str) -> Self {
+        let (register_inspector_tx, register_inspector_rx) = mpsc::unbounded::<InspectorInfo>();
+
+        let (shutdown_server_tx, shutdown_server_rx) = oneshot::channel();
+
+        let thread_handle = thread::spawn(move || {
+            let rt = create_basic_runtime();
+            let local = tokio::task::LocalSet::new();
+            local.block_on(
+                &rt,
+                server(host, register_inspector_rx, shutdown_server_rx, name),
+            )
+        });
+
+        Self {
+            host,
+            register_inspector_tx,
+            shutdown_server_tx: Some(shutdown_server_tx),
+            thread_handle: Some(thread_handle),
+        }
+    }
+
+    pub fn register_inspector(
+        &self,
+        module_url: String,
+        js_runtime: &mut JsRuntime,
+        wait_for_session: bool,
+    ) {
+        let inspector_rc = js_runtime.inspector();
+        let mut inspector = inspector_rc.borrow_mut();
+        let session_sender = inspector.get_session_sender();
+        let deregister_rx = inspector.add_deregister_handler();
+        let info = InspectorInfo::new(
+            self.host,
+            session_sender,
+            deregister_rx,
+            module_url,
+            wait_for_session,
+        );
+        self.register_inspector_tx.unbounded_send(info).unwrap();
+    }
+}
+
+impl Drop for InspectorServer {
+    fn drop(&mut self) {
+        if let Some(shutdown_server_tx) = self.shutdown_server_tx.take() {
+            shutdown_server_tx
+                .send(())
+                .expect("unable to send shutdown signal");
+        }
+
+        if let Some(thread_handle) = self.thread_handle.take() {
+            thread_handle.join().expect("unable to join thread");
+        }
+    }
+}
+
+// Needed so hyper can use non Send futures
+#[derive(Clone)]
+struct LocalExecutor;
+
+impl<Fut> hyper1::rt::Executor<Fut> for LocalExecutor
+where
+    Fut: Future + 'static,
+    Fut::Output: 'static,
+{
+    fn execute(&self, fut: Fut) {
+        deno_core::task::spawn(fut);
+    }
+}
+
+fn handle_ws_request(
+    req: http::Request<hyper1::Body>,
+    inspector_map_rc: Rc<RefCell<HashMap<Uuid, InspectorInfo>>>,
+) -> http::Result<http::Response<hyper1::Body>> {
+    let (parts, body) = req.into_parts();
+    let req = http::Request::from_parts(parts, ());
+
+    let maybe_uuid = req
+        .uri()
+        .path()
+        .strip_prefix("/ws/")
+        .and_then(|s| Uuid::parse_str(s).ok());
+
+    if maybe_uuid.is_none() {
+        return http::Response::builder()
+            .status(http::StatusCode::BAD_REQUEST)
+            .body("Malformed inspector UUID".into());
+    }
+
+    // run in a block to not hold borrow to `inspector_map` for too long
+    let new_session_tx = {
+        let inspector_map = inspector_map_rc.borrow();
+        let maybe_inspector_info = inspector_map.get(&maybe_uuid.unwrap());
+
+        if maybe_inspector_info.is_none() {
+            return http::Response::builder()
+                .status(http::StatusCode::NOT_FOUND)
+                .body("Invalid inspector UUID".into());
+        }
+
+        let info = maybe_inspector_info.unwrap();
+        info.new_session_tx.clone()
+    };
+    let (parts, _) = req.into_parts();
+    let mut req = http::Request::from_parts(parts, body);
+
+    let (resp, fut) = match fastwebsockets::upgrade::upgrade(&mut req) {
+        Ok(e) => e,
+        _ => {
+            return http::Response::builder()
+                .status(http::StatusCode::BAD_REQUEST)
+                .body("Not a valid Websocket Request".into());
+        }
+    };
+
+    // spawn a task that will wait for websocket connection and then pump messages between
+    // the socket and inspector proxy
+    spawn(async move {
+        let websocket = if let Ok(w) = fut.await {
+            w
+        } else {
+            eprintln!("Inspector server failed to upgrade to WS connection");
+            return;
+        };
+
+        // The 'outbound' channel carries messages sent to the websocket.
+        let (outbound_tx, outbound_rx) = mpsc::unbounded();
+        // The 'inbound' channel carries messages received from the websocket.
+        let (inbound_tx, inbound_rx) = mpsc::unbounded();
+
+        let inspector_session_proxy = InspectorSessionProxy {
+            tx: outbound_tx,
+            rx: inbound_rx,
+        };
+
+        eprintln!("Debugger session started.");
+        let _ = new_session_tx.unbounded_send(inspector_session_proxy);
+        pump_websocket_messages(websocket, inbound_tx, outbound_rx).await;
+    });
+
+    Ok(resp)
+}
+
+fn handle_json_request(
+    inspector_map: Rc<RefCell<HashMap<Uuid, InspectorInfo>>>,
+) -> http::Result<http::Response<hyper1::Body>> {
+    let data = inspector_map
+        .borrow()
+        .values()
+        .map(|info| info.get_json_metadata())
+        .collect::<Vec<_>>();
+    http::Response::builder()
+        .status(http::StatusCode::OK)
+        .header(http::header::CONTENT_TYPE, "application/json")
+        .body(serde_json::to_string(&data).unwrap().into())
+}
+
+fn handle_json_version_request(
+    version_response: Value,
+) -> http::Result<http::Response<hyper1::Body>> {
+    http::Response::builder()
+        .status(http::StatusCode::OK)
+        .header(http::header::CONTENT_TYPE, "application/json")
+        .body(serde_json::to_string(&version_response).unwrap().into())
+}
+
+async fn server(
+    host: SocketAddr,
+    register_inspector_rx: UnboundedReceiver<InspectorInfo>,
+    shutdown_server_rx: oneshot::Receiver<()>,
+    name: &str,
+) {
+    let inspector_map_ = Rc::new(RefCell::new(HashMap::<Uuid, InspectorInfo>::new()));
+
+    let inspector_map = Rc::clone(&inspector_map_);
+    let mut register_inspector_handler = pin!(register_inspector_rx
+        .map(|info| {
+            eprintln!(
+                "Debugger listening on {}",
+                info.get_websocket_debugger_url()
+            );
+            eprintln!("Visit chrome://inspect to connect to the debugger.");
+            if info.wait_for_session {
+                eprintln!("Deno is waiting for debugger to connect.");
+            }
+            if inspector_map.borrow_mut().insert(info.uuid, info).is_some() {
+                panic!("Inspector UUID already in map");
+            }
+        })
+        .collect::<()>());
+
+    let inspector_map = Rc::clone(&inspector_map_);
+    let mut deregister_inspector_handler = pin!(future::poll_fn(|cx| {
+        inspector_map
+            .borrow_mut()
+            .retain(|_, info| info.deregister_rx.poll_unpin(cx) == Poll::Pending);
+        Poll::<Never>::Pending
+    })
+    .fuse());
+
+    let json_version_response = json!({
+      "Browser": name,
+      "Protocol-Version": "1.3",
+      "V8-Version": deno_core::v8_version(),
+    });
+
+    let make_svc = hyper1::service::make_service_fn(|_| {
+        let inspector_map = Rc::clone(&inspector_map_);
+        let json_version_response = json_version_response.clone();
+
+        future::ok::<_, Infallible>(hyper1::service::service_fn(
+            move |req: http::Request<hyper1::Body>| {
+                future::ready({
+                    match (req.method(), req.uri().path()) {
+                        (&http::Method::GET, path) if path.starts_with("/ws/") => {
+                            handle_ws_request(req, Rc::clone(&inspector_map))
+                        }
+                        (&http::Method::GET, "/json/version") => {
+                            handle_json_version_request(json_version_response.clone())
+                        }
+                        (&http::Method::GET, "/json") => {
+                            handle_json_request(Rc::clone(&inspector_map))
+                        }
+                        (&http::Method::GET, "/json/list") => {
+                            handle_json_request(Rc::clone(&inspector_map))
+                        }
+                        _ => http::Response::builder()
+                            .status(http::StatusCode::NOT_FOUND)
+                            .body("Not Found".into()),
+                    }
+                })
+            },
+        ))
+    });
+
+    // Create the server manually so it can use the Local Executor
+    let mut server_handler = pin!(hyper1::server::Builder::new(
+        hyper1::server::conn::AddrIncoming::bind(&host).unwrap_or_else(|e| {
+            eprintln!("Cannot start inspector server: {e}.");
+            process::exit(1);
+        }),
+        hyper1::server::conn::Http::new().with_executor(LocalExecutor),
+    )
+    .serve(make_svc)
+    .with_graceful_shutdown(async {
+        shutdown_server_rx.await.ok();
+    })
+    .unwrap_or_else(|err| {
+        eprintln!("Cannot start inspector server: {err}.");
+        process::exit(1);
+    })
+    .fuse());
+
+    select! {
+      _ = register_inspector_handler => {},
+      _ = deregister_inspector_handler => unreachable!(),
+      _ = server_handler => {},
+    }
+}
+
+/// The pump future takes care of forwarding messages between the websocket
+/// and channels. It resolves when either side disconnects, ignoring any
+/// errors.
+///
+/// The future proxies messages sent and received on a warp WebSocket
+/// to a UnboundedSender/UnboundedReceiver pair. We need these "unbounded" channel ends to sidestep
+/// Tokio's task budget, which causes issues when JsRuntimeInspector::poll_sessions()
+/// needs to block the thread because JavaScript execution is paused.
+///
+/// This works because UnboundedSender/UnboundedReceiver are implemented in the
+/// 'futures' crate, therefore they can't participate in Tokio's cooperative
+/// task yielding.
+async fn pump_websocket_messages(
+    mut websocket: WebSocket<hyper1::upgrade::Upgraded>,
+    inbound_tx: UnboundedSender<String>,
+    mut outbound_rx: UnboundedReceiver<InspectorMsg>,
+) {
+    'pump: loop {
+        tokio::select! {
+            Some(msg) = outbound_rx.next() => {
+                let msg = Frame::text(msg.content.into_bytes());
+                let _ = websocket.write_frame(msg).await;
+            }
+            Ok(msg) = websocket.read_frame() => {
+                match msg.opcode {
+                    OpCode::Text => {
+                        if let Ok(s) = String::from_utf8(msg.payload) {
+                          let _ = inbound_tx.unbounded_send(s);
+                        }
+                    }
+                    OpCode::Close => {
+                        // Users don't care if there was an error coming from debugger,
+                        // just about the fact that debugger did disconnect.
+                        eprintln!("Debugger session ended");
+                        break 'pump;
+                    }
+                    _ => {
+                        // Ignore other messages.
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Inspector information that is sent from the isolate thread to the server
+/// thread when a new inspector is created.
+pub struct InspectorInfo {
+    pub host: SocketAddr,
+    pub uuid: Uuid,
+    pub thread_name: Option<String>,
+    pub new_session_tx: UnboundedSender<InspectorSessionProxy>,
+    pub deregister_rx: oneshot::Receiver<()>,
+    pub url: String,
+    pub wait_for_session: bool,
+}
+
+impl InspectorInfo {
+    pub fn new(
+        host: SocketAddr,
+        new_session_tx: mpsc::UnboundedSender<InspectorSessionProxy>,
+        deregister_rx: oneshot::Receiver<()>,
+        url: String,
+        wait_for_session: bool,
+    ) -> Self {
+        Self {
+            host,
+            uuid: Uuid::new_v4(),
+            thread_name: thread::current().name().map(|n| n.to_owned()),
+            new_session_tx,
+            deregister_rx,
+            url,
+            wait_for_session,
+        }
+    }
+
+    fn get_json_metadata(&self) -> Value {
+        json!({
+          "description": "deno",
+          "devtoolsFrontendUrl": self.get_frontend_url(),
+          "faviconUrl": "https://deno.land/favicon.ico",
+          "id": self.uuid.to_string(),
+          "title": self.get_title(),
+          "type": "node",
+          "url": self.url.to_string(),
+          "webSocketDebuggerUrl": self.get_websocket_debugger_url(),
+        })
+    }
+
+    pub fn get_websocket_debugger_url(&self) -> String {
+        format!("ws://{}/ws/{}", &self.host, &self.uuid)
+    }
+
+    fn get_frontend_url(&self) -> String {
+        format!(
+            "devtools://devtools/bundled/js_app.html?ws={}/ws/{}&experiments=true&v8only=true",
+            &self.host, &self.uuid
+        )
+    }
+
+    fn get_title(&self) -> String {
+        format!(
+            "deno{} [pid: {}]",
+            self.thread_name
+                .as_ref()
+                .map(|n| format!(" - {n}"))
+                .unwrap_or_default(),
+            process::id(),
+        )
+    }
+}

--- a/rust/decentraland-godot-lib/src/dcl/mod.rs
+++ b/rust/decentraland-godot-lib/src/dcl/mod.rs
@@ -101,7 +101,7 @@ pub struct SpawnDclSceneData {
     pub local_main_crdt_file_path: String,
     // Content mapping and URL reference
     pub content_mapping: ContentMappingAndUrlRef,
-    // Sender to send messages to the main thread
+    // Sender to send messages to the main thread (renderer)
     pub thread_sender_to_main: std::sync::mpsc::SyncSender<SceneResponse>,
     // Whether the scene is in testing mode
     pub testing_mode: bool,
@@ -111,6 +111,8 @@ pub struct SpawnDclSceneData {
     pub ephemeral_wallet: Option<EphemeralAuthChain>,
     // Realm Data
     pub realm_info: DclSceneRealmData,
+    // Inspect
+    pub inspect: bool,
 }
 
 impl DclScene {

--- a/rust/decentraland-godot-lib/src/dcl/scene_apis.rs
+++ b/rust/decentraland-godot-lib/src/dcl/scene_apis.rs
@@ -156,7 +156,6 @@ pub enum RpcCall {
     },
     SendCommsMessage {
         body: Vec<Vec<u8>>,
-        response: RpcResultSender<Result<(), String>>,
     },
 }
 

--- a/rust/decentraland-godot-lib/src/scene_runner/components/ui/scene_ui.rs
+++ b/rust/decentraland-godot-lib/src/scene_runner/components/ui/scene_ui.rs
@@ -190,6 +190,27 @@ pub fn update_scene_ui(
         true
     };
 
+    let need_update_ui_canvas = {
+        let ui_canvas_information_component =
+            SceneCrdtStateProtoComponents::get_ui_canvas_information(crdt_state);
+        if let Some(entry) = ui_canvas_information_component.get(&SceneEntityId::ROOT) {
+            if let Some(current_value) = entry.value.as_ref() {
+                current_value != ui_canvas_information
+            } else {
+                true
+            }
+        } else {
+            true
+        }
+    };
+
+    if need_update_ui_canvas {
+        let ui_canvas_information_component =
+            SceneCrdtStateProtoComponents::get_ui_canvas_information_mut(crdt_state);
+        ui_canvas_information_component
+            .put(SceneEntityId::ROOT, Some(ui_canvas_information.clone()));
+    }
+
     if !ui_is_visible {
         for component_id in UI_COMPONENT_IDS {
             if let Some(dirty) = scene.current_dirty.lww_components.get(&component_id) {
@@ -226,19 +247,6 @@ pub fn update_scene_ui(
     }
 
     let dirty_lww_components = &scene.current_dirty.lww_components;
-    let need_update_ui_canvas = {
-        let ui_canvas_information_component =
-            SceneCrdtStateProtoComponents::get_ui_canvas_information(crdt_state);
-        if let Some(entry) = ui_canvas_information_component.get(&SceneEntityId::ROOT) {
-            if let Some(current_value) = entry.value.as_ref() {
-                current_value != ui_canvas_information
-            } else {
-                true
-            }
-        } else {
-            true
-        }
-    };
     let need_skip: bool = dirty_lww_components
         .get(&SceneComponentId::UI_TRANSFORM)
         .is_none()
@@ -255,13 +263,6 @@ pub fn update_scene_ui(
             .get(&SceneComponentId::UI_INPUT)
             .is_none()
         && !need_update_ui_canvas;
-
-    if need_update_ui_canvas {
-        let ui_canvas_information_component =
-            SceneCrdtStateProtoComponents::get_ui_canvas_information_mut(crdt_state);
-        ui_canvas_information_component
-            .put(SceneEntityId::ROOT, Some(ui_canvas_information.clone()));
-    }
 
     if need_skip {
         update_input_result(scene, crdt_state);

--- a/rust/decentraland-godot-lib/src/scene_runner/rpc_calls/mod.rs
+++ b/rust/decentraland-godot-lib/src/scene_runner/rpc_calls/mod.rs
@@ -93,14 +93,13 @@ pub fn process_rpcs(scene: &mut Scene, current_parcel_scene_id: &SceneId, rpc_ca
                     .bind()
                     .send_async(body, response);
             }
-            RpcCall::SendCommsMessage { body, response } => {
+            RpcCall::SendCommsMessage { body } => {
                 let scene_id = scene.scene_entity_definition.id.clone();
                 let mut comms = DclGlobal::singleton().bind().get_comms();
                 let mut communication_manager = comms.bind_mut();
                 for data in body {
                     communication_manager.send_scene_message(scene_id.clone(), data);
                 }
-                response.send(Ok(()));
             }
         }
     }

--- a/rust/decentraland-godot-lib/src/scene_runner/scene_manager.rs
+++ b/rust/decentraland-godot-lib/src/scene_runner/scene_manager.rs
@@ -113,6 +113,7 @@ impl SceneManager {
         local_main_js_file_path: GString,
         local_main_crdt_file_path: GString,
         dcl_scene_entity_definition: Gd<DclSceneEntityDefinition>,
+        inspect: bool,
     ) -> i32 {
         let scene_entity_definition = dcl_scene_entity_definition.bind().get_ref();
 
@@ -165,6 +166,7 @@ impl SceneManager {
                 comms_adapter,
                 is_preview,
             },
+            inspect,
         });
 
         let new_scene = Scene::new(


### PR DESCRIPTION
- fix: comms sender blocks the javascript runtime
- fix: ui_canvas_information is only sent when there is UI stuffs
- feat: add v8-inspector support (with feature `enable_inspector`, no default)
- feat: run scene-code without wrapping it with `require`
- fix: idle_anim is shared between avatars
- chore: remove some logs