### PR TITLE
fix: avatar rotating in x,z axis when walking

### DIFF
--- a/godot/src/logic/player/player.gd
+++ b/godot/src/logic/player/player.gd
@@ -153,6 +153,8 @@ func _physics_process(dt: float) -> void:
 			velocity.z = current_direction.z * jog_speed
 
 		avatar.look_at(current_direction.normalized() + position)
+		avatar.rotation.x = 0.0
+		avatar.rotation.z = 0.0
 	else:
 		avatar.walk = false
 		avatar.run = false


### PR DESCRIPTION
This fix an issue that the avatar was being rotated in x,z axis when you walk using a combination of FORWARD/BACKWARD + LEFT/RIGHT