### PR TITLE
feat: enable low processor mode for lobby/menus

### DIFF
--- a/godot/src/config/graphic_settings.gd
+++ b/godot/src/config/graphic_settings.gd
@@ -84,3 +84,17 @@ static func apply_fps_limit():
 			physics_fps = 60
 
 	Engine.physics_ticks_per_second = physics_fps
+
+
+static func apply_low_processor_mode() -> void:
+	# For lobby/menus - reduce CPU usage
+	OS.low_processor_usage_mode = true
+	DisplayServer.window_set_vsync_mode(DisplayServer.VSYNC_ENABLED)
+	Engine.max_fps = 0  # Let VSync control frame rate
+	Engine.physics_ticks_per_second = 60
+
+
+static func apply_full_processor_mode() -> void:
+	# For world exploration - full performance
+	OS.low_processor_usage_mode = false
+	apply_fps_limit()  # Apply user's configured FPS limit

--- a/godot/src/main.gd
+++ b/godot/src/main.gd
@@ -24,7 +24,7 @@ func start():
 		# Apply basic config
 		var main_window: Window = get_node("/root")
 		GraphicSettings.apply_window_config()
-		GraphicSettings.apply_fps_limit()
+		GraphicSettings.apply_low_processor_mode()
 		main_window.move_to_center()
 		GraphicSettings.connect_global_signal(main_window)
 		GraphicSettings.apply_ui_zoom(main_window)

--- a/godot/src/ui/explorer.gd
+++ b/godot/src/ui/explorer.gd
@@ -102,6 +102,8 @@ func get_params_from_cmd():
 
 
 func _ready():
+	GraphicSettings.apply_full_processor_mode()
+
 	Global.scene_runner.on_change_scene_id.connect(_on_change_scene_id)
 	Global.change_parcel.connect(_on_change_parcel)
 


### PR DESCRIPTION
## Summary
- Enables Godot's `OS.low_processor_mode` with VSync during app startup (lobby, menus) to reduce CPU/battery usage
- When entering the world (explorer.tscn), switches to full performance mode with the user's configured FPS limit

## Changes
- Added `apply_low_processor_mode()` and `apply_full_processor_mode()` functions to `graphic_settings.gd`
- Updated `main.gd` to use low processor mode on startup
- Updated `explorer.gd` to switch to full processor mode when entering the world

## Test plan
- [ ] Run the app and observe CPU usage in lobby vs. in-world
- [ ] Verify FPS counter shows VSync-limited FPS (~60) in lobby
- [ ] Verify FPS switches to configured limit when entering the world