### PR TITLE
fix: use PR-{number}-{branch} format for iOS deploy pipeline branches

### DIFF
--- a/.github/workflows/ios_builds.yml
+++ b/.github/workflows/ios_builds.yml
@@ -52,25 +52,25 @@ jobs:
 
       # Build section
       - name: Cargo install
-        timeout-minutes: 4
+        timeout-minutes: 8
         run: cargo run -- install --targets ios
 
       - name: Set prod flag
         uses: ./.github/actions/set-prod-flag
 
       - name: Build MacOS
-        timeout-minutes: 15
+        timeout-minutes: 20
         run: cargo run -- build --release ${{ env.PROD_FLAG }}
 
       - name: Build iOS
-        timeout-minutes: 15
+        timeout-minutes: 20
         run: cargo run -- build --release --target ios ${{ env.PROD_FLAG }}
 
       - name: Import Assets
         uses: ./.github/actions/import-assets
 
       - name: Export
-        timeout-minutes: 2
+        timeout-minutes: 5
         run: cargo run -- export --target ios
 
       # Deploy to godot-mobile-deploy-pipeline
@@ -89,7 +89,7 @@ jobs:
           ssh-keyscan github.com >> ~/.ssh/known_hosts
 
       - name: Deploy iOS exports to mobile deploy pipeline
-        timeout-minutes: 6
+        timeout-minutes: 10
         run: |
           # Use PR-{number}-{branch} format for PR builds, otherwise use the ref name
           if [ -n "${{ github.event.inputs.pr_number }}" ]; then


### PR DESCRIPTION
## Summary
- Update iOS workflow to use `PR-{pr_number}-{branch_name}` format when deploying to godot-mobile-deploy-pipeline repository
- Example: PR #989 on branch `feat/optimizations` deploys to `PR-989-feat/optimizations`
- Non-PR builds (main, release) continue to use the branch name as-is

## Test plan
- [x] Trigger iOS build on a PR and verify the deploy branch uses the new format