### PR TITLE
fix: modals close keyboard + mentions open profile

### DIFF
--- a/godot/src/ui/components/chat/chat_message.gd
+++ b/godot/src/ui/components/chat/chat_message.gd
@@ -438,6 +438,8 @@ func _on_url_clicked(meta):
 		_handle_mention_click(mention_str)
 	else:
 		Global.show_url_popup(meta_str)
+	if Global.is_mobile():
+		DisplayServer.virtual_keyboard_hide()
 
 
 func _handle_coordinate_click(coord_str: String):
@@ -463,7 +465,7 @@ func _handle_mention_click(mention_str: String):
 				var avatar_name = avatar.get_avatar_name()
 				if avatar_name == mention_without_at:
 					# Show some kind of user profile or interaction
-					Global.get_explorer()._async_open_profile(avatar.avatar_id)
+					Global.get_explorer()._async_open_profile_by_address(avatar.avatar_id)
 					break
 
 


### PR DESCRIPTION
Closes #1139 

## Summary

This PR addresses two issues:
1. **Virtual Keyboard closure**: When clicking on URLs, mentions, or coordinates in chat messages, the virtual keyboard now properly closes on mobile devices when popups are opened.
2. **Profile opening bug**: Fixed an issue where clicking on mentions in chat messages wasn't opening user profiles correctly.

## Testing

- [x] Verified that virtual keyboard closes when clicking URLs in chat messages on mobile
- [x] Verified that virtual keyboard closes when clicking mentions in chat messages on mobile
- [x] Verified that virtual keyboard closes when clicking coordinates in chat messages on mobile
- [x] Verified that clicking mentions now correctly opens user profiles
- [x] Tested on mobile devices to ensure proper keyboard dismissal behavior