### PR TITLE
fix: android build on windows

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -78,12 +78,14 @@ jni = { version = "0.21.1", features = ["invocation"] }
 paranoid-android = "0.2.1"
 
 [features]
-# FFMPEG disabled until next iteration
-default = ["use_livekit", "use_deno", "enable_inspector"]
+default = ["use_livekit", "use_deno"]
 use_ffmpeg = ["dep:ffmpeg-next", "dep:cpal"]
 use_livekit = ["dep:livekit", "dep:webrtc-sys-build"]
 use_deno = ["dep:deno_core", "dep:v8"]
 use_resource_tracking = []
+
+# TODO: Fix enable_inspector failure when cross-compiling to Android from Windows.
+#       The FastWebSockets build incorrectly includes `unmask`.
 enable_inspector = ["use_deno", "dep:fastwebsockets", "dep:hyper1"]
 
 [build-dependencies]

--- a/src/install_dependency.rs
+++ b/src/install_dependency.rs
@@ -691,7 +691,8 @@ pub fn install_ffmpeg() -> Result<(), anyhow::Error> {
     match env::consts::OS {
         "linux" => {
             // Use BtbN's shared library builds for FFmpeg 6.1
-            let url = "https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2025-08-29-13-31/ffmpeg-n6.1.3-linux64-lgpl-shared-6.1.tar.xz";
+            let url = "https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2025-05-31-14-01/ffmpeg-n6.1.2-31-gf120f66838-linux64-lgpl-shared-6.1.tar.xz";
+
             let temp_extract_path = BinPaths::temp_dir("ffmpeg_temp");
 
             // Clean up any existing temp directory first
@@ -702,13 +703,13 @@ pub fn install_ffmpeg() -> Result<(), anyhow::Error> {
             download_and_extract_tar_xz(
                 url,
                 temp_extract_path.to_str().unwrap(),
-                Some("ffmpeg-n6.1.3-linux64-lgpl-shared-6.1.tar.xz".to_string()),
+                Some("ffmpeg-n6.1.2-31-gf120f66838-linux64-lgpl-shared-6.1.tar.xz".to_string()),
             )?;
 
             // The archive extracts to a folder like ffmpeg
             // We need to move its contents to our ffmpeg folder
             let extracted_folder =
-                temp_extract_path.join("ffmpeg-n6.1.3-linux64-lgpl-shared-6.1");
+                temp_extract_path.join("ffmpeg-n6.1.2-31-gf120f66838-linux64-lgpl-shared-6.1");
 
             // Create the final ffmpeg folder
             fs::create_dir_all(&ffmpeg_folder)?;
@@ -770,8 +771,7 @@ pub fn install_ffmpeg() -> Result<(), anyhow::Error> {
             )?;
 
             // The archive extracts to a folder like ffmpeg-n6.1-latest-win64-lgpl-shared-6.1
-            let extracted_folder =
-                temp_extract_path.join("ffmpeg-n6.1-win64");
+            let extracted_folder = temp_extract_path.join("ffmpeg-n6.1-win64");
 
             // Create the final ffmpeg folder
             fs::create_dir_all(&ffmpeg_folder)?;


### PR DESCRIPTION
Fix the build system to build correctly to android from windows, removing unmask requirement.