### PR TITLE
feat: add verification of the nickname when it is changed from the profile

### DIFF
--- a/godot/src/ui/components/auth/lobby.tscn
+++ b/godot/src/ui/components/auth/lobby.tscn
@@ -275,7 +275,6 @@ icon_alignment = 2
 
 [node name="RestoreAndChooseName" type="Control" parent="Main"]
 unique_name_in_owner = true
-visible = false
 layout_mode = 2
 
 [node name="MarginContainer" type="MarginContainer" parent="Main/RestoreAndChooseName"]
@@ -323,8 +322,9 @@ theme_override_constants/separation = 12
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
-advise = "*Avoid using your real name for safety"
+advice = "*Avoid using your real name for safety"
 hint = "Username"
+show_tag = false
 
 [node name="VBoxContainer" type="MarginContainer" parent="Main/RestoreAndChooseName/MarginContainer/VBoxContainer/ChooseNameHead/HBoxContainer"]
 layout_mode = 2
@@ -475,6 +475,7 @@ text = "USE ANOTHER ACCOUNT"
 
 [node name="SignIn" type="Control" parent="Main"]
 unique_name_in_owner = true
+visible = false
 layout_mode = 2
 
 [node name="MarginContainer" type="MarginContainer" parent="Main/SignIn"]

--- a/godot/src/ui/components/change_nick_popup.gd
+++ b/godot/src/ui/components/change_nick_popup.gd
@@ -7,9 +7,9 @@ var new_nickname: String
 @onready var button_cancel: Button = %Button_Cancel
 @onready var button_save: Button = %Button_Save
 @onready var button_claim_name: Button = %Button_ClaimName
-@onready var dcl_text_edit_new_nick: VBoxContainer = %DclTextEdit_NewNick
 @onready var label_tag: Label = %Label_Tag
 @onready var claim_name_container: MarginContainer = %ClaimNameContainer
+@onready var dcl_line_edit: VBoxContainer = %DclLineEdit
 
 
 func _ready():
@@ -23,7 +23,7 @@ func _on_gui_input(event: InputEvent) -> void:
 
 
 func close() -> void:
-	dcl_text_edit_new_nick.text_edit.text = ""
+	dcl_line_edit.line_edit.text = ""
 	hide()
 
 
@@ -32,25 +32,12 @@ func open() -> void:
 	var address = profile.get_ethereum_address()
 	new_nickname = profile.get_name()
 	label_tag.text = "#" + address.substr(address.length() - 4, 4)
-	dcl_text_edit_new_nick.set_text(new_nickname)
-	_check_error()
+	dcl_line_edit.set_text_value(new_nickname)
 	show()
-
-
-func _check_error() -> void:
-	if dcl_text_edit_new_nick.error or dcl_text_edit_new_nick.text_edit.text.length() <= 0:
-		button_save.disabled = true
-	else:
-		button_save.disabled = false
 
 
 func _on_button_new_link_cancel_pressed() -> void:
 	close()
-
-
-func _on_dcl_text_edit_new_nick_dcl_text_edit_changed() -> void:
-	new_nickname = dcl_text_edit_new_nick.text_edit.text
-	_check_error()
 
 
 func _on_button_cancel_pressed() -> void:
@@ -66,3 +53,8 @@ func _on_button_save_pressed() -> void:
 
 func _on_button_claim_name_pressed() -> void:
 	Global.open_url("https://decentraland.org/marketplace/names/claim")
+
+
+func _on_dcl_line_edit_dcl_line_edit_changed() -> void:
+	new_nickname = dcl_line_edit.line_edit.text
+	button_save.disabled = dcl_line_edit.error

--- a/godot/src/ui/components/change_nick_popup.tscn
+++ b/godot/src/ui/components/change_nick_popup.tscn
@@ -68,8 +68,9 @@ layout_mode = 2
 [node name="DclLineEdit" parent="PanelContainer/VBoxContainer/MarginContainer/VBoxContainer/VBoxContainer" instance=ExtResource("3_v0a8f")]
 unique_name_in_owner = true
 layout_mode = 2
-advise = "*Avoid using your real name for safety"
+advice = "*Avoid using your real name for safety"
 hint = "Username"
+show_tag = false
 
 [node name="HBoxContainer2" type="HBoxContainer" parent="PanelContainer/VBoxContainer/MarginContainer/VBoxContainer"]
 custom_minimum_size = Vector2(0, 38)

--- a/godot/src/ui/components/dcl_line_edit.gd
+++ b/godot/src/ui/components/dcl_line_edit.gd
@@ -9,9 +9,10 @@ signal checked_error
 @export var allow_edge_spaces: bool = false
 @export var allow_special_characters: bool = false
 @export var is_optional: bool = false
