### PR TITLE
fix: tween doesn't use the duration so it fallbacks to 0 and finishes immediately

### DIFF
--- a/godot/src/decentraland_components/audio_source.gd
+++ b/godot/src/decentraland_components/audio_source.gd
@@ -2,6 +2,7 @@ extends DclAudioSource
 
 var last_loaded_audio_clip := ""
 var valid := false
+var _time_specified := false
 
 
 func apply_audio_props(action_on_playing: bool):
@@ -9,6 +10,11 @@ func apply_audio_props(action_on_playing: bool):
 		return
 
 	self.pitch_scale = dcl_pitch
+
+	if dcl_global:
+		attenuation_model = AudioStreamPlayer3D.ATTENUATION_DISABLED
+	else:
+		attenuation_model = AudioStreamPlayer3D.ATTENUATION_INVERSE_DISTANCE
 
 	if not dcl_enable:
 		self.volume_db = -80
@@ -20,12 +26,13 @@ func apply_audio_props(action_on_playing: bool):
 	if action_on_playing:
 		if self.playing and not dcl_playing:
 			self.stop()
-		elif not self.playing and dcl_playing:
-			self.play()
+		elif dcl_playing and (not self.playing or _time_specified):
+			self.play(dcl_current_time)
 
 
-func _async_refresh_data():
+func _async_refresh_data(time_specified: bool):
 	dcl_audio_clip_url = dcl_audio_clip_url.to_lower()
+	_time_specified = time_specified
 
 	if last_loaded_audio_clip == dcl_audio_clip_url:
 		apply_audio_props(true)

--- a/godot/src/logic/scene_fetcher.gd
+++ b/godot/src/logic/scene_fetcher.gd
@@ -74,7 +74,7 @@ func get_current_spawn_point():
 func on_loading_finished():
 	var target_position = get_current_spawn_point()
 	if target_position != null:
-		Global.get_explorer().move_to(target_position)
+		Global.get_explorer().move_to(target_position, true)
 
 
 func on_scene_killed(killed_scene_id, _entity_id):

--- a/godot/src/ui/explorer.gd
+++ b/godot/src/ui/explorer.gd
@@ -363,17 +363,18 @@ func _on_control_menu_request_pause_scenes(enabled):
 	Global.scene_runner.set_pause(enabled)
 
 
-func move_to(position: Vector3):
+func move_to(position: Vector3, skip_loading: bool):
 	player.set_position(position)
 	var cur_parcel_position = Vector2(player.position.x * 0.0625, -player.position.z * 0.0625)
-	if not Global.scene_fetcher.is_scene_loaded(cur_parcel_position.x, cur_parcel_position.y):
-		loading_ui.enable_loading_screen()
+	if not skip_loading:
+		if not Global.scene_fetcher.is_scene_loaded(cur_parcel_position.x, cur_parcel_position.y):
+			loading_ui.enable_loading_screen()
 
 
 func teleport_to(parcel: Vector2i, realm: String = ""):
 	if realm != Global.realm.get_realm_string():
 		Global.realm.async_set_realm(realm)
-	move_to(Vector3i(parcel.x * 16, 3, -parcel.y * 16))
+	move_to(Vector3i(parcel.x * 16, 3, -parcel.y * 16), false)
 
 	Global.config.add_place_to_last_places(parcel, realm)
 	dirty_save_position = true

