### PR TITLE
fix: ui scrolling bugs

### DIFF
--- a/godot/assets/shaders/dcl_unlit_alpha.gdshader.uid
+++ b/godot/assets/shaders/dcl_unlit_alpha.gdshader.uid
@@ -1,0 +1,1 @@
+uid://fe6ila2no4x2

--- a/godot/src/ui/components/chat/chat_message.tscn
+++ b/godot/src/ui/components/chat/chat_message.tscn
@@ -15,11 +15,11 @@ corner_radius_top_right = 12
 corner_radius_bottom_right = 12
 corner_radius_bottom_left = 12
 
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_kjivd"]
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_q5i5r"]
 bg_color = Color(1, 1, 1, 0)
 
-[sub_resource type="Theme" id="Theme_pb0jp"]
-LinkButton/styles/normal = SubResource("StyleBoxFlat_kjivd")
+[sub_resource type="Theme" id="Theme_rb0rw"]
+LinkButton/styles/normal = SubResource("StyleBoxFlat_q5i5r")
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_fq752"]
 bg_color = Color(0.0862745, 0.0823529, 0.0941176, 0.784314)
@@ -28,11 +28,11 @@ corner_radius_top_right = 5
 corner_radius_bottom_right = 5
 corner_radius_bottom_left = 5
 
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_h5jj7"]
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_kjivd"]
 bg_color = Color(1, 1, 1, 0)
 
-[sub_resource type="Theme" id="Theme_a6tuv"]
-LinkButton/styles/normal = SubResource("StyleBoxFlat_h5jj7")
+[sub_resource type="Theme" id="Theme_pb0jp"]
+LinkButton/styles/normal = SubResource("StyleBoxFlat_kjivd")
 
 [node name="ChatMessage" type="VBoxContainer"]
 offset_right = 237.0
@@ -58,6 +58,7 @@ unique_name_in_owner = true
 custom_minimum_size = Vector2(28, 28)
 layout_mode = 2
 size_flags_vertical = 8
+mouse_filter = 1
 picture_size = 3
 
 [node name="PanelContainer_Extended" type="PanelContainer" parent="MarginContainer/HBoxContainer_ExtendedChat"]
@@ -141,7 +142,8 @@ expand_mode = 1
 [node name="RichTextLabel_Message" type="RichTextLabel" parent="MarginContainer/HBoxContainer_ExtendedChat/PanelContainer_Extended/MarginContainer/VBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2
-theme = SubResource("Theme_pb0jp")
+mouse_filter = 1
+theme = SubResource("Theme_rb0rw")
 theme_override_colors/default_color = Color(1, 1, 1, 1)
 theme_override_fonts/normal_font = ExtResource("5_q5i5r")
 theme_override_fonts/bold_font = ExtResource("6_rb0rw")
@@ -189,6 +191,7 @@ unique_name_in_owner = true
 custom_minimum_size = Vector2(28, 28)
 layout_mode = 2
 size_flags_vertical = 8
+mouse_filter = 1
 picture_size = 3
 
 [node name="PanelContainer_Compact" type="PanelContainer" parent="MarginContainer/HBoxContainer_CompactChat"]
@@ -197,6 +200,7 @@ custom_minimum_size = Vector2(109, 0)
 layout_mode = 2
 size_flags_horizontal = 4
 size_flags_vertical = 4
+mouse_filter = 1
 theme_override_styles/panel = SubResource("StyleBoxFlat_fq752")
 
 [node name="MarginContainer" type="MarginContainer" parent="MarginContainer/HBoxContainer_CompactChat/PanelContainer_Compact"]
@@ -214,7 +218,8 @@ layout_mode = 2
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
-theme = SubResource("Theme_a6tuv")
+mouse_filter = 1
+theme = SubResource("Theme_pb0jp")
 theme_override_colors/default_color = Color(1, 1, 1, 1)
 theme_override_fonts/normal_font = ExtResource("5_q5i5r")
 theme_override_fonts/bold_font = ExtResource("6_rb0rw")

--- a/godot/src/ui/components/custom_touch_button/custom_touch_button.gd
+++ b/godot/src/ui/components/custom_touch_button/custom_touch_button.gd
@@ -1,7 +1,11 @@
 class_name CustomTouchButton
 extends Button
 
+const DRAG_THRESHOLD = 10.0
+
 var is_pressing = false
+var press_position: Vector2 = Vector2.ZERO
+var is_dragging = false
 
 
 func _init():
@@ -19,9 +23,21 @@ func _on_gui_input(event):
 	if event is InputEventScreenTouch:
 		if event.pressed:
 			is_pressing = true
-		elif is_pressing and not event.pressed:
+			is_dragging = false
+			press_position = get_global_mouse_position()
+		elif is_pressing:
 			is_pressing = false
-			var inside = get_global_rect().has_point(get_global_mouse_position())
+
+			var release_position = get_global_mouse_position()
+
+			# Check if finger moved beyond threshold (scroll gesture)
+			if press_position.distance_to(release_position) > DRAG_THRESHOLD:
+				is_dragging = true
+
+			if is_dragging:
+				return
+
+			var inside = get_global_rect().has_point(release_position)
 			if not inside:
 				return
 

--- a/godot/src/ui/components/emotes/emote_square_item.tscn
+++ b/godot/src/ui/components/emotes/emote_square_item.tscn
@@ -64,6 +64,7 @@ custom_minimum_size = Vector2(118, 118)
 offset_right = 118.0
 offset_bottom = 118.0
 pivot_offset = Vector2(-38, 215)
+mouse_filter = 1
 toggle_mode = true
 script = ExtResource("1_hlkld")
 


### PR DESCRIPTION
## Summary

  - Fix `CustomTouchButton` to distinguish between scroll gestures and button taps using drag distance threshold
  - Set `mouse_filter = 1` (MOUSE_FILTER_PASS) on chat message interactive elements to enable click interactions
  - Set `mouse_filter = 1` on emote square items for consistent touch handling

  ## Description

  ### CustomTouchButton scroll detection

  `CustomTouchButton` was triggering button presses when users tried to scroll through lists (e.g., wearables in the backpack). This happened because the button only checked if the release position was inside its bounds, without considering whether the finger had moved (indicating a scroll intent).

  **Fix:** Track the press position using global screen coordinates and compare with release position. If the distance exceeds `DRAG_THRESHOLD` (10 pixels), treat it as a scroll gesture and skip the button toggle.

  Using `get_global_mouse_position()` instead of `event.position` is critical because `event.position` is in local coordinates - when the ScrollContainer scrolls, the button moves with the content, making the relative position appear unchanged even though the finger moved on screen.

  ### Chat message interactions

  Several controls in `chat_message.tscn` had default `mouse_filter` (MOUSE_FILTER_STOP) which blocked click events from reaching interactive elements like profile pictures and message links.

  ### Emote square item

  Added explicit `mouse_filter = 1` for consistent touch event handling.

  Closes #1234
  Closes #1235
  Closes #1137

  ## Test plan

  - [ ] Open backpack and scroll through wearables list - items should not get selected while scrolling
  - [ ] Tap on a wearable item without dragging - item should be selected
  - [ ] ~~In chat, tap on a user's profile picture - should open their profile~~ (not working, unrelated issue)
  - [ ] In chat, tap on links in messages - should trigger link action
  - [ ] Open emote edit panel and scroll through emotes - emotes should not be selected while scrolling
  - [ ] Tap on an emote - should play the emote