-@export var advise: String = "Any advice or nothing"
+@export var advice: String = "Any advice or nothing"
 @export var hint: String = "Hint"
 @export var error_color: Color = Color.RED
+@export var show_tag: bool = false
 
 var error: bool = false
 var error_message: String = ""
@@ -19,9 +20,10 @@ var text_value: String = ""
 
 @onready var line_edit: LineEdit = %LineEdit
 @onready var label_length: Label = %Label_Length
-@onready var label_advise: Label = %Label_Advise
+@onready var label_advice: Label = %Label_Advice
 @onready var label_error: RichTextLabel = %Label_Error
 @onready var panel_container_error_border: PanelContainer = %PanelContainer_ErrorBorder
+@onready var label_tag: Label = %Label_Tag
 
 
 func is_alphanumeric_with_spaces(value: String) -> bool:
@@ -82,20 +84,25 @@ func _check_error():
 	label_length.label_settings.font_color = color
 
 	if error:
-		label_error.show()
-		label_advise.hide()
-		label_error.text = error_message
+		if error_message.length() > 0:
+			label_error.show()
+			label_advice.hide()
+			label_error.text = error_message
+		else:
+			label_error.hide()
+			label_advice.show()
 		panel_container_error_border.self_modulate = error_color
 	else:
 		label_error.hide()
-		label_advise.show()
+		label_advice.show()
 		panel_container_error_border.self_modulate = Color.TRANSPARENT
 
 
 func _ready() -> void:
 	line_edit.text_changed.connect(_on_line_edit_text_changed)
-	label_advise.text = advise
+	label_advice.text = advice
 	line_edit.placeholder_text = hint
+	label_tag.visible = show_tag
 	_check_error()
 
 

--- a/godot/src/ui/components/dcl_line_edit.tscn
+++ b/godot/src/ui/components/dcl_line_edit.tscn
@@ -41,6 +41,8 @@ offset_bottom = 109.0
 grow_horizontal = 2
 size_flags_vertical = 0
 script = ExtResource("1_gt5hx")
+advice = null
+show_tag = null
 
 [node name="Control" type="Control" parent="."]
 custom_minimum_size = Vector2(0, 80)
@@ -48,6 +50,7 @@ layout_mode = 2
 
 [node name="PanelContainer_ErrorBorder" type="PanelContainer" parent="Control"]
 unique_name_in_owner = true
+self_modulate = Color(1, 0, 0, 1)
 custom_minimum_size = Vector2(0, 72)
 layout_mode = 1
 anchors_preset = 15
@@ -64,7 +67,7 @@ layout_mode = 2
 size_flags_horizontal = 3
 theme_override_colors/font_color = Color(0.0862745, 0.0823529, 0.0941176, 1)
 theme_override_font_sizes/font_size = 24
-placeholder_text = "Username"
+placeholder_text = "Hint"
 clear_button_enabled = true
 
 [node name="MarginContainer" type="MarginContainer" parent="Control"]
@@ -90,17 +93,17 @@ vertical_alignment = 1
 [node name="HBoxContainer2" type="HBoxContainer" parent="."]
 layout_mode = 2
 
-[node name="Label_Advise" type="Label" parent="HBoxContainer2"]
+[node name="Label_Advice" type="Label" parent="HBoxContainer2"]
 unique_name_in_owner = true
+visible = false
 layout_mode = 2
 size_flags_horizontal = 3
-text = "*Avoid using your real name for safety"
+text = "Any advice or nothing"
 label_settings = SubResource("LabelSettings_uxhe4")
 autowrap_mode = 2
 
 [node name="Label_Error" type="RichTextLabel" parent="HBoxContainer2"]
 unique_name_in_owner = true
-visible = false
 layout_mode = 2
 size_flags_horizontal = 3
 theme_override_colors/default_color = Color(1, 0, 0, 1)
@@ -108,7 +111,6 @@ theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
 theme_override_constants/outline_size = 2
 theme_override_fonts/normal_font = ExtResource("4_v66w7")
 theme_override_font_sizes/normal_font_size = 20
-text = "Error"
 fit_content = true
 autowrap_mode = 2
 


### PR DESCRIPTION
Closes #866

## Overview
A new component, dcl_line_edit, was created that has different checks, error labels, length labels, and saves a true or false error status.

This same component is used in lobby.tscn and change_nick_popup.tscn, so now the verification and style are the same in both.

## Testing Plan:
- [ ] Create a new account and write a nickname. You should not be able to complete the process if the chosen nickname has spaces at the beginning or end, more than 15 characters, or special characters.
- [ ] Open your profile and edit your nickname. You should not be able to complete the process if the chosen nickname has spaces at the beginning or end, more than 15 characters, or special characters.