--- a/rust/decentraland-godot-lib/src/godot_classes/dcl_audio_source.rs
+++ b/rust/decentraland-godot-lib/src/godot_classes/dcl_audio_source.rs
@@ -28,6 +28,12 @@ pub struct DclAudioSource {
     dcl_audio_clip_url: GString,
 
     #[var]
+    dcl_current_time: f32,
+
+    #[var]
+    dcl_global: bool,
+
+    #[var]
     dcl_scene_id: i32,
 
     #[base]

--- a/rust/decentraland-godot-lib/src/scene_runner/components/audio_source.rs
+++ b/rust/decentraland-godot-lib/src/scene_runner/components/audio_source.rs
@@ -59,7 +59,10 @@ pub fn update_audio_source(
                     new_audio_source
                 };
 
-                audio_source.call_deferred("_async_refresh_data".into(), &[]);
+                audio_source.call_deferred(
+                    "_async_refresh_data".into(),
+                    &[new_value.current_time.is_some().to_variant()],
+                );
 
                 let mut audio_source = audio_source.bind_mut();
                 audio_source.set_dcl_audio_clip_url(GString::from(new_value.audio_clip_url));
@@ -67,6 +70,7 @@ pub fn update_audio_source(
                 audio_source.set_dcl_playing(new_value.playing.unwrap_or(false));
                 audio_source.set_dcl_pitch(new_value.pitch.unwrap_or(1.0));
                 audio_source.set_dcl_volume(new_value.volume.unwrap_or(1.0).clamp(0.0, 1.0));
+                audio_source.set_dcl_current_time(new_value.current_time.unwrap_or(0.0));
                 audio_source.set_dcl_scene_id(scene.scene_id.0);
 
                 let dcl_enable = if let SceneType::Parcel = scene.scene_type {

--- a/rust/decentraland-godot-lib/src/scene_runner/components/material.rs
+++ b/rust/decentraland-godot-lib/src/scene_runner/components/material.rs
@@ -111,7 +111,7 @@ pub fn update_material(scene: &mut Scene, crdt_state: &mut SceneCrdtState) {
                     godot_material
                 };
 
-                godot_material.set_transparency(Transparency::TRANSPARENCY_ALPHA);
+                godot_material.set_transparency(Transparency::TRANSPARENCY_ALPHA_DEPTH_PRE_PASS);
 
                 match &dcl_material {
                     DclMaterial::Unlit(unlit) => {

--- a/rust/decentraland-godot-lib/src/scene_runner/components/tween.rs
+++ b/rust/decentraland-godot-lib/src/scene_runner/components/tween.rs
@@ -24,13 +24,12 @@ pub struct Tween {
     pub ease_fn: fn(f32) -> f32,
     pub start_time: std::time::Instant,
     pub paused_time: Option<std::time::Instant>,
-    pub duration: Duration,
     pub playing: Option<bool>,
 }
 
 impl Tween {
     fn get_progress(&self, elapsed_time: Duration) -> f32 {
-        elapsed_time.as_millis() as f32 / self.duration.as_millis() as f32 // 0 to 1...
+        elapsed_time.as_millis() as f32 / self.data.duration // 0 to 1...
     }
 }
 
@@ -98,7 +97,6 @@ pub fn update_tween(scene: &mut Scene, crdt_state: &mut SceneCrdtState) {
             } else if let Some(new_value) = new_value {
                 let offset_time_ms = new_value.duration * new_value.current_time();
                 let offset_time = std::time::Duration::from_millis(offset_time_ms as u64);
-                let duration = std::time::Duration::from_millis(new_value.duration as u64);
 
                 if let Some(existing_tween) = existing {
                     // update tween
@@ -144,7 +142,6 @@ pub fn update_tween(scene: &mut Scene, crdt_state: &mut SceneCrdtState) {
                             data: new_value,
                             start_time: now - offset_time,
                             paused_time,
-                            duration,
                             playing: None,
                         },
                     );
@@ -168,8 +165,9 @@ pub fn update_tween(scene: &mut Scene, crdt_state: &mut SceneCrdtState) {
         let mut current_tween_state: TweenStateStatus = TweenStateStatus::TsActive;
 
         let elapsed_time = now - tween.start_time;
+        let duration = std::time::Duration::from_millis(tween.data.duration as u64);
 
-        let progress = if elapsed_time >= tween.duration {
+        let progress = if elapsed_time >= duration {
             tween.playing = Some(false);
             current_tween_state = TweenStateStatus::TsCompleted;
             1.0 // finished

--- a/rust/decentraland-godot-lib/src/scene_runner/rpc_calls/handle_restricted_actions.rs
+++ b/rust/decentraland-godot-lib/src/scene_runner/rpc_calls/handle_restricted_actions.rs
@@ -211,7 +211,10 @@ pub fn move_player_to(
 
     // Set player position
     let position_target = Vector3::new(position_target.x, position_target.y, -position_target.z);
-    explorer_node.call("move_to".into(), &[Variant::from(position_target)]);
+    explorer_node.call(
+        "move_to".into(),
+        &[Variant::from(position_target), false.to_variant()],
+    );
 
     // Set camera to look at camera target position
     if let Some(camera_target) = camera_target {


### PR DESCRIPTION
this effect is evident in the switchable-platform scene, when you press the button and the platform goes instantaneously to the end
also:
- feat: update last audio source spec
- fix: some mesh renderer disappear because the depth-test (material)
- fix: with scene-radius==0 when changing parcel position, it shows the loading screen and call moveTo