### PR TITLE
chore: disable macos and windows builds and remove cache usage on imports

### DIFF
--- a/.github/actions/import-assets/action.yml
+++ b/.github/actions/import-assets/action.yml
@@ -1,11 +1,18 @@
 name: Import assets
 description: Import assets
 
+inputs:
+  cache:
+    description: 'Whether to use cache for Godot assets'
+    required: false
+    default: 'false'
+
 runs:
   using: composite
   steps:
     # Step 1: Restore cache
     - name: Restore Godot assets cache
+      if: inputs.cache == 'true'
       uses: actions/cache@v3
       with:
         path: godot/.godot
@@ -18,6 +25,7 @@ runs:
 
     # Step 3: Save cache
     - name: Cache Godot assets
+      if: inputs.cache == 'true'
       uses: actions/cache@v3
       with:
         path: godot/.godot

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -76,6 +76,8 @@ jobs:
 
       - name: Import Assets
         uses: ./.github/actions/import-assets
+        with:
+          cache: false
 
       - name: Run xtask coverage
         run: |

--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -42,6 +42,8 @@ jobs:
       # Export section
       - name: Import Assets
         uses: ./.github/actions/import-assets
+        with:
+          cache: false
 
       - name: Export
         run: cargo run -- export

--- a/.github/workflows/macos_builds.yml
+++ b/.github/workflows/macos_builds.yml
@@ -40,6 +40,8 @@ jobs:
       # Export section (multi platform)
       - name: Import Assets
         uses: ./.github/actions/import-assets
+        with:
+          cache: false
 
       - name: Export
         run: cargo run -- export

--- a/.github/workflows/runner.yml
+++ b/.github/workflows/runner.yml
@@ -26,25 +26,25 @@ jobs:
     needs: static-checks
     uses: ./.github/workflows/android_builds.yml
 
-  linux-build:
-    name: 🐧 Linux
-    needs: static-checks
-    uses: ./.github/workflows/linux_builds.yml
-
-  macos-build:
-    name: 🍎 macOS
-    needs: static-checks
-    uses: ./.github/workflows/macos_builds.yml
-
   ios-build:
     name: 🍏 iOS (only lib)
     needs: static-checks
     uses: ./.github/workflows/ios_builds.yml
 
-  windows-build:
-    name: 🏁 Windows
+  linux-build:
+    name: 🐧 Linux
     needs: static-checks
-    uses: ./.github/workflows/windows_builds.yml
+    uses: ./.github/workflows/linux_builds.yml
+  # Disable Windows and MacOS builds for now
+  # macos-build:
+  #   name: 🍎 macOS
+  #   needs: static-checks
+  #   uses: ./.github/workflows/macos_builds.yml
+
+  # windows-build:
+  #   name: 🏁 Windows
+  #   needs: static-checks
+  #   uses: ./.github/workflows/windows_builds.yml
 
   # Third stage: Extras
   docker-build-test:

--- a/.github/workflows/windows_builds.yml
+++ b/.github/workflows/windows_builds.yml
@@ -43,6 +43,8 @@ jobs:
       # Export section
       - name: Import Assets
         uses: ./.github/actions/import-assets
+        with:
+          cache: false
 
       - name: Export
         run: cargo run -- export


### PR DESCRIPTION
Disable MacOS and Windows. They are not used. Just taking CI time.

Also, we were having a lot of issues due to the inconsistency of the import cache. When we delete/add new class_name, it fails because it doesn't find it. Removing for now.