### PR TITLE
fix: crashes in empty data textures and infinite rotations

### DIFF
--- a/lib/src/content/texture.rs
+++ b/lib/src/content/texture.rs
@@ -37,6 +37,10 @@ pub async fn load_image_texture(
         .await
         .map_err(anyhow::Error::msg)?;
 
+    if bytes_vec.len() == 0 {
+        return Err(anyhow::Error::msg("Empty texture data"));
+    }
+
     let _thread_safe_check = GodotSingleThreadSafety::acquire_owned(&ctx)
         .await
         .ok_or(anyhow::Error::msg("Failed trying to get thread-safe check"))?;

--- a/lib/src/content/texture.rs
+++ b/lib/src/content/texture.rs
@@ -37,7 +37,7 @@ pub async fn load_image_texture(
         .await
         .map_err(anyhow::Error::msg)?;
 
-    if bytes_vec.len() == 0 {
+    if bytes_vec.is_empty() {
         return Err(anyhow::Error::msg("Empty texture data"));
     }
 

--- a/lib/src/scene_runner/components/transform_and_parent.rs
+++ b/lib/src/scene_runner/components/transform_and_parent.rs
@@ -73,6 +73,10 @@ pub fn update_transform_and_parent(
                 }
             }
 
+            if !transform.rotation.is_finite() {
+                transform.rotation = godot::prelude::Quaternion::default();
+            }
+
             node_3d.set_transform(transform.to_godot_transform_3d_without_scaled());
             if transform.scale.x.is_zero_approx() {
                 transform.scale.x = 0.00001;


### PR DESCRIPTION
Fix crashes on https://worlds.dcl-iwb.co/world/BuilderWorld.dcl.eth/