### PR TITLE
fix: infinite loop when self-parenting

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:latest
+FROM ubuntu:22.04
 
 RUN apt-get update && apt-get upgrade -y
 

--- a/rust/decentraland-godot-lib/src/scene_runner/components/transform_and_parent.rs
+++ b/rust/decentraland-godot-lib/src/scene_runner/components/transform_and_parent.rs
@@ -194,6 +194,12 @@ fn detect_entity_id_in_parent_chain(
         if node.desired_parent_3d == search_entity {
             return true;
         }
+
+        // self-parenting?
+        if current_entity == node.desired_parent_3d {
+            return false;
+        }
+
         current_entity = node.desired_parent_3d;
     }
 


### PR DESCRIPTION
- Fix infinity loop finding an entity
- workaround: CI builds on 22.04, so the Dockerfile should be 22.04 

Future:
A. The ffmpeg should be included in the Dockerfile instead of installing the from `apt`.
B. Build it statically