### PR TITLE
fix: put debug panel into a safe container

### DIFF
--- a/godot/src/ui/components/debug_panel/debug_panel.gd
+++ b/godot/src/ui/components/debug_panel/debug_panel.gd
@@ -22,8 +22,8 @@ var icon_visible: Texture2D = preload(
 	"res://src/ui/components/debug_panel/icons/GuiVisibilityVisible.svg"
 )
 
-@onready var expression_text_edit = $TabContainer_DebugPanel/Expression/TextEdit
-@onready var expression_label = $TabContainer_DebugPanel/Expression/Label
+@onready var text_edit_expression: TextEdit = %TextEdit_Expression
+@onready var label_expression: TextEdit = %Label_Expression
 
 @onready var tree_console: Tree = %Tree_Console
 @onready var tab_container_debug_panel: TabContainer = %TabContainer_DebugPanel
@@ -31,7 +31,7 @@ var icon_visible: Texture2D = preload(
 @onready var popup_menu: PopupMenu = %PopupMenu
 @onready var button_debug_js = %Button_DebugJS
 @onready var button_open_source = %Button_OpenSource
-@onready var label_debug_info = $"TabContainer_DebugPanel/Misc&Debugger/Label_DebugInfo"
+@onready var label_debug_info: Label = %Label_DebugInfo
 
 
 func _ready():
@@ -179,18 +179,18 @@ func _on_button_copy_pressed():
 
 func _on_text_edit_text_changed():
 	var expression = Expression.new()
-	var err = expression.parse(expression_text_edit.text, ["Global"])
+	var err = expression.parse(text_edit_expression.text, ["Global"])
 
 	if err != OK:
-		expression_label.text = "Parse failed: " + expression.get_error_text()
+		label_expression.text = "Parse failed: " + expression.get_error_text()
 		return
 
 	var result = expression.execute([Global], self)
 	if expression.has_execute_failed():
-		expression_label.text = "Execution failed: " + expression.get_error_text()
+		label_expression.text = "Execution failed: " + expression.get_error_text()
 		return
 
-	expression_label.text = "Ok: " + str(result)
+	label_expression.text = "Ok: " + str(result)
 
 
 func _on_tab_container_debug_panel_visibility_changed():

--- a/godot/src/ui/components/debug_panel/debug_panel.tscn
+++ b/godot/src/ui/components/debug_panel/debug_panel.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=7 format=3 uid="uid://dua04n3geh0yf"]
+[gd_scene load_steps=8 format=3 uid="uid://dua04n3geh0yf"]
 
 [ext_resource type="Theme" uid="uid://yt0vgau51udk" path="res://src/ui/components/debug_panel/dark_theme/Dark.theme" id="1_c8oen"]
 [ext_resource type="Script" uid="uid://csxkemel3hrdv" path="res://src/ui/components/debug_panel/debug_panel.gd" id="2_juhlr"]
@@ -6,50 +6,72 @@
 [ext_resource type="Texture2D" uid="uid://ckn18yn0v8tsa" path="res://src/ui/components/debug_panel/icons/Clear.svg" id="4_k7442"]
 [ext_resource type="Texture2D" uid="uid://cqwsvinsujxri" path="res://src/ui/components/debug_panel/icons/ActionCopy.svg" id="5_0aohs"]
 [ext_resource type="Texture2D" uid="uid://c0x4ssitmbcrg" path="res://src/ui/components/debug_panel/icons/GuiVisibilityHidden.svg" id="5_34smo"]
+[ext_resource type="Theme" uid="uid://bn7q4ap7m5gdu" path="res://assets/themes/dcl_theme.tres" id="7_nlnrl"]
 
 [node name="DebugPanel" type="Control"]
 custom_minimum_size = Vector2(500, 300)
 layout_mode = 3
-anchors_preset = 3
-anchor_left = 1.0
-anchor_top = 1.0
+anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
-offset_left = -505.0
-offset_top = -305.0
-offset_right = -5.0
-offset_bottom = -5.0
-grow_horizontal = 0
-grow_vertical = 0
+grow_horizontal = 2
+grow_vertical = 2
 mouse_filter = 2
 theme = ExtResource("1_c8oen")
 script = ExtResource("2_juhlr")
 
-[node name="TabContainer_DebugPanel" type="TabContainer" parent="."]
+[node name="PopupMenu" type="PopupMenu" parent="."]
 unique_name_in_owner = true
