### PR TITLE
fix: profile report was broadcasting others profile if you have in th…

### DIFF
--- a/lib/src/comms/adapter/message_processor.rs
+++ b/lib/src/comms/adapter/message_processor.rs
@@ -999,48 +999,6 @@ impl MessageProcessor {
                                 "ProfileRequest for our address but no profile available"
                             );
                         }
-                    } else if let Some(peer) = self.peer_identities.get(&requested_address) {
-                        // Check if we have this peer's profile cached
-                        if let Some(peer_profile) = &peer.profile {
-                            let serialized_profile = serde_json::to_string(&peer_profile.content)
-                                .unwrap_or_else(|_| "{}".to_string());
-
-                            let response_packet = rfc4::Packet {
-                                message: Some(rfc4::packet::Message::ProfileResponse(
-                                    rfc4::ProfileResponse {
-                                        serialized_profile,
-                                        base_url: peer_profile.base_url.clone(),
-                                    },
-                                )),
-                                protocol_version: DEFAULT_PROTOCOL_VERSION,
-                            };
-
-                            // Send response back to the requesting room
-                            let outgoing = OutgoingMessage {
-                                packet: response_packet,
-                                unreliable: false,
-                            };
-
-                            if let Err(e) = self.outgoing_sender.try_send(outgoing) {
-                                tracing::warn!(
-                                    "Failed to queue ProfileResponse for cached peer: {}",
-                                    e
-                                );
-                            } else {
-                                tracing::debug!(
-                                    "📤 Sending cached ProfileResponse for {:#x} to {:#x}",
-                                    requested_address,
-                                    address
-                                );
-                            }
-                        } else {
-                            tracing::debug!(
-                                "ProfileRequest for {:#x} but no cached profile available",
-                                requested_address
-                            );
-                        }
-                    } else {
-                        tracing::debug!("ProfileRequest for unknown peer {:#x}", requested_address);
                     }
                 } else {
                     tracing::warn!(


### PR DESCRIPTION
…e cache

Fix https://github.com/decentraland/godot-explorer/issues/774

Looks like this issue was introduced by the wrong code made by IA 🫠. I'm going to review better 🙌. We never want to broadcast OTHER profile.

# Issue

The ProfileRequest handler contained logic that allowed peers to forward cached profiles of other users. This caused ProfileResponse messages to broadcast incorrect profile data, leading to profiles being misassociated with the wrong users.

Root cause: When a peer received a ProfileRequest for another user's address, it would check its cache and respond with that user's cached profile. This response was then broadcast to all peers, causing identity confusion.

# Changes

Removed the cached profile forwarding logic in message_processor.rs (lines 1002-1044). Now peers only respond to ProfileRequests for their own profile.

Before:
  - User A requests a profile on the network
  - User B receives the request and broadcasts all cached profiles (including User C's profile)
  - User C receives the request and broadcasts all cached profiles (including User B's profile)
  - Result: Profile data gets misassociated with the wrong users

After:
  - User A requests a profile on the network
  - User B receives the request and sends only their own profile
  - User C receives the request and sends only their own profile
  - Result: Each user correctly responds with their own profile data only

# Technical Details
Each user still broadcasts their ProfileVersion every 10 seconds, triggering profile requests as needed. The authoritative source for a profile is always the user themselves, not cached copies from other peers.