### PR TITLE
fix: landscape event details margins

### DIFF
--- a/godot/src/ui/components/events/event_details_landscape.tscn
+++ b/godot/src/ui/components/events/event_details_landscape.tscn
@@ -1,7 +1,6 @@
-[gd_scene load_steps=34 format=3 uid="uid://jel6s7s7w8h3"]
+[gd_scene load_steps=33 format=3 uid="uid://jel6s7s7w8h3"]
 
 [ext_resource type="Script" uid="uid://dqrm5fg1bv6rg" path="res://src/ui/components/place_item.gd" id="1_4okyg"]
-[ext_resource type="Script" uid="uid://bhwm0bl5qoiph" path="res://src/ui/components/utils/safe_margin_container.gd" id="2_rf1tr"]
 [ext_resource type="Theme" uid="uid://bm1rvmngc833v" path="res://assets/themes/theme.tres" id="3_a1tfr"]
 [ext_resource type="Texture2D" uid="uid://cmls1puqgwrwi" path="res://assets/ui/placeholder.png" id="4_n1hx1"]
 [ext_resource type="FontVariation" uid="uid://ct75rjpcbx4cb" path="res://src/ui/components/events/inter600_icons.tres" id="6_6i5jl"]
@@ -124,11 +123,6 @@ theme_override_constants/margin_left = 42
 theme_override_constants/margin_top = 20
 theme_override_constants/margin_right = 42
 theme_override_constants/margin_bottom = 42
-script = ExtResource("2_rf1tr")
-default_margin = 42
-use_left = false
-use_right = false
-use_top = false
 
 [node name="VBoxContainer" type="VBoxContainer" parent="VBoxContainer/MarginContainer"]
 layout_mode = 2


### PR DESCRIPTION
Remove the safe margin container script to fix the wrong margins in the landscape event details