### PR TITLE
fix: correct default FPS limit and config parameter emission

### DIFF
--- a/godot/src/config/config_data.gd
+++ b/godot/src/config/config_data.gd
@@ -3,6 +3,14 @@ extends DclConfig
 
 signal param_changed(param: ConfigParams)
 
+enum FpsLimitMode {
+	VSYNC = 0,
+	NO_LIMIT = 1,
+	FPS_30 = 2,
+	FPS_60 = 3,
+	FPS_120 = 4,
+}
+
 enum ConfigParams {
 	CONTENT_DIRECTORY,
 	WINDOW_MODE,
@@ -93,8 +101,8 @@ var skybox_time: int = 43200:
 		skybox_time = value
 		param_changed.emit(ConfigParams.SKYBOX_TIME)
 
-# 0 - Vsync, 1 - No limit, Other-> Limit limit_fps that amount
-var limit_fps: int = 2:
+# See FpsLimitMode enum for available options
+var limit_fps: int = FpsLimitMode.FPS_30:
 	set(value):
 		limit_fps = value
 		param_changed.emit(ConfigParams.LIMIT_FPS)
@@ -215,7 +223,7 @@ func load_from_default():
 	self.run_velocity = 6.0
 
 	self.process_tick_quota_ms = 10
-	self.limit_fps = 2
+	self.limit_fps = FpsLimitMode.FPS_30
 
 	self.skybox = 0  # basic
 

--- a/godot/src/config/graphic_settings.gd
+++ b/godot/src/config/graphic_settings.gd
@@ -60,18 +60,18 @@ static func apply_window_config() -> void:
 
 static func apply_fps_limit():
 	match Global.get_config().limit_fps:
-		0:  # VSync
+		ConfigData.FpsLimitMode.VSYNC:
 			Engine.max_fps = 0
 			DisplayServer.window_set_vsync_mode(DisplayServer.VSYNC_ENABLED)
-		1:  # No Limit
+		ConfigData.FpsLimitMode.NO_LIMIT:
 			Engine.max_fps = 0
 			DisplayServer.window_set_vsync_mode(DisplayServer.VSYNC_DISABLED)
-		2:  # 30
+		ConfigData.FpsLimitMode.FPS_30:
 			Engine.max_fps = 30
 			DisplayServer.window_set_vsync_mode(DisplayServer.VSYNC_DISABLED)
-		3:  # 60
+		ConfigData.FpsLimitMode.FPS_60:
 			Engine.max_fps = 60
 			DisplayServer.window_set_vsync_mode(DisplayServer.VSYNC_DISABLED)
-		4:  # 120
+		ConfigData.FpsLimitMode.FPS_120:
 			Engine.max_fps = 120
 			DisplayServer.window_set_vsync_mode(DisplayServer.VSYNC_DISABLED)


### PR DESCRIPTION
- Change default limit_fps from 0 (vsync) to 2 (30 FPS cap)
- Fix param_changed emission to use LIMIT_FPS instead of GRAVITY
- Changed config file key to reset default value on existing users

Closes #813