### PR TITLE
fix: coverage timing out by handling the lazy-loaded settings panel in explorer

### DIFF
--- a/godot/src/ui/explorer.gd
+++ b/godot/src/ui/explorer.gd
@@ -226,7 +226,8 @@ func _ready():
 
 	if cmd_realm != null:
 		Global.realm.async_set_realm(cmd_realm)
-		control_menu.control_settings.set_preview_url(cmd_realm)
+		if control_menu.control_settings.instance != null:
+			control_menu.control_settings.instance.set_preview_url(cmd_realm)
 	else:
 		if Global.get_config().last_realm_joined.is_empty():
 			Global.realm.async_set_realm(


### PR DESCRIPTION
## Summary
- Fixes coverage CI workflow timeout caused by lazy loading PR (#1233)
- `control_settings` is now wrapped in `PlaceholderManager` which doesn't have `set_preview_url`
- Scene tests with `--realm` argument were failing silently and hanging for 53+ minutes

## Test plan
- [ ] Run `cargo run -- coverage --dev` locally to verify it completes
- [ ] CI coverage workflow should complete within ~15-20 minutes instead of timing out at 60 minutes