### PR TITLE
fix: resolve multiple Sentry errors affecting users

### DIFF
--- a/godot/src/config/audio_settings.gd
+++ b/godot/src/config/audio_settings.gd
@@ -50,11 +50,3 @@ static func apply_music_volume_settings():
 
 static func apply_mic_amplification_settings():
 	pass
-# TODO: Renable when we re-implement Voice Chat
-#	var volume_db = -10 + (34.0 * (float(Global.get_config().audio_mic_amplification) / 100.0))
-#
-#	var bus_index := AudioServer.get_bus_index("Capture")
-#	for i in range(AudioServer.get_bus_effect_count(bus_index)):
-#		var effect = AudioServer.get_bus_effect(bus_index, i)
-#		if effect is AudioEffectAmplify:
-#			effect.volume_db = volume_db

--- a/godot/src/helpers_components/persistant_camera.gd
+++ b/godot/src/helpers_components/persistant_camera.gd
@@ -2,4 +2,6 @@ extends Camera3D
 
 
 func _on_tree_exiting() -> void:
-	reparent(get_viewport())
+	var viewport = get_viewport()
+	if is_instance_valid(viewport) and get_parent() != viewport:
+		reparent.call_deferred(viewport)

--- a/godot/src/logic/player/stuck_detector.gd
+++ b/godot/src/logic/player/stuck_detector.gd
@@ -12,7 +12,8 @@ func _ready():
 	collision_mask = 0xFFFFFFFF  # Detect all layers so we can track colliders after disabling CL_PHYSICS
 	monitoring = true
 	monitorable = false
-	body_exited.connect(_on_body_exited)
+	if not body_exited.is_connected(_on_body_exited):
+		body_exited.connect(_on_body_exited)
 
 
 ## Called after teleport to detect overlapping colliders

--- a/godot/src/ui/components/radio_selector/radio_selector.gd
+++ b/godot/src/ui/components/radio_selector/radio_selector.gd
@@ -12,6 +12,8 @@ signal select_item(index: int, item: String)
 @export var selected: int = 0:
 	set(new_value):
 		selected = new_value
+		if selected < 0 or selected >= get_child_count():
+			return
 		var radio_button = get_child(selected)
 		if is_instance_valid(radio_button) and radio_button is CheckBox:
 			for child in self.get_children():

--- a/godot/src/ui/components/settings/settings.gd
+++ b/godot/src/ui/components/settings/settings.gd
@@ -264,15 +264,18 @@ func refresh_zooms():
 	var selected_index: int = -1
 	var i: int = 0
 	var options := GraphicSettings.get_ui_zoom_available(get_window())
-	radio_selector_ui_zoom.clear()
 
+	var new_items: Array[String] = []
 	for ui_zoom_option in options.keys():
-		radio_selector_ui_zoom.items.push_back(ui_zoom_option)
+		new_items.push_back(ui_zoom_option)
 		if options[ui_zoom_option] == get_window().content_scale_factor:
 			selected_index = i
 		i += 1
 	if selected_index == -1:
 		selected_index = i - 1
+
+	# Assign items array to trigger _refresh_list() and create children
+	radio_selector_ui_zoom.items = new_items
 	radio_selector_ui_zoom.selected = selected_index
 
 


### PR DESCRIPTION
## Summary
- Fix RadioSelector index out of bounds error affecting **1,225 users** (5,036 events)
- Fix PersistantCamera reparent race condition affecting **45 users** (687 events)
- Fix duplicate signal connection in stuck_detector affecting **8 users**
- Remove commented mic amplification code for removed Capture bus (affected **1,698 users**)

## Changes

### RadioSelector index out of bounds (GODOT-EXPLORER-N/K/6T)
**Root cause:** `refresh_zooms()` in `settings.gd` used `items.push_back()` which doesn't trigger `_refresh_list()`. Only the setter `items = new_value` triggers child creation, so when `selected` was set there were no children.

**Fix:** Build items array first, then assign it to trigger `_refresh_list()`. Also added bounds check in RadioSelector setter as defensive measure.

### PersistantCamera already has parent (GODOT-EXPLORER-4F/4J/4Q/4W)
**Root cause:** `reparent()` in `_on_tree_exiting` conflicted with `dcl_global_camera_controller.gd` which also reparents the camera during transitions.

**Fix:** Check if reparent is needed and use `call_deferred` to avoid race conditions.

### Duplicate signal connection (GODOT-EXPLORER-E5/E7)
**Fix:** Check `is_connected()` before connecting signal in `stuck_detector.gd`.

### Mic amplification code (GODOT-EXPLORER-6A)
**Fix:** Removed commented-out Capture bus code since the bus was removed.

## Test plan
- [ ] Open settings panel and verify UI zoom options work correctly
- [ ] Teleport to different scenes and verify no camera errors
- [ ] Test stuck detector functionality after teleporting inside colliders
- [ ] Verify no audio-related errors on startup