### PR TITLE
feat: enable preview mode with deeplink

### DIFF
--- a/godot/src/global.gd
+++ b/godot/src/global.gd
@@ -546,15 +546,23 @@ func check_deep_link_teleport_to():
 				"[DEEPLINK] Parsed deep_link_obj: location=",
 				deep_link_obj.location,
 				" realm=",
-				deep_link_obj.realm
+				deep_link_obj.realm,
+				" preview=",
+				deep_link_obj.preview
 			)
 
 		if Global.deep_link_obj.is_location_defined():
-			var realm = Global.deep_link_obj.realm
+			# Use preview URL as realm if specified, otherwise use realm, otherwise main
+			var realm = Global.deep_link_obj.preview
+			if realm.is_empty():
+				realm = Global.deep_link_obj.realm
 			if realm.is_empty():
 				realm = Realm.MAIN_REALM
 
 			Global.teleport_to(Global.deep_link_obj.location, realm)
+		elif not Global.deep_link_obj.preview.is_empty():
+			# Preview without location - just set realm, don't teleport
+			Global.teleport_to(Vector2i.ZERO, Global.deep_link_obj.preview)
 		elif not Global.deep_link_obj.realm.is_empty():
 			Global.teleport_to(Vector2i.ZERO, Global.deep_link_obj.realm)
 		elif deep_link_url.begins_with("https://decentraland.org/events/event/?id="):

--- a/godot/src/notifications_manager.gd
+++ b/godot/src/notifications_manager.gd
@@ -88,7 +88,7 @@ var _android_plugin = null:
 
 func _ready() -> void:
 	# Enable debug logging in debug builds
-	_debug_notifications_enabled = OS.is_debug_build()
+	# _debug_notifications_enabled = OS.is_debug_build()
 
 	# Create polling timer
 	_poll_timer = Timer.new()

--- a/godot/src/ui/explorer.gd
+++ b/godot/src/ui/explorer.gd
@@ -86,6 +86,10 @@ func get_params_from_cmd():
 	if location_vector == Vector2i.MAX:
 		location_vector = null
 
+	# Preview deeplink takes priority - use it as the realm for hot reload development
+	if not Global.deep_link_obj.preview.is_empty() and realm_string == null:
+		realm_string = Global.deep_link_obj.preview
+
 	if not Global.deep_link_obj.realm.is_empty() and realm_string == null:
 		realm_string = Global.deep_link_obj.realm
 
@@ -148,8 +152,8 @@ func _ready():
 		var test_spawn_and_move_avatars = TestSpawnAndMoveAvatars.new()
 		add_child(test_spawn_and_move_avatars)
 
-	# --debug-panel (automatically enabled with --preview)
-	if Global.cli.debug_panel:
+	# --debug-panel (automatically enabled with --preview or preview deeplink)
+	if Global.cli.debug_panel or not Global.deep_link_obj.preview.is_empty():
 		_on_control_menu_request_debug_panel(true)
 
 	virtual_joystick.mouse_filter = Control.MOUSE_FILTER_IGNORE

--- a/lib/src/godot_classes/dcl_parse_deep_link.rs
+++ b/lib/src/godot_classes/dcl_parse_deep_link.rs
@@ -10,6 +10,11 @@ pub struct DclParseDeepLink {
     #[var]
     realm: GString,
 
+    /// Preview URL for hot reloading (e.g., http://192.168.0.55:8000)
+    /// When set, skips lobby and enables preview mode with WebSocket hot reload
+    #[var]
+    preview: GString,
+
     #[var]
     params: Dictionary,
 }
@@ -22,6 +27,7 @@ impl IRefCounted for DclParseDeepLink {
             //  Check is_location_defined
             location: Vector2i::MAX,
             realm: GString::new(),
+            preview: GString::new(),
             params: Dictionary::new(),
         }
     }
@@ -34,6 +40,7 @@ impl DclParseDeepLink {
         let mut return_object = DclParseDeepLink {
             location: Vector2i::MAX,
             realm: GString::new(),
+            preview: GString::new(),
             params: Dictionary::new(),
         };
 
@@ -74,6 +81,10 @@ impl DclParseDeepLink {
                 }
                 "realm" => {
                     return_object.realm = value.to_string().into();
+                }
+                "preview" => {
+                    // Preview URL for hot reloading (e.g., http://192.168.0.55:8000)
+                    return_object.preview = value.to_string().into();
                 }
                 _ => {}
             }


### PR DESCRIPTION
enable preview mode with deeplink

tested on android by opening the camera, scane the QR generated by https://github.com/decentraland/js-sdk-toolchain/pull/1261 and being in the same network