### PR TITLE
feat: resource tracking and loading state ux

### DIFF
--- a/godot/.godot/global_script_class_cache.cfg
+++ b/godot/.godot/global_script_class_cache.cfg
@@ -240,6 +240,12 @@ list=Array[Dictionary]([{
 "path": "res://src/logic/realm.gd"
 }, {
 "base": &"RefCounted",
+"class": &"ResourceTrackerDebugger",
+"icon": "",
+"language": &"GDScript",
+"path": "res://addons/resource_tracker/resource_tracker_debugger.gd"
+}, {
+"base": &"RefCounted",
 "class": &"RustHttpRequesterWrapper",
 "icon": "",
 "language": &"GDScript",

--- a/godot/addons/resource_tracker/plugin.cfg
+++ b/godot/addons/resource_tracker/plugin.cfg
@@ -1,0 +1,6 @@
+[plugin]
+name="ResourceTrackerPlugin"
+description="A custom profiler for tracking custom resources."
+author="Kuruk"
+version="1.0"
+script="resource_tracker_plugin.gd"

--- a/godot/addons/resource_tracker/resource_tracker_debugger.gd
+++ b/godot/addons/resource_tracker/resource_tracker_debugger.gd
@@ -1,0 +1,37 @@
+class_name ResourceTrackerDebugger
+
+enum ResourceTrackerState {
+	STARTED = 0,
+	DOWNLOADING = 1,
+	DOWNLOADED = 2,
+	LOADING = 3,
+	FAILED = 4,
+	FINISHED = 5,
+}
+
+
+static func report_resource(
+	hash_id: String, state: ResourceTrackerState, progress: String, size: String, metadata: String
+):
+	EngineDebugger.send_message(
+		"resource_tracker:report", [hash_id, state, progress, size, metadata]
+	)
+	return true
+
+
+static func get_resource_state_string(state: ResourceTrackerState) -> String:
+	match state:
+		ResourceTrackerState.STARTED:
+			return "Started"
+		ResourceTrackerState.DOWNLOADING:
+			return "Downloading"
+		ResourceTrackerState.DOWNLOADED:
+			return "Downloaded"
+		ResourceTrackerState.LOADING:
+			return "Loading"
+		ResourceTrackerState.FAILED:
+			return "Failed"
+		ResourceTrackerState.FINISHED:
+			return "Finished"
+		_:
+			return "Unknown State"

--- a/godot/addons/resource_tracker/resource_tracker_panel.gd
+++ b/godot/addons/resource_tracker/resource_tracker_panel.gd
@@ -1,0 +1,132 @@
+@tool
+extends Control
+
+var resource_statuses = {}
+
+@onready var tree = %Tree
+@onready var option_box_filter = %OptionBox_Filter
+@onready var label_speed = %Label_Speed
+@onready var label_info = %LabelInfo
+
+
+func _ready():
+	# Initialize the Tree node
+	tree.create_item()  # Create a root item
+	tree.columns = 6
+	tree.set_column_title(0, "Hash ID")
+	tree.set_column_title(1, "State")
+	tree.set_column_title(2, "Progress")
+	tree.set_column_title(3, "Size")
+	tree.set_column_title(4, "Metadata")
+	tree.set_column_title(5, "Time")
+
+	# Cache for tree items
+	resource_statuses = {}
+
+	# Update the resource status regularly
+	set_process(true)
+
+
+func _process(_delta):
+	update_resource_status()
+
+
+func report_speed(speed: String):
+	label_info.hide()
+	label_speed.text = speed
+
+
+func report_resource(
+	hash_id: String,
+	state: ResourceTrackerDebugger.ResourceTrackerState,
+	progress: String,
+	size: String,
+	metadata: String
+):
+	# Check if the resource already exists in the cache
+	if resource_statuses.has(hash_id):
+		# Update existing resource
+		var resource = resource_statuses[hash_id]
+		if resource["state"] < state:  # only update the state when is greater
+			resource["state"] = state
+
+		if not progress.is_empty():
+			resource["progress"] = progress
+
+		if not size.is_empty():
+			resource["size"] = size
+
+		if not metadata.is_empty():
+			resource["metadata"] = metadata
+
+		var elapsed: float = float(Time.get_ticks_msec() - resource["start_tick"]) / 1000.0
+		resource["elapsed"] = snappedf(elapsed, 0.01)
+
+		resource_statuses[hash_id] = resource
+	else:
+		# Add new resource
+		resource_statuses[hash_id] = {
+			"hash_id": hash_id,
+			"state": state,
+			"progress": progress,
+			"size": size,
+			"metadata": metadata,
+			"start_tick": Time.get_ticks_msec(),
+			"elapsed": 0.0,
+			"item": null  # Placeholder for the TreeItem
+		}
+	# Update the UI after modifying the resource status
+	_update_ui()
+
+
+func update_resource_status():
+	# This can be used to periodically update the status if needed
+	pass
+
+
+func clear_cache():
+	resource_statuses.clear()
+	clear()
+
+
+func clear():
+	tree.clear()
+	tree.create_item()  # Create a root item
+
+
+func _update_ui():
+	var root = tree.get_root()
+	for hash_id in resource_statuses.keys():
+		var resource = resource_statuses[hash_id]
+		var item = null
+
+		if option_box_filter.get_selected_id() != 0:
+			if resource["state"] != (option_box_filter.get_selected_id() - 1):
+				if resource["item"] != null:
+					item = resource["item"]
+					item.free()
+					resource_statuses[hash_id]["item"] = null
+				continue
+
+		if resource["item"] != null:
+			item = resource["item"]
+		else:
+			item = tree.create_item(root, 0)
+			resource["item"] = item
+
+		item.set_text(0, hash_id)
+		item.set_text(1, ResourceTrackerDebugger.get_resource_state_string(resource["state"]))
+		item.set_text(2, resource["progress"])
+		item.set_text(3, resource["size"])
+		item.set_text(4, resource["metadata"])
+		item.set_text(5, str(resource["elapsed"]) + "segs")
+
+		resource_statuses[hash_id] = resource
+
+
+func _on_option_box_filter_item_selected(_index):
+	clear()
+	for hash_id in resource_statuses.keys():
+		resource_statuses[hash_id]["item"] = null
+
+	_update_ui()

--- a/godot/addons/resource_tracker/resource_tracker_panel.tscn
+++ b/godot/addons/resource_tracker/resource_tracker_panel.tscn
@@ -79,7 +79,7 @@ text = "0mb/s"
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_vertical = 3
-columns = 5
+columns = 6
 column_titles_visible = true
 hide_root = true
 

--- a/godot/addons/resource_tracker/resource_tracker_panel.tscn
+++ b/godot/addons/resource_tracker/resource_tracker_panel.tscn
@@ -1,0 +1,86 @@
+[gd_scene load_steps=3 format=3 uid="uid://brb47xgf4juex"]
+
+[ext_resource type="Script" path="res://addons/resource_tracker/resource_tracker_panel.gd" id="1_recoy"]
+
+[sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_u0lyc"]
+
+[node name="ResourceTrackerPanel" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1_recoy")
+
+[node name="VBoxContainer" type="VBoxContainer" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer"]
+layout_mode = 2
+
+[node name="Label" type="Label" parent="VBoxContainer/HBoxContainer"]
+layout_mode = 2
+text = "Resource Tracker"
+
+[node name="LabelInfo" type="Label" parent="VBoxContainer/HBoxContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+text = "(remember to compile with -t for enabling it)"
+
+[node name="HSeparator2" type="VSeparator" parent="VBoxContainer/HBoxContainer"]
+layout_mode = 2
+
+[node name="Label3" type="Label" parent="VBoxContainer/HBoxContainer"]
+layout_mode = 2
+text = "Filter by:
+"
+
+[node name="OptionBox_Filter" type="OptionButton" parent="VBoxContainer/HBoxContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+item_count = 7
+selected = 0
+popup/item_0/text = "None"
+popup/item_0/id = 0
+popup/item_1/text = "Started"
+popup/item_1/id = 1
+popup/item_2/text = "Downloading"
+popup/item_2/id = 2
+popup/item_3/text = "Downloaded"
+popup/item_3/id = 3
+popup/item_4/text = "Loading"
+popup/item_4/id = 4
+popup/item_5/text = "Failed"
+popup/item_5/id = 5
+popup/item_6/text = "Finished"
+popup/item_6/id = 6
+
+[node name="HSeparator" type="VSeparator" parent="VBoxContainer/HBoxContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+theme_override_styles/separator = SubResource("StyleBoxEmpty_u0lyc")
+
+[node name="Label2" type="Label" parent="VBoxContainer/HBoxContainer"]
+layout_mode = 2
+text = "Speed:"
+
+[node name="Label_Speed" type="Label" parent="VBoxContainer/HBoxContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+text = "0mb/s"
+
+[node name="Tree" type="Tree" parent="VBoxContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_vertical = 3
+columns = 5
+column_titles_visible = true
+hide_root = true
+
+[connection signal="item_selected" from="VBoxContainer/HBoxContainer/OptionBox_Filter" to="." method="_on_option_box_filter_item_selected"]

--- a/godot/addons/resource_tracker/resource_tracker_plugin.gd
+++ b/godot/addons/resource_tracker/resource_tracker_plugin.gd
@@ -1,0 +1,53 @@
+@tool
+extends EditorPlugin
+
+
+class ResourceTrackerDebuggerPlugin:
+	extends EditorDebuggerPlugin
+
+	var profiler_panel
+
+	func _has_capture(prefix):
+		# Return true if you wish to handle message with this prefix.
+		return prefix == "resource_tracker"
+
+	func _capture(message, data, _session_id):
+		if message == "resource_tracker:report":
+			var hash_id: String = data[0]
+			var state: ResourceTrackerDebugger.ResourceTrackerState = data[1]
+			var progress: String = data[2]
+			var size: String = data[3]
+			var metadata: String = data[4]
+
+			profiler_panel.report_resource(hash_id, state, progress, size, metadata)
+			return true
+		if message == "resource_tracker:report_speed":
+			profiler_panel.report_speed(data[0])
+			return true
+		return false
+
+	func _setup_session(session_id):
+		# Add a new tab in the debugger session UI containing a label.
+		# Load and instantiate the profiler panel
+		profiler_panel = (
+			preload("res://addons/resource_tracker/resource_tracker_panel.tscn").instantiate()
+		)
+		profiler_panel.name = "Resource Tracker"
+
+		var session = get_session(session_id)
+		# Listens to the session started and stopped signals.
+		session.started.connect(func(): print("Session started"))
+		session.started.connect(func(): profiler_panel.clear_cache())
+		session.stopped.connect(func(): print("Session stopped"))
+		session.add_session_tab(profiler_panel)
+
+
+var debugger = ResourceTrackerDebuggerPlugin.new()
+
+
+func _enter_tree():
+	add_debugger_plugin(debugger)
+
+
+func _exit_tree():
+	remove_debugger_plugin(debugger)

--- a/godot/project.godot
+++ b/godot/project.godot
@@ -40,6 +40,10 @@ window/size/viewport_height=720
 
 run/main_run_args="--clear-cache-startup"
 
+[editor_plugins]
+
+enabled=PackedStringArray("res://addons/resource_tracker/plugin.cfg")
+
 [filesystem]
 
 import/blender/enabled=false

--- a/godot/src/decentraland_components/avatar/avatar.tscn
+++ b/godot/src/decentraland_components/avatar/avatar.tscn
@@ -787,7 +787,7 @@ bones/61/rotation = Quaternion(-0.0187227, 0.0752644, -0.00259158, 0.996984)
 bones/61/scale = Vector3(1, 1, 1)
 
 [node name="BoneAttachment3D_Name" type="BoneAttachment3D" parent="Armature/Skeleton3D"]
-transform = Transform3D(1, 3.01981e-06, -2.17557e-06, 2.35438e-06, -0.0728586, 0.997342, 2.85544e-06, -0.997342, -0.0728585, -0.218824, -4.11655, -172.159)
+transform = Transform3D(1, 3.03891e-06, -2.27988e-06, 2.45869e-06, -0.0728592, 0.997342, 2.87499e-06, -0.997342, -0.0728593, -0.218822, -4.1166, -172.159)
 bone_name = "Avatar_Head"
 bone_idx = 61
 

--- a/godot/src/decentraland_components/avatar/avatar.tscn
+++ b/godot/src/decentraland_components/avatar/avatar.tscn
@@ -787,7 +787,7 @@ bones/61/rotation = Quaternion(-0.0187227, 0.0752644, -0.00259158, 0.996984)
 bones/61/scale = Vector3(1, 1, 1)
 
 [node name="BoneAttachment3D_Name" type="BoneAttachment3D" parent="Armature/Skeleton3D"]
-transform = Transform3D(1, 3.03891e-06, -2.27988e-06, 2.45869e-06, -0.0728592, 0.997342, 2.87499e-06, -0.997342, -0.0728593, -0.218822, -4.1166, -172.159)
+transform = Transform3D(1, 3.01981e-06, -2.17557e-06, 2.35438e-06, -0.0728586, 0.997342, 2.85544e-06, -0.997342, -0.0728585, -0.218824, -4.11655, -172.159)
 bone_name = "Avatar_Head"
 bone_idx = 61
 

--- a/godot/src/ui/components/loading_screen/loading_screen.gd
+++ b/godot/src/ui/components/loading_screen/loading_screen.gd
@@ -18,8 +18,11 @@ var popup_warning_pos_y: int = 0
 
 var last_hide_click := 0.0
 
+var loaded_resources_offset := 0
+
 @onready var loading_progress = %ColorRect_LoadingProgress
 @onready var loading_progress_label = %Label_LoadingProgress
+@onready var label_loading_state = %Label_LoadingState
 
 @onready
 var carousel = $VBox_Loading/ColorRect_Background/Control_Discover/VBoxContainer/HBoxContainer_Content/CarouselViewport/SubViewport/Carousel
@@ -131,6 +134,17 @@ func _on_timer_check_progress_timeout_timeout():
 		last_progress_change = Time.get_ticks_msec()
 		return
 
+	var loading_resources = (
+		Global.content_provider.count_loading_resources() - loaded_resources_offset
+	)
+	var loaded_resources = (
+		Global.content_provider.count_loaded_resources() - loaded_resources_offset
+	)
+	var download_speed_mbs: float = Global.content_provider.get_download_speed_mbs()
+	label_loading_state.text = (
+		"(%d/%d resources at %.2fmb/s)" % [loaded_resources, loading_resources, download_speed_mbs]
+	)
+
 	var inactive_seconds: int = int(floor((Time.get_ticks_msec() - last_progress_change) / 1000.0))
 	if inactive_seconds > 20:
 		var tween = get_tree().create_tween()
@@ -166,6 +180,7 @@ func _on_loading_screen_progress_logic_loading_show_requested():
 	last_progress_change = Time.get_ticks_msec()
 	popup_warning.hide()
 	timer_check_progress_timeout.start()
+	loaded_resources_offset = Global.content_provider.count_loaded_resources()
 
 
 # For dev purposes

--- a/godot/src/ui/components/loading_screen/loading_screen.tscn
+++ b/godot/src/ui/components/loading_screen/loading_screen.tscn
@@ -1,7 +1,8 @@
-[gd_scene load_steps=19 format=3 uid="uid://bmjwqm6jgri7c"]
+[gd_scene load_steps=20 format=3 uid="uid://bmjwqm6jgri7c"]
 
 [ext_resource type="Theme" uid="uid://bm1rvmngc833v" path="res://assets/themes/theme.tres" id="1_uio8w"]
 [ext_resource type="Script" path="res://src/ui/components/loading_screen/loading_screen.gd" id="2_7hdbk"]
+[ext_resource type="FontFile" uid="uid://drw8yv4w843s4" path="res://assets/themes/fonts/inter/Inter-SemiBold.ttf" id="4_fygee"]
 [ext_resource type="FontFile" uid="uid://hqi2efd5kd17" path="res://assets/themes/fonts/inter/Inter-Bold.ttf" id="4_uxxaw"]
 [ext_resource type="Texture2D" uid="uid://dpippmiepkyeb" path="res://decentraland_logo.png" id="4_w6anr"]
 [ext_resource type="Shader" path="res://src/ui/components/loading_screen/loading_screen.gdshader" id="6_u88hd"]
@@ -86,22 +87,40 @@ custom_minimum_size = Vector2(0, 80)
 layout_mode = 2
 color = Color(0.0862745, 0.0862745, 0.0862745, 1)
 
-[node name="Label_LoadingProgress" type="Label" parent="VBox_Loading/VBox_Header/ColorRect_Header"]
-unique_name_in_owner = true
+[node name="BoxContainer" type="VBoxContainer" parent="VBox_Loading/VBox_Header/ColorRect_Header"]
 layout_mode = 1
-anchors_preset = 1
+anchors_preset = 6
 anchor_left = 1.0
+anchor_top = 0.5
 anchor_right = 1.0
-offset_left = -97.0
-offset_top = 26.0
-offset_right = -34.0
-offset_bottom = 54.0
+anchor_bottom = 0.5
+offset_left = -413.0
+offset_top = -23.0
+offset_right = -20.0
+offset_bottom = 24.0
 grow_horizontal = 0
+grow_vertical = 2
+alignment = 1
+
+[node name="Label_LoadingProgress" type="Label" parent="VBox_Loading/VBox_Header/ColorRect_Header/BoxContainer"]
+unique_name_in_owner = true
+layout_mode = 2
 size_flags_vertical = 1
 theme_override_colors/font_color = Color(0.988235, 0.988235, 0.988235, 1)
 theme_override_fonts/font = ExtResource("4_uxxaw")
 theme_override_font_sizes/font_size = 18
 text = "LOADING 0%"
+horizontal_alignment = 2
+vertical_alignment = 1
+
+[node name="Label_LoadingState" type="Label" parent="VBox_Loading/VBox_Header/ColorRect_Header/BoxContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_vertical = 1
+theme_override_colors/font_color = Color(0.988235, 0.988235, 0.988235, 1)
+theme_override_fonts/font = ExtResource("4_fygee")
+theme_override_font_sizes/font_size = 16
+horizontal_alignment = 2
 vertical_alignment = 1
 
 [node name="VBoxContainer" type="VBoxContainer" parent="VBox_Loading/VBox_Header/ColorRect_Header"]
@@ -264,6 +283,7 @@ one_shot = true
 autostart = true
 
 [node name="Timer_CheckProgressTimeout" type="Timer" parent="."]
+wait_time = 0.5
 
 [node name="LoadingScreenProgressLogic" type="Node" parent="." node_paths=PackedStringArray("loading_screen")]
 script = ExtResource("10_xsh10")

--- a/godot/src/ui/components/loading_screen/loading_screen_progress_logic.gd
+++ b/godot/src/ui/components/loading_screen/loading_screen_progress_logic.gd
@@ -10,6 +10,7 @@ var waiting_for_scenes = false
 var wait_for: float = 0.0
 var empty_timeout: float = 0.0
 var pending_to_load: int = 0
+var loaded_resources_offset := 0
 
 
 func _ready():
@@ -41,6 +42,8 @@ func enable_loading_screen():
 	waiting_new_scene_load_report = true
 	loading_show_requested.emit()
 	wait_for = 1.0
+
+	loaded_resources_offset = Global.content_provider.count_loaded_resources()
 
 
 func hide_loading_screen():
@@ -89,7 +92,17 @@ func _physics_process(delta):
 					this_scene_progress = 1.0
 			scene_progress += this_scene_progress
 
-		var current_progress: int = int(scene_progress / float(scenes_loaded_count) * 80.0) + 20
+		var loading_resources = (
+			Global.content_provider.count_loading_resources() - loaded_resources_offset
+		)
+		var loaded_resources = (
+			Global.content_provider.count_loaded_resources() - loaded_resources_offset
+		)
+		var scene_loading_progress = scene_progress / float(scenes_loaded_count)
+		var loading_progress = float(loaded_resources) / float(loading_resources)
+		var current_progress: int = (
+			int(scene_loading_progress * 40.0) + int(loading_progress * 40.0) + 20
+		)
 		loading_screen.set_progress(current_progress)
 
 		if current_progress == 100:

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -79,6 +79,7 @@ default = ["use_ffmpeg", "use_livekit", "use_deno"]
 use_ffmpeg = ["dep:ffmpeg-next", "dep:cpal"]
 use_livekit = ["dep:livekit", "dep:webrtc-sys-build"]
 use_deno = ["dep:deno_core", "dep:v8"]
+use_resource_tracking = []
 enable_inspector = ["use_deno", "dep:fastwebsockets", "dep:hyper1"]
 
 [build-dependencies]

--- a/lib/src/content/content_provider.rs
+++ b/lib/src/content/content_provider.rs
@@ -1,6 +1,9 @@
 use std::{
     collections::{HashMap, HashSet},
-    sync::{atomic::{AtomicU64, Ordering}, Arc},
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc,
+    },
     time::{Duration, Instant},
 };
 
@@ -221,7 +224,7 @@ impl ContentProvider {
         TokioRuntime::spawn(async move {
             #[cfg(feature = "use_resource_tracking")]
             report_resource_start(&hash_id);
-            
+
             loading_resources.fetch_add(1, Ordering::Relaxed);
 
             let result =
@@ -421,7 +424,7 @@ impl ContentProvider {
             report_resource_start(&hash_id);
 
             loading_resources.fetch_add(1, Ordering::Relaxed);
-            
+
             let absolute_file_path = format!("{}{}", ctx.content_folder, hash_id);
 
             if ctx
@@ -457,8 +460,6 @@ impl ContentProvider {
 
         let bytes = bytes.to_vec();
 
-        let loading_resources = self.loading_resources.clone();
-        let loaded_resources = self.loaded_resources.clone();
         TokioRuntime::spawn(async move {
             if ctx
                 .resource_provider
@@ -588,7 +589,7 @@ impl ContentProvider {
         TokioRuntime::spawn(async move {
             #[cfg(feature = "use_resource_tracking")]
             report_resource_start(&hash_id);
-            
+
             loading_resources.fetch_add(1, Ordering::Relaxed);
 
             let result = load_image_texture(url, hash_id.clone(), content_provider_context).await;
@@ -828,7 +829,6 @@ impl ContentProvider {
                     new_promise = Some((promise, get_promise));
                 }
 
-                tracing::error!("wearable_id: {}", wearable_id);
                 self.cached.insert(
                     wearable_id,
                     ContentEntry {
@@ -936,17 +936,17 @@ impl ContentProvider {
     }
 
     #[func]
-    pub fn get_download_speed_mbs(&self) -> u64 {
+    pub fn get_download_speed_mbs(&self) -> f64 {
         self.download_speed_mbs
     }
 
     #[func]
-    pub fn count_downloaded_files(&self) -> u64 {
+    pub fn count_loaded_resources(&self) -> u64 {
         self.loaded_resources.load(Ordering::Relaxed)
     }
 
     #[func]
-    pub fn count_downloading_files(&self) -> u64 {
+    pub fn count_loading_resources(&self) -> u64 {
         self.loading_resources.load(Ordering::Relaxed)
     }
 

--- a/lib/src/content/content_provider.rs
+++ b/lib/src/content/content_provider.rs
@@ -631,6 +631,8 @@ impl ContentProvider {
 
         let loading_resources = self.loading_resources.clone();
         let loaded_resources = self.loaded_resources.clone();
+
+        #[cfg(feature = "use_resource_tracking")]
         let hash_id = file_hash.clone();
         TokioRuntime::spawn(async move {
             #[cfg(feature = "use_resource_tracking")]

--- a/lib/src/content/gltf.rs
+++ b/lib/src/content/gltf.rs
@@ -76,7 +76,6 @@ pub async fn internal_load_gltf(
     let futures = dependencies_hash
         .iter()
         .map(|(file_path, dependency_file_hash)| {
-            tracing::error!("file_path: {} {}", file_path, dependency_file_hash);
             let ctx = ctx.clone();
             let content_mapping = content_mapping.clone();
             async move {

--- a/lib/src/content/mod.rs
+++ b/lib/src/content/mod.rs
@@ -6,6 +6,8 @@ mod file_string;
 mod gltf;
 pub mod packed_array;
 mod profile;
+#[cfg(feature = "use_resource_tracking")]
+mod resource_download_tracking;
 mod resource_provider;
 pub mod semaphore_ext;
 mod texture;

--- a/lib/src/content/resource_download_tracking.rs
+++ b/lib/src/content/resource_download_tracking.rs
@@ -1,0 +1,110 @@
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use tokio::sync::RwLock;
+use tokio::time::Instant;
+
+pub struct DownloadState {
+    pub current_size: AtomicU64,
+    pub start_time: Instant,
+    pub done: bool,
+}
+
+impl DownloadState {
+    pub fn new() -> Self {
+        Self {
+            current_size: AtomicU64::new(0),
+            start_time: Instant::now(),
+            done: false,
+        }
+    }
+
+    pub fn update_progress(&self, current_size: u64) {
+        self.current_size.store(current_size, Ordering::SeqCst);
+    }
+
+    pub fn mark_done(&mut self) {
+        self.done = true;
+    }
+
+    pub fn get_speed(&self) -> f64 {
+        let elapsed = self.start_time.elapsed().as_secs_f64();
+        if elapsed > 0.0 {
+            self.current_size.load(Ordering::SeqCst) as f64 / elapsed
+        } else {
+            0.0
+        }
+    }
+}
+
+pub struct DownloadStateInfo {
+    pub current_size: u64,
+    pub speed: f64,
+    pub done: bool,
+}
+
+impl DownloadStateInfo {
+    pub fn from_download_state(state: &DownloadState) -> Self {
+        Self {
+            current_size: state.current_size.load(Ordering::SeqCst),
+            speed: state.get_speed(),
+            done: state.done,
+        }
+    }
+}
+
+pub struct ResourceDownloadTracking {
+    downloads: Arc<RwLock<HashMap<String, Arc<RwLock<DownloadState>>>>>,
+}
+
+impl ResourceDownloadTracking {
+    pub fn new() -> Self {
+        Self {
+            downloads: Arc::new(RwLock::new(HashMap::new())),
+        }
+    }
+
+    pub async fn start(&self, file_hash: String) {
+        let state = Arc::new(RwLock::new(DownloadState::new()));
+        let mut downloads = self.downloads.write().await;
+        downloads.insert(file_hash, state);
+    }
+
+    pub async fn report_progress(&self, file_hash: &str, current_size: u64) {
+        let downloads = self.downloads.read().await;
+        if let Some(state) = downloads.get(file_hash) {
+            let state = state.read().await;
+            state.update_progress(current_size);
+        }
+    }
+
+    pub async fn end(&self, file_hash: &str) {
+        let downloads = self.downloads.read().await;
+        if let Some(state) = downloads.get(file_hash) {
+            let mut state = state.write().await;
+            state.mark_done();
+        }
+    }
+
+    pub fn consume_downloads_state(&self) -> HashMap<String, DownloadStateInfo> {
+        let mut downloads = self.downloads.blocking_write();
+        let mut downloads_to_return = HashMap::new();
+
+        downloads.retain(|file_hash, state| {
+            let state_info = {
+                let state = state.blocking_read();
+                DownloadStateInfo::from_download_state(&state)
+            };
+
+            if state_info.done {
+                downloads_to_return.insert(file_hash.clone(), state_info);
+                false
+            } else {
+                downloads_to_return.insert(file_hash.clone(), state_info);
+                true
+            }
+        });
+
+        downloads_to_return
+    }
+}

--- a/lib/src/content/resource_provider.rs
+++ b/lib/src/content/resource_provider.rs
@@ -2,16 +2,18 @@ use futures_util::StreamExt;
 use reqwest::Client;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
-use std::sync::atomic::AtomicI64;
-use std::sync::{atomic::Ordering, Arc, Mutex};
+use std::sync::atomic::{AtomicI64, Ordering};
+use std::sync::Arc;
 use tokio::fs;
 use tokio::io::{self, AsyncReadExt, AsyncWriteExt};
 use tokio::sync::{Notify, OnceCell, RwLock, Semaphore};
 use tokio::time::Instant;
 
+#[cfg(feature = "use_resource_tracking")]
+use super::resource_download_tracking::ResourceDownloadTracking;
 use crate::content::semaphore_ext::SemaphoreExt;
 
-struct FileMetadata {
+pub struct FileMetadata {
     file_size: i64,
     last_accessed: Instant,
 }
@@ -20,23 +22,32 @@ pub struct ResourceProvider {
     cache_folder: PathBuf,
     existing_files: RwLock<HashMap<String, FileMetadata>>,
     max_cache_size: AtomicI64,
-    pending_downloads: Mutex<HashMap<String, Arc<Notify>>>,
+    pending_downloads: RwLock<HashMap<String, Arc<Notify>>>,
     client: Client,
     initialized: OnceCell<()>,
     semaphore: Arc<Semaphore>,
+    #[cfg(feature = "use_resource_tracking")]
+    download_tracking: Arc<ResourceDownloadTracking>,
 }
 
 impl ResourceProvider {
     // Synchronous constructor that sets up the ResourceProvider
-    pub fn new(cache_folder: &str, max_cache_size: i64, max_concurrent_downloads: usize) -> Self {
+    pub fn new(
+        cache_folder: &str,
+        max_cache_size: i64,
+        max_concurrent_downloads: usize,
+        #[cfg(feature = "use_resource_tracking")] download_tracking: Arc<ResourceDownloadTracking>,
+    ) -> Self {
         ResourceProvider {
             cache_folder: PathBuf::from(cache_folder),
             existing_files: RwLock::new(HashMap::new()),
             max_cache_size: AtomicI64::new(max_cache_size),
-            pending_downloads: Mutex::new(HashMap::new()),
+            pending_downloads: RwLock::new(HashMap::new()),
             client: Client::new(),
             initialized: OnceCell::new(),
             semaphore: Arc::new(Semaphore::new(max_concurrent_downloads)),
+            #[cfg(feature = "use_resource_tracking")]
+            download_tracking,
         }
     }
 
@@ -130,7 +141,12 @@ impl ResourceProvider {
         }
     }
 
-    async fn download_file(&self, url: &str, dest: &Path) -> Result<(), String> {
+    async fn download_file(
+        &self,
+        url: &str,
+        dest: &Path,
+        #[cfg(feature = "use_resource_tracking")] file_hash: &str,
+    ) -> Result<(), String> {
         let tmp_dest = dest.with_extension("tmp");
         let response = self
             .client
@@ -138,6 +154,13 @@ impl ResourceProvider {
             .send()
             .await
             .map_err(|e| format!("Request error: {:?}", e))?;
+
+        #[cfg(feature = "use_resource_tracking")]
+        self.download_tracking.start(file_hash.to_string()).await;
+
+        #[cfg(feature = "use_resource_tracking")]
+        let mut current_size = 0;
+
         let mut file = fs::File::create(&tmp_dest)
             .await
             .map_err(|e| format!("File creation error: {:?}", e))?;
@@ -148,16 +171,32 @@ impl ResourceProvider {
             file.write_all(&chunk)
                 .await
                 .map_err(|e| format!("File write error: {:?}", e))?;
+
+            #[cfg(feature = "use_resource_tracking")]
+            {
+                current_size += chunk.len() as u64;
+                self.download_tracking
+                    .report_progress(file_hash, current_size)
+                    .await;
+            }
         }
 
         fs::rename(&tmp_dest, dest)
             .await
             .map_err(|e| format!("Failed to rename file: {:?}", e))?;
 
+        #[cfg(feature = "use_resource_tracking")]
+        self.download_tracking.end(file_hash).await;
+
         Ok(())
     }
 
-    async fn download_file_with_buffer(&self, url: &str, dest: &Path) -> Result<Vec<u8>, String> {
+    async fn download_file_with_buffer(
+        &self,
+        url: &str,
+        dest: &Path,
+        #[cfg(feature = "use_resource_tracking")] file_hash: &str,
+    ) -> Result<Vec<u8>, String> {
         let tmp_dest = dest.with_extension("tmp");
         let response = self
             .client
@@ -165,6 +204,12 @@ impl ResourceProvider {
             .send()
             .await
             .map_err(|e| format!("Request error: {:?}", e))?;
+
+        #[cfg(feature = "use_resource_tracking")]
+        self.download_tracking.start(file_hash.to_string()).await;
+        #[cfg(feature = "use_resource_tracking")]
+        let mut current_size = 0;
+
         let mut file = fs::File::create(&tmp_dest)
             .await
             .map_err(|e| format!("File creation error: {:?}", e))?;
@@ -177,11 +222,22 @@ impl ResourceProvider {
                 .await
                 .map_err(|e| format!("File write error: {:?}", e))?;
             buffer.extend_from_slice(&chunk);
+
+            #[cfg(feature = "use_resource_tracking")]
+            {
+                current_size += chunk.len() as u64;
+                self.download_tracking
+                    .report_progress(file_hash, current_size)
+                    .await;
+            }
         }
 
         fs::rename(&tmp_dest, dest)
             .await
             .map_err(|e| format!("Failed to rename file: {:?}", e))?;
+
+        #[cfg(feature = "use_resource_tracking")]
+        self.download_tracking.end(file_hash).await;
 
         Ok(buffer)
     }
@@ -213,7 +269,7 @@ impl ResourceProvider {
         absolute_file_path: &String,
     ) -> Result<(), String> {
         let notify = {
-            let mut pending_downloads = self.pending_downloads.lock().unwrap();
+            let mut pending_downloads = self.pending_downloads.write().await;
             if let Some(notify) = pending_downloads.get(file_hash) {
                 Some(notify.clone())
             } else {
@@ -280,8 +336,13 @@ impl ResourceProvider {
         let permit = self.semaphore.acquire().await.unwrap();
 
         if tokio::fs::metadata(&absolute_file_path).await.is_err() {
-            self.download_file(url, Path::new(absolute_file_path))
-                .await?;
+            self.download_file(
+                url,
+                Path::new(absolute_file_path),
+                #[cfg(feature = "use_resource_tracking")]
+                file_hash,
+            )
+            .await?;
 
             let metadata = tokio::fs::metadata(absolute_file_path)
                 .await
@@ -296,7 +357,7 @@ impl ResourceProvider {
             self.handle_existing_file(absolute_file_path).await?;
         }
 
-        let mut pending_downloads = self.pending_downloads.lock().unwrap();
+        let mut pending_downloads = self.pending_downloads.write().await;
         if let Some(notify) = pending_downloads.remove(file_hash) {
             notify.notify_waiters();
         }
@@ -321,7 +382,12 @@ impl ResourceProvider {
         let permit = self.semaphore.acquire().await.unwrap();
         let data = if tokio::fs::metadata(&absolute_file_path).await.is_err() {
             let data = self
-                .download_file_with_buffer(url, Path::new(absolute_file_path))
+                .download_file_with_buffer(
+                    url,
+                    Path::new(absolute_file_path),
+                    #[cfg(feature = "use_resource_tracking")]
+                    file_hash,
+                )
                 .await?;
             let metadata = tokio::fs::metadata(absolute_file_path)
                 .await
@@ -336,7 +402,7 @@ impl ResourceProvider {
             self.handle_existing_file(absolute_file_path).await?
         };
 
-        let mut pending_downloads = self.pending_downloads.lock().unwrap();
+        let mut pending_downloads = self.pending_downloads.write().await;
         if let Some(notify) = pending_downloads.remove(file_hash) {
             notify.notify_waiters();
         }
@@ -398,7 +464,16 @@ mod tests {
             .await
             .expect("Failed to create cache folder");
 
-        let provider = Arc::new(ResourceProvider::new(path, max_cache_size, 2));
+        #[cfg(feature = "use_resource_tracking")]
+        let resource_download_tracking = Arc::new(ResourceDownloadTracking::new());
+
+        let provider = Arc::new(ResourceProvider::new(
+            path,
+            max_cache_size,
+            2,
+            #[cfg(feature = "use_resource_tracking")]
+            resource_download_tracking.clone(),
+        ));
         provider.clear().await;
 
         let files_to_download = vec![

--- a/lib/src/content/resource_provider.rs
+++ b/lib/src/content/resource_provider.rs
@@ -193,7 +193,7 @@ impl ResourceProvider {
             }
         }
 
-        if accumulated_size > UPDATE_THRESHOLD {
+        if accumulated_size > 0 {
             self.downloaded_size
                 .fetch_add(accumulated_size, Ordering::Relaxed);
             #[cfg(feature = "use_resource_tracking")]
@@ -264,7 +264,7 @@ impl ResourceProvider {
             }
         }
 
-        if accumulated_size > UPDATE_THRESHOLD {
+        if accumulated_size > 0 {
             self.downloaded_size
                 .fetch_add(accumulated_size, Ordering::Relaxed);
             #[cfg(feature = "use_resource_tracking")]

--- a/lib/src/content/video.rs
+++ b/lib/src/content/video.rs
@@ -12,5 +12,6 @@ pub async fn download_video(
         .fetch_resource(&url, &file_hash, &absolute_file_path)
         .await
         .map_err(anyhow::Error::msg)?;
+
     Ok(None)
 }

--- a/lib/src/dcl/js/adaptation_layer_helper.rs
+++ b/lib/src/dcl/js/adaptation_layer_helper.rs
@@ -1,8 +1,5 @@
 use crate::dcl::scene_apis::RpcCall;
-use deno_core::{
-    anyhow::{self, anyhow},
-    op, Op, OpDecl, OpState,
-};
+use deno_core::{anyhow::anyhow, op, Op, OpDecl, OpState};
 use serde::Serialize;
 use std::{cell::RefCell, rc::Rc};
 

--- a/lib/src/godot_classes/dcl_resource_tracker.rs
+++ b/lib/src/godot_classes/dcl_resource_tracker.rs
@@ -1,0 +1,73 @@
+use godot::{engine::EngineDebugger, prelude::*};
+
+#[repr(i32)]
+pub enum ResourceTrackerState {
+    Started = 0,
+    Downloading = 1,
+    Downloaded = 2,
+    Loading = 3,
+    Failed = 4,
+    Finished = 5,
+}
+
+fn send_resource_tracker_message(
+    state: ResourceTrackerState,
+    hash_id: &String,
+    progress: &str,
+    size: &str,
+    metadata: &str,
+) {
+    if !EngineDebugger::singleton().is_active() {
+        return;
+    }
+    let mut array = Array::new();
+    array.push(hash_id.to_variant());
+    array.push((state as i32).to_variant());
+    array.push(progress.to_variant());
+    array.push(size.to_variant());
+    array.push(metadata.to_variant());
+    EngineDebugger::singleton().send_message("resource_tracker:report".into_godot(), array);
+}
+
+pub fn report_download_speed(speed: f64) {
+    if !EngineDebugger::singleton().is_active() {
+        return;
+    }
+    let speed_str = format!("{:.2}mb/s", speed / 1024.0 / 1024.0);
+    let mut array = Array::new();
+    array.push(speed_str.to_variant());
+    EngineDebugger::singleton().send_message("resource_tracker:report_speed".into_godot(), array);
+}
+
+pub fn report_resource_start(hash_id: &String) {
+    send_resource_tracker_message(ResourceTrackerState::Started, hash_id, "0%", "0mb", "");
+}
+
+pub fn report_resource_downloading(hash_id: &String, current_size: u64, speed: f64) {
+    let size_str = format!("{:.2}mb", (current_size as f64) / 1024.0 / 1024.0);
+    let speed_str = format!("{:.2}kb/s", speed / 1024.0);
+    send_resource_tracker_message(
+        ResourceTrackerState::Downloading,
+        hash_id,
+        "",
+        &size_str,
+        &speed_str,
+    );
+}
+
+pub fn report_resource_download_done(hash_id: &String, current_size: u64) {
+    let size_str = format!("{:.2}mb", (current_size as f64) / 1024.0 / 1024.0);
+    send_resource_tracker_message(ResourceTrackerState::Downloaded, hash_id, "", &size_str, "");
+}
+
+pub fn report_resource_error(hash_id: &String, error: &String) {
+    send_resource_tracker_message(ResourceTrackerState::Failed, hash_id, "Failed", "", error);
+}
+
+pub fn report_resource_loading(hash_id: &String, progress: &String, detail: &String) {
+    send_resource_tracker_message(ResourceTrackerState::Loading, hash_id, progress, "", detail);
+}
+
+pub fn report_resource_loaded(hash_id: &String) {
+    send_resource_tracker_message(ResourceTrackerState::Finished, hash_id, "Done", "", "");
+}

--- a/lib/src/godot_classes/mod.rs
+++ b/lib/src/godot_classes/mod.rs
@@ -13,6 +13,8 @@ pub mod dcl_gltf_container;
 pub mod dcl_hashing;
 pub mod dcl_node_entity_3d;
 pub mod dcl_realm;
+#[cfg(feature = "use_resource_tracking")]
+pub mod dcl_resource_tracker;
 pub mod dcl_scene_node;
 pub mod dcl_ui_background;
 pub mod dcl_ui_control;

--- a/lib/src/godot_classes/rpc_sender/take_and_compare_snapshot_response.rs
+++ b/lib/src/godot_classes/rpc_sender/take_and_compare_snapshot_response.rs
@@ -1,4 +1,4 @@
-use godot::{builtin::Vector2, prelude::*};
+use godot::prelude::*;
 
 use crate::{
     dcl::common::{GreyPixelDiffResult, TakeAndCompareSnapshotResponse},

--- a/src/main.rs
+++ b/src/main.rs
@@ -106,10 +106,7 @@ fn main() -> Result<(), anyhow::Error> {
                         .help("enables resource tracking feature")
                         .takes_value(false),
                 )
-                .arg(
-                    Arg::new("build-args")
-                        .help("extra build args for rust")
-                )
+                .arg(Arg::new("build-args").help("extra build args for rust"))
                 .arg(
                     Arg::new("extras")
                         .last(true)
@@ -137,7 +134,7 @@ fn main() -> Result<(), anyhow::Error> {
                 .values_of("build-args")
                 .map(|v| v.map(|it| it.into()).collect())
                 .unwrap_or_default();
-        
+
             if sm.is_present("resource-tracking") {
                 build_args.extend(&["-F", "use_resource_tracking"]);
             }

--- a/src/run.rs
+++ b/src/run.rs
@@ -18,6 +18,7 @@ pub fn run(
     only_build: bool,
     link_libs: bool,
     scene_tests: bool,
+    extra_build_args: Vec<&str>,
     extras: Vec<String>,
     with_build_envs: Option<HashMap<String, String>>,
 ) -> Result<(), anyhow::Error> {
@@ -45,16 +46,16 @@ pub fn run(
     }
 
     #[allow(unused_mut)]
-    let mut build_args = if release_mode {
-        vec!["build", "--release"]
-    } else {
-        vec!["build"]
-    };
-
+    let mut build_args = vec!["build"];
+    if release_mode {
+        build_args.push("--release");
+    }
+    
     #[cfg(target_os = "macos")]
     {
         build_args.extend(&["--no-default-features", "-F", "use_deno"]);
     }
+    build_args.extend(extra_build_args);
     
     let build_cwd =
         adjust_canonicalization(std::fs::canonicalize(RUST_LIB_PROJECT_FOLDER).unwrap());

--- a/src/run.rs
+++ b/src/run.rs
@@ -50,13 +50,13 @@ pub fn run(
     if release_mode {
         build_args.push("--release");
     }
-    
+
     #[cfg(target_os = "macos")]
     {
         build_args.extend(&["--no-default-features", "-F", "use_deno"]);
     }
     build_args.extend(extra_build_args);
-    
+
     let build_cwd =
         adjust_canonicalization(std::fs::canonicalize(RUST_LIB_PROJECT_FOLDER).unwrap());
 


### PR DESCRIPTION
# Test
Add `-t` for compiling with `resource tracking`

example `cargo run -- run -et`