### PR TITLE
feat: add version reporting via LiveKit metadata

### DIFF
--- a/godot/src/decentraland_components/avatar/avatar.gd
+++ b/godot/src/decentraland_components/avatar/avatar.gd
@@ -759,6 +759,10 @@ func _on_timer_hide_mic_timeout():
 	nickname_ui.mic_enabled = false
 
 
+func set_client_version(version: String):
+	nickname_ui.client_version = version
+
+
 func _play_emote_audio(file_hash: String):
 	emote_controller.play_emote_audio(file_hash)
 

--- a/godot/src/decentraland_components/nickname_ui.gd
+++ b/godot/src/decentraland_components/nickname_ui.gd
@@ -49,6 +49,14 @@ var send_message_action = func(): async_show_message.bind(send_message).call()
 			return
 		nickname_label.add_theme_color_override("font_color", nickname_color)
 
+@export var client_version := "":
+	set(value):
+		client_version = value
+		if !is_inside_tree():
+			return
+		version_label.visible = !client_version.is_empty()
+		version_label.text = client_version
+
 var message_tween: Tween
 
 @onready var mic_enabled_icon = %MicEnabled
@@ -58,6 +66,7 @@ var message_tween: Tween
 @onready var hash_container = %Hash
 @onready var checkmark_container = %ClaimedCheckmark
 @onready var message_clip = %MessageClip
+@onready var version_label = %VersionLabel
 
 
 func create_message_container(message: String):

--- a/godot/src/decentraland_components/nickname_ui.tscn
+++ b/godot/src/decentraland_components/nickname_ui.tscn
@@ -103,6 +103,15 @@ texture = ExtResource("3_tj4hi")
 expand_mode = 2
 stretch_mode = 4
 
+[node name="VersionLabel" type="Label" parent="MarginContainer/VBoxContainer"]
+unique_name_in_owner = true
+visible = false
+layout_mode = 2
+theme_override_colors/font_color = Color(0.5, 0.5, 0.5, 1)
+theme_override_fonts/font = ExtResource("4_wgh2x")
+theme_override_font_sizes/font_size = 30
+horizontal_alignment = 1
+
 [node name="MessageClip" type="Control" parent="MarginContainer/VBoxContainer"]
 unique_name_in_owner = true
 clip_contents = true

--- a/lib/src/avatars/avatar_scene.rs
+++ b/lib/src/avatars/avatar_scene.rs
@@ -358,6 +358,20 @@ impl AvatarScene {
     pub fn update_dcl_avatar_by_alias(&mut self, alias: u32, profile: Gd<DclUserProfile>) {
         self.update_avatar_by_alias(alias, &profile.bind().inner);
     }
+
+    #[func]
+    pub fn set_avatar_version_by_address(&mut self, address: GString, version: GString) {
+        let address_str = address.to_string();
+        if let Some(h160) = address_str.as_h160() {
+            if let Some(alias) = self.avatar_address.get(&h160) {
+                if let Some(entity_id) = self.avatar_entity.get(alias) {
+                    if let Some(avatar) = self.avatar_godot_scene.get_mut(entity_id) {
+                        avatar.call("set_client_version", &[version.to_variant()]);
+                    }
+                }
+            }
+        }
+    }
 }
 
 impl AvatarScene {


### PR DESCRIPTION
## Summary
- Set participant metadata (`dcl_version`, `agent`, `platform`) on every LiveKit room connection
- Display version label under avatar nickname for non-production builds (staging/dev)
- Handle metadata from both existing participants (on room join) and new joiners (via ParticipantMetadataChanged event)

## Changes
- **livekit.rs**: Set metadata on connection, handle existing participants' metadata in Connected event, handle ParticipantMetadataChanged event
- **message_processor.rs**: Add PeerMetadata message type, store peer_version in Peer struct, update avatar version display (only for non-production)
- **avatar_scene.rs**: Add `set_avatar_version_by_address` method to propagate version to GDScript
- **nickname_ui.gd/tscn**: Add version label property and UI element
- **avatar.gd**: Add `set_client_version` method to wire version to nickname UI

## Test plan
- [ ] Build staging version and connect two clients to same realm
- [ ] Verify version appears under remote avatar's nickname
- [ ] Test with one staging + one production client (version should only show on staging client's view)
- [ ] Verify version shows for players already in the room when you join