-custom_minimum_size = Vector2(500, 250)
+oversampling_override = 1.0
+
+[node name="MarginContainer" type="MarginContainer" parent="."]
 layout_mode = 1
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
+mouse_filter = 2
+theme_override_constants/margin_right = 65
+theme_override_constants/margin_bottom = 20
+
+[node name="Control_Panel" type="Control" parent="MarginContainer"]
+custom_minimum_size = Vector2(500, 350)
+layout_mode = 2
+size_flags_horizontal = 8
+size_flags_vertical = 8
+mouse_filter = 2
+
+[node name="TabContainer_DebugPanel" type="TabContainer" parent="MarginContainer/Control_Panel"]
+unique_name_in_owner = true
+custom_minimum_size = Vector2(500, 250)
+layout_mode = 1
+anchors_preset = 3
+anchor_left = 1.0
+anchor_top = 1.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = -500.0
+offset_top = -250.0
+grow_horizontal = 0
+grow_vertical = 0
 theme = ExtResource("1_c8oen")
 current_tab = 2
 tab_focus_mode = 0
 
-[node name="Console" type="VBoxContainer" parent="TabContainer_DebugPanel"]
+[node name="Console" type="VBoxContainer" parent="MarginContainer/Control_Panel/TabContainer_DebugPanel"]
 visible = false
 layout_mode = 2
+metadata/_tab_index = 0
 
-[node name="HBoxContainer" type="HBoxContainer" parent="TabContainer_DebugPanel/Console"]
+[node name="HBoxContainer" type="HBoxContainer" parent="MarginContainer/Control_Panel/TabContainer_DebugPanel/Console"]
 layout_mode = 2
 
-[node name="Label" type="Label" parent="TabContainer_DebugPanel/Console/HBoxContainer"]
+[node name="Label" type="Label" parent="MarginContainer/Control_Panel/TabContainer_DebugPanel/Console/HBoxContainer"]
 layout_mode = 2
 text = "Filter:"
 
