### PR TITLE
fix: hide log out button

### DIFF
--- a/godot/src/ui/components/settings/settings.tscn
+++ b/godot/src/ui/components/settings/settings.tscn
@@ -861,9 +861,11 @@ theme_override_font_sizes/font_size = 22
 text = "DELETE ACCOUNT"
 
 [node name="Button_LogOut" type="Button" parent="ColorRect_Content/SafeMarginContainer/MarginContainer/ScrollContainer/VBoxContainer/VBoxContainer_Account"]
+visible = false
 custom_minimum_size = Vector2(300, 80)
 layout_mode = 2
 size_flags_horizontal = 0
+focus_mode = 0
 theme = ExtResource("12_sa1v7")
 disabled = true
 text = "LOG OUT"


### PR DESCRIPTION
Closes #1142

The button has not yet been implemented. It could be confusing for users.
It's hide for now.