### PR TITLE
fix: avatar icon generation

### DIFF
--- a/godot/src/decentraland_components/avatar/avatar.gd
+++ b/godot/src/decentraland_components/avatar/avatar.gd
@@ -397,7 +397,7 @@ func async_load_wearables():
 			emote_controller.load_emote_from_dcl_emote_gltf(emote_urn, obj, file_hash)
 
 	emote_controller.clean_unused_emotes()
-	emit_signal("avatar_loaded")
+	avatar_loaded.emit()
 
 
 func apply_color_and_facial():

--- a/godot/src/global.gd
+++ b/godot/src/global.gd
@@ -1,6 +1,5 @@
 extends DclGlobal
 
-signal config_changed
 signal loading_started
 signal loading_finished
 signal change_parcel(new_parcel: Vector2i)

--- a/godot/src/logic/realm.gd
+++ b/godot/src/logic/realm.gd
@@ -204,7 +204,7 @@ func async_set_realm(new_realm_string: String, search_new_pos: bool = false) -> 
 		Global.metrics.update_realm(realm_url)
 
 		_has_realm = true
-		emit_signal("realm_changed")
+		realm_changed.emit()
 
 
 func async_request_set_position(scene_urn):

--- a/godot/src/logic/scene_fetcher.gd
+++ b/godot/src/logic/scene_fetcher.gd
@@ -174,10 +174,7 @@ func get_parcel_scene_id(x: int, z: int) -> int:
 func _is_there_any_new_scene_to_load() -> bool:
 	var d = scene_entity_coordinator.get_desired_scenes()
 	var loadable_scenes = d.get("loadable_scenes", [])
-	var keep_alive_scenes = d.get("keep_alive_scenes", [])
-	var empty_parcels = d.get("empty_parcels", [])
 
-	var loading_promises: Array = []
 	for scene_id in loadable_scenes:
 		if not loaded_scenes.has(scene_id):
 			var scene_definition = scene_entity_coordinator.get_scene_definition(scene_id)

--- a/godot/src/ui/color_picker/colorable_square.gd
+++ b/godot/src/ui/color_picker/colorable_square.gd
@@ -20,7 +20,7 @@ func _ready():
 
 func _on_toggled(is_button_pressed):
 	if is_button_pressed:
-		emit_signal("select_color", background_color)
+		select_color.emit(background_color)
 		panel_container_border.show()
 	else:
 		panel_container_border.hide()

--- a/godot/src/ui/components/auth/lobby.gd
+++ b/godot/src/ui/components/auth/lobby.gd
@@ -64,7 +64,7 @@ func show_panel(child_node: Control):
 func async_close_sign_in(generate_snapshots: bool = true):
 	if generate_snapshots:
 		var avatar := current_profile.get_avatar()
-		await backpack.async_prepare_snapshots(avatar)
+		await backpack.async_prepare_snapshots(avatar, current_profile)
 
 	if Global.is_xr():
 		change_scene.emit("res://src/ui/components/discover/discover.tscn")
@@ -201,7 +201,7 @@ func _on_button_next_pressed():
 	current_profile.set_has_connected_web3(!Global.player_identity.is_guest)
 	var avatar := current_profile.get_avatar()
 
-	await backpack.async_prepare_snapshots(avatar)
+	await backpack.async_prepare_snapshots(avatar, current_profile)
 
 	current_profile.set_avatar(avatar)
 

--- a/godot/src/ui/components/backpack/backpack.tscn
+++ b/godot/src/ui/components/backpack/backpack.tscn
@@ -552,6 +552,23 @@ offset_bottom = 64.0
 grow_horizontal = 2
 grow_vertical = 2
 
+[node name="ClonedAvatarPreview" parent="." instance=ExtResource("4_4kxkq")]
+unique_name_in_owner = true
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = 1280.0
+offset_top = 720.0
+offset_bottom = 256.0
+grow_horizontal = 2
+grow_vertical = 2
+size_flags_horizontal = 1
+mouse_filter = 0
+stretch = true
+hide_name = true
+show_platform = true
+
 [connection signal="pressed" from="VBoxContainer/PanelContainer_Navbar/MarginContainer/HBoxContainer/Button_Wearables" to="." method="_on_button_wearables_pressed"]
 [connection signal="pressed" from="VBoxContainer/PanelContainer_Navbar/MarginContainer/HBoxContainer/Button_Emotes" to="." method="_on_button_emotes_pressed"]
 [connection signal="toggled" from="VBoxContainer/PanelContainer_Navbar/MarginContainer/HBoxContainer/CheckBox_OnlyCollectibles" to="." method="_on_check_box_only_collectibles_toggled"]

--- a/godot/src/ui/components/custom_slider/custom_background_slider.gd
+++ b/godot/src/ui/components/custom_slider/custom_background_slider.gd
@@ -68,7 +68,7 @@ func _process(_delta):
 
 func follow_mouse(mouse_position: Vector2i):
 	refresh_grabber_position(mouse_position.x)
-	emit_signal("value_change")
+	value_change.emit()
 
 
 func refresh_grabber_position(new_x: int):

--- a/godot/src/ui/components/wearable_button/wearable_filter_button.gd
+++ b/godot/src/ui/components/wearable_button/wearable_filter_button.gd
@@ -101,6 +101,6 @@ func type_to_category(category_enum: WearableCategoryEnum) -> String:
 
 func _on_toggled(_button_pressed):
 	if _button_pressed:
-		emit_signal("filter_type", type_to_category(filter_category))
+		filter_type.emit(type_to_category(filter_category))
 	else:
-		emit_signal("clear_filter")
+		clear_filter.emit()


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/b980ca5d-2967-4977-a0c9-2e8c754007ee)

Icon generation was not working after 4.3 update.

The issue was with the AvatarPreview duplication.
I bit of research found that the issue was due to the following: https://github.com/godotengine/godot/pull/87387
So I changed the code not to use duplication of the AvatarPreview. It just loads a parallel node. 