-[node name="LineEdit_Filter" type="LineEdit" parent="TabContainer_DebugPanel/Console/HBoxContainer"]
+[node name="LineEdit_Filter" type="LineEdit" parent="MarginContainer/Control_Panel/TabContainer_DebugPanel/Console/HBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
@@ -57,26 +79,26 @@ focus_mode = 1
 placeholder_text = "Filter Messages"
 right_icon = ExtResource("3_nth2r")
 
-[node name="Button_Clear" type="Button" parent="TabContainer_DebugPanel/Console/HBoxContainer"]
+[node name="Button_Clear" type="Button" parent="MarginContainer/Control_Panel/TabContainer_DebugPanel/Console/HBoxContainer"]
 layout_mode = 2
 focus_mode = 0
 icon = ExtResource("4_k7442")
 
-[node name="Button_Copy" type="Button" parent="TabContainer_DebugPanel/Console/HBoxContainer"]
+[node name="Button_Copy" type="Button" parent="MarginContainer/Control_Panel/TabContainer_DebugPanel/Console/HBoxContainer"]
 layout_mode = 2
 focus_mode = 0
 icon = ExtResource("5_0aohs")
 
-[node name="Tree_Console" type="Tree" parent="TabContainer_DebugPanel/Console"]
+[node name="Tree_Console" type="Tree" parent="MarginContainer/Control_Panel/TabContainer_DebugPanel/Console"]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_vertical = 3
 focus_mode = 1
 theme_override_constants/scroll_speed = 100
-theme_override_constants/scrollbar_margin_left = 5
 theme_override_constants/scrollbar_margin_top = 5
 theme_override_constants/scrollbar_margin_right = 5
 theme_override_constants/scrollbar_margin_bottom = 5
+theme_override_constants/scrollbar_margin_left = 5
 theme_override_constants/scrollbar_h_separation = 5
 theme_override_constants/scrollbar_v_separation = 5
 theme_override_font_sizes/font_size = 12
@@ -86,72 +108,81 @@ allow_rmb_select = true
 hide_root = true
 select_mode = 1
 
-[node name="Expression" type="VBoxContainer" parent="TabContainer_DebugPanel"]
+[node name="Expression" type="VBoxContainer" parent="MarginContainer/Control_Panel/TabContainer_DebugPanel"]
 visible = false
 layout_mode = 2
+metadata/_tab_index = 1
 
-[node name="TextEdit" type="TextEdit" parent="TabContainer_DebugPanel/Expression"]
+[node name="TextEdit_Expression" type="TextEdit" parent="MarginContainer/Control_Panel/TabContainer_DebugPanel/Expression"]
+unique_name_in_owner = true
 custom_minimum_size = Vector2(0, 100)
 layout_mode = 2
 
-[node name="Label" type="TextEdit" parent="TabContainer_DebugPanel/Expression"]
+[node name="Label_Expression" type="TextEdit" parent="MarginContainer/Control_Panel/TabContainer_DebugPanel/Expression"]
+unique_name_in_owner = true
 custom_minimum_size = Vector2(0, 100)
 layout_mode = 2
 
-[node name="Misc&Debugger" type="VBoxContainer" parent="TabContainer_DebugPanel"]
+[node name="Misc&Debugger" type="VBoxContainer" parent="MarginContainer/Control_Panel/TabContainer_DebugPanel"]
 layout_mode = 2
+metadata/_tab_index = 2
 
-[node name="Button_ShowNetwork" type="Button" parent="TabContainer_DebugPanel/Misc&Debugger"]
+[node name="Button_ShowNetwork" type="Button" parent="MarginContainer/Control_Panel/TabContainer_DebugPanel/Misc&Debugger"]
 unique_name_in_owner = true
 layout_mode = 2
 focus_mode = 0
 text = "Open Network Inpector"
 
-[node name="Button_DebugJS" type="Button" parent="TabContainer_DebugPanel/Misc&Debugger"]
+[node name="Button_DebugJS" type="Button" parent="MarginContainer/Control_Panel/TabContainer_DebugPanel/Misc&Debugger"]
 unique_name_in_owner = true
 layout_mode = 2
 focus_mode = 0
 text = "JS Debugger not available"
 
-[node name="Button_OpenSource" type="Button" parent="TabContainer_DebugPanel/Misc&Debugger"]
+[node name="Button_OpenSource" type="Button" parent="MarginContainer/Control_Panel/TabContainer_DebugPanel/Misc&Debugger"]
 unique_name_in_owner = true
 layout_mode = 2
 focus_mode = 0
 text = "Open Scene Source Code"
 
-[node name="Label_DebugInfo" type="Label" parent="TabContainer_DebugPanel/Misc&Debugger"]
+[node name="Label_DebugInfo" type="Label" parent="MarginContainer/Control_Panel/TabContainer_DebugPanel/Misc&Debugger"]
+unique_name_in_owner = true
 visible = false
 layout_mode = 2
 text = "Open chromium browser with url chrome://inspect and pick the scene debugger."
 
-[node name="Button_ShowHide" type="Button" parent="."]
-unique_name_in_owner = true
+[node name="MarginContainer2" type="MarginContainer" parent="."]
 layout_mode = 1
-anchors_preset = 3
-anchor_left = 1.0
-anchor_top = 1.0
+anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
-offset_left = -101.0
-offset_top = -22.0
-offset_bottom = 3.0
-grow_horizontal = 0
-grow_vertical = 0
+grow_horizontal = 2
+grow_vertical = 2
+size_flags_horizontal = 8
+size_flags_vertical = 0
+mouse_filter = 2
+theme_override_constants/margin_top = 25
+theme_override_constants/margin_right = 120
+
+[node name="Button_ShowHide" type="Button" parent="MarginContainer2"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 8
+size_flags_vertical = 0
 focus_mode = 0
+theme = ExtResource("7_nlnrl")
+theme_type_variation = &"SecondaryLittle"
 text = "Debug Panel"
 icon = ExtResource("5_34smo")
 
-[node name="PopupMenu" type="PopupMenu" parent="."]
-unique_name_in_owner = true
-
-[connection signal="visibility_changed" from="TabContainer_DebugPanel" to="." method="_on_tab_container_debug_panel_visibility_changed"]
-[connection signal="text_changed" from="TabContainer_DebugPanel/Console/HBoxContainer/LineEdit_Filter" to="." method="_on_line_edit_filter_text_changed"]
-[connection signal="pressed" from="TabContainer_DebugPanel/Console/HBoxContainer/Button_Clear" to="." method="_on_button_clear_pressed"]
-[connection signal="pressed" from="TabContainer_DebugPanel/Console/HBoxContainer/Button_Copy" to="." method="_on_button_copy_pressed"]
-[connection signal="item_mouse_selected" from="TabContainer_DebugPanel/Console/Tree_Console" to="." method="_on_tree_console_item_mouse_selected"]
-[connection signal="text_changed" from="TabContainer_DebugPanel/Expression/TextEdit" to="." method="_on_text_edit_text_changed"]
-[connection signal="pressed" from="TabContainer_DebugPanel/Misc&Debugger/Button_ShowNetwork" to="." method="_on_button_show_network_pressed"]
-[connection signal="pressed" from="TabContainer_DebugPanel/Misc&Debugger/Button_DebugJS" to="." method="_on_button_debug_js_pressed"]
-[connection signal="pressed" from="TabContainer_DebugPanel/Misc&Debugger/Button_OpenSource" to="." method="_on_button_open_source_pressed"]
-[connection signal="pressed" from="Button_ShowHide" to="." method="_on_button_show_hide_pressed"]
 [connection signal="index_pressed" from="PopupMenu" to="." method="_on_popup_menu_index_pressed"]
+[connection signal="visibility_changed" from="MarginContainer/Control_Panel/TabContainer_DebugPanel" to="." method="_on_tab_container_debug_panel_visibility_changed"]
+[connection signal="text_changed" from="MarginContainer/Control_Panel/TabContainer_DebugPanel/Console/HBoxContainer/LineEdit_Filter" to="." method="_on_line_edit_filter_text_changed"]
+[connection signal="pressed" from="MarginContainer/Control_Panel/TabContainer_DebugPanel/Console/HBoxContainer/Button_Clear" to="." method="_on_button_clear_pressed"]
+[connection signal="pressed" from="MarginContainer/Control_Panel/TabContainer_DebugPanel/Console/HBoxContainer/Button_Copy" to="." method="_on_button_copy_pressed"]
+[connection signal="item_mouse_selected" from="MarginContainer/Control_Panel/TabContainer_DebugPanel/Console/Tree_Console" to="." method="_on_tree_console_item_mouse_selected"]
+[connection signal="text_changed" from="MarginContainer/Control_Panel/TabContainer_DebugPanel/Expression/TextEdit_Expression" to="." method="_on_text_edit_text_changed"]
+[connection signal="pressed" from="MarginContainer/Control_Panel/TabContainer_DebugPanel/Misc&Debugger/Button_ShowNetwork" to="." method="_on_button_show_network_pressed"]
+[connection signal="pressed" from="MarginContainer/Control_Panel/TabContainer_DebugPanel/Misc&Debugger/Button_DebugJS" to="." method="_on_button_debug_js_pressed"]
+[connection signal="pressed" from="MarginContainer/Control_Panel/TabContainer_DebugPanel/Misc&Debugger/Button_OpenSource" to="." method="_on_button_open_source_pressed"]
+[connection signal="pressed" from="MarginContainer2/Button_ShowHide" to="." method="_on_button_show_hide_pressed"]

--- a/godot/src/ui/explorer.gd
+++ b/godot/src/ui/explorer.gd
@@ -24,6 +24,7 @@ var _pending_notification_toast: Dictionary = {}  # Store notification waiting t
 
 @onready var ui_root: Control = %UI
 @onready var ui_safe_area: Control = %SceneUIContainer
+@onready var safe_margin_container_debug: SafeMarginContainer = %SafeMarginContainerDebug
 
 @onready var warning_messages = %WarningMessages
 @onready var label_crosshair = %Label_Crosshair
@@ -589,11 +590,10 @@ func _on_control_menu_request_debug_panel(enabled):
 	if enabled:
 		if not is_instance_valid(debug_panel):
 			debug_panel = load("res://src/ui/components/debug_panel/debug_panel.tscn").instantiate()
-			ui_root.add_child(debug_panel)
-			ui_root.move_child(debug_panel, control_menu.get_index() - 1)
+			safe_margin_container_debug.add_child(debug_panel)
 	else:
 		if is_instance_valid(debug_panel):
-			ui_root.remove_child(debug_panel)
+			safe_margin_container_debug.remove_child(debug_panel)
 			debug_panel.queue_free()
 			debug_panel = null
 

--- a/godot/src/ui/explorer.tscn
+++ b/godot/src/ui/explorer.tscn
@@ -376,11 +376,6 @@ offset_top = -140.0
 offset_right = 180.0
 offset_bottom = 140.0
 
-[node name="Loading" parent="UI" instance=ExtResource("17_0blod")]
-unique_name_in_owner = true
-visible = false
-layout_mode = 1
-
 [node name="RecordingNotification" parent="UI" instance=ExtResource("20_uf6rv")]
 layout_mode = 1
 anchors_preset = 7
@@ -411,6 +406,24 @@ visible = false
 layout_mode = 1
 
 [node name="JumpInPopup" parent="UI" instance=ExtResource("28_jump_in_popup")]
+unique_name_in_owner = true
+visible = false
+layout_mode = 1
+
+[node name="SafeMarginContainerDebug" type="MarginContainer" parent="UI"]
+unique_name_in_owner = true
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+mouse_filter = 2
+script = ExtResource("5_c8ksg")
+use_top = false
+use_bottom = false
+
+[node name="Loading" parent="UI" instance=ExtResource("17_0blod")]
 unique_name_in_owner = true
 visible = false
 layout_mode = 1


### PR DESCRIPTION
Fixes #1187 

This PR puts the debug panel into a safe container, also positions it in the upper right to be seen with the virtual keyboard open

<img width="2340" height="1080" alt="image" src="https://github.com/user-attachments/assets/4bebd434-d782-47f1-b850-391632633d88" />

<img width="2340" height="1080" alt="image" src="https://github.com/user-attachments/assets/5cc6dd8c-c18c-4c89-b40a-f00e375d8aeb" />
