### PR TITLE
fix: scene ui order with the mobile ui

### DIFF
--- a/godot/src/ui/explorer.tscn
+++ b/godot/src/ui/explorer.tscn
@@ -82,6 +82,17 @@ focus_mode = 1
 mouse_filter = 1
 theme = ExtResource("4_2vs87")
 
+[node name="SceneUIContainer" type="MarginContainer" parent="UI"]
+unique_name_in_owner = true
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+mouse_filter = 2
+script = ExtResource("5_c8ksg")
+
 [node name="SafeMarginContainer" type="MarginContainer" parent="UI"]
 unique_name_in_owner = true
 layout_mode = 1
@@ -309,17 +320,6 @@ theme_override_constants/outline_size = 4
 theme_override_font_sizes/font_size = 12
 horizontal_alignment = 1
 vertical_alignment = 1
-
-[node name="SceneUIContainer" type="MarginContainer" parent="UI"]
-unique_name_in_owner = true
-layout_mode = 1
-anchors_preset = 15
-anchor_right = 1.0
-anchor_bottom = 1.0
-grow_horizontal = 2
-grow_vertical = 2
-mouse_filter = 2
-script = ExtResource("5_c8ksg")
 
 [node name="Timer_FPSLabel" type="Timer" parent="UI"]
 autostart = true


### PR DESCRIPTION
Fix https://github.com/decentraland/godot-explorer/issues/660

Before:
<img width="2556" height="1179" alt="image" src="https://github.com/user-attachments/assets/4305f092-b57a-4fd5-941b-55b5b431a85e" />

After:
<img width="633" height="350" alt="image" src="https://github.com/user-attachments/assets/0707e434-facb-4a66-96c3-1f7d2c175540" />
