### PR TITLE
fix: double navbar in menu landscape orientation

### DIFF
--- a/godot/src/global.gd
+++ b/godot/src/global.gd
@@ -58,7 +58,6 @@ const TERMS_AND_CONDITIONS_VERSION: int = 1
 const LOCAL_ASSETS_CACHE_VERSION: int = 3
 
 ## Global classes (singleton pattern)
-var is_portrait: bool = true
 
 var raycast_debugger: RaycastDebugger
 
@@ -94,6 +93,8 @@ var deep_link_url: String = ""
 
 var player_camera_node: DclCamera3D
 var session_id: String
+
+var _is_portrait: bool = true
 
 # Cached reference to SafeAreaPresets (loaded dynamically to avoid export issues)
 var _safe_area_presets: GDScript = null
@@ -538,11 +539,11 @@ func set_orientation_landscape():
 	else:
 		get_window().size = Vector2i(1280, 720)
 		get_window().move_to_center()
-	is_portrait = false
+	_is_portrait = false
 
 
 func is_orientation_portrait() -> bool:
-	return is_portrait
+	return _is_portrait
 
 
 func set_orientation_portrait():
@@ -559,7 +560,7 @@ func set_orientation_portrait():
 	else:
 		get_window().size = Vector2i(720, 1280)
 		get_window().move_to_center()
-	is_portrait = true
+	_is_portrait = true
 
 
 func teleport_to(parcel_position: Vector2i, new_realm: String):

--- a/godot/src/ui/components/utils/clean_orientation.gd
+++ b/godot/src/ui/components/utils/clean_orientation.gd
@@ -9,10 +9,10 @@ func _ready() -> void:
 
 
 func _check_orientation_and_clean() -> void:
-	if clean_on_landscape and !Global.is_portrait:
+	if clean_on_landscape and !Global.is_orientation_portrait():
 		queue_free()
 		return
 
-	if clean_on_portrait and Global.is_portrait:
+	if clean_on_portrait and Global.is_orientation_portrait():
 		queue_free()
 		return


### PR DESCRIPTION
Fixes #1239 

We are storing the orientation in a global variable when setting it. This way, we can check that variable instead of checking the screen dimensions when we try to delete a component that should only be in one orientation.