### PR TITLE
fix: hide navbar when account deletion popup is visible

### DIFF
--- a/godot/src/ui/components/menu/account_deletion_popup.gd
+++ b/godot/src/ui/components/menu/account_deletion_popup.gd
@@ -106,3 +106,13 @@ func _async_on_button_cancel_deletion_pressed() -> void:
 	else:
 		printerr("Cancel deletion request failed: ", data.get("error", "Unknown error"))
 		fail_dialog.show()
+
+
+func _on_visibility_changed() -> void:
+	if Global.get_explorer():
+		var navbar = Global.get_explorer().navbar
+		if navbar:
+			if visible:
+				navbar.hide()
+			else:
+				navbar.show()

--- a/godot/src/ui/components/menu/account_deletion_popup.tscn
+++ b/godot/src/ui/components/menu/account_deletion_popup.tscn
@@ -359,6 +359,7 @@ size_flags_horizontal = 3
 script = ExtResource("5_p3g0a")
 hide_on_portrait = true
 
+[connection signal="visibility_changed" from="." to="." method="_on_visibility_changed"]
 [connection signal="pressed" from="MarginContainer/ConfirmationDialog/VBoxContainer/HBoxContainer/Button_ConfirmDeleteAccount" to="." method="_async_on_button_confirm_delete_account_pressed"]
 [connection signal="pressed" from="MarginContainer/ConfirmationDialog/VBoxContainer/HBoxContainer2/Button_CancelDeleteAccount" to="." method="_on_button_cancel_delete_account_pressed"]
 [connection signal="pressed" from="MarginContainer/DoneDialog/VBoxContainer/HBoxContainer/Button_Ok" to="." method="_on_button_ok_pressed"]


### PR DESCRIPTION
Fixes #1144

This PR adds a check for visibility changes in the account deletion popup. When it is displayed and the navbar exists, it hides it. When the popup closes, if the navbar exists, it displays it again.