### PR TITLE
feat: hide share button

### DIFF
--- a/godot/src/ui/components/chatbar/chatbar.tscn
+++ b/godot/src/ui/components/chatbar/chatbar.tscn
@@ -66,7 +66,7 @@ icon_alignment = 1
 
 [node name="PanelContainer2" type="PanelContainer" parent="HBoxContainer"]
 unique_name_in_owner = true
-custom_minimum_size = Vector2(120, 0)
+custom_minimum_size = Vector2(66, 0)
 layout_mode = 2
 theme_override_styles/panel = SubResource("StyleBoxFlat_tw2ns")
 
@@ -89,9 +89,10 @@ toggle_mode = true
 button_group = SubResource("ButtonGroup_grvqo")
 icon = ExtResource("3_2fmgn")
 flat = true
-icon_alignment = 2
+icon_alignment = 1
 
 [node name="HudButton_Share" type="Button" parent="HBoxContainer/PanelContainer2/VBoxContainer_Buttons"]
+visible = false
 custom_minimum_size = Vector2(66, 66)
 layout_mode = 2
 size_flags_horizontal = 4


### PR DESCRIPTION
Closes #1174 

This PR hides the Share button. The button will remain hidden until we have universal deep links.