### PR TITLE
feat: add nearby players count on social panel

### DIFF
--- a/godot/src/ui/components/friends/friends_panel.gd
+++ b/godot/src/ui/components/friends/friends_panel.gd
@@ -78,6 +78,7 @@ func _ready() -> void:
 	request_list.size_changed.connect(_update_badge_visibility_on_navbar)
 	online_list.size_changed.connect(_update_dropdown_visibility)
 	offline_list.size_changed.connect(_update_dropdown_visibility)
+	nearby_list.size_changed.connect(_on_nearby_list_size_changed)
 
 	# Connect to error signals
 	request_list.load_error.connect(_on_load_error)
@@ -132,6 +133,7 @@ func _input(event: InputEvent) -> void:
 			Global.explorer_release_focus()
 
 
+## Opens the friends panel
 func show_panel_on_friends_tab() -> void:
 	show()
 	_load_unloaded_items()
@@ -570,6 +572,19 @@ func _check_blocked_list_size() -> void:
 
 func _on_blocked_list_size_changed() -> void:
 	_check_blocked_list_size()
+
+
+## Updates NEARBY users count.
+## If the amount is 0 don't show counter.
+## If amount is > 99 show "99+".
+## Else show the amount from list_size.
+func _on_nearby_list_size_changed() -> void:
+	var nearby_text := tr("NEARBY")
+	if nearby_list.list_size > 99:
+		nearby_text = "%s (99+)" % nearby_text
+	elif nearby_list.list_size > 0:
+		nearby_text = "%s (%d)" % [nearby_text, nearby_list.list_size]
+	button_nearby.text = nearby_text
 
 
 func _on_timer_timeout() -> void:


### PR DESCRIPTION
## Summary
  - Displays the count of nearby players on the NEARBY tab button in the social panel
  - Shows no counter when there are 0 nearby players
  - Shows "(99+)" when there are more than 99 nearby players
  - Shows the exact count "(N)" for 1-99 nearby players

<img width="654" height="716" alt="imagen" src="https://github.com/user-attachments/assets/dda08664-8a3a-472d-ab9c-7072d068f0bf" />

  Closes #1138

  ## Test plan
  - [ ] Open the social panel and switch to the NEARBY tab
  - [ ] Verify the button shows just "NEARBY" when no players are nearby
  - [ ] Verify the button shows "NEARBY (N)" when there are 1-99 players nearby
  - [ ] Verify the button shows "NEARBY (99+)" when there are more than 99 players nearby