### PR TITLE
fix: await purge_file promises before fetching script in preview mode

### DIFF
--- a/godot/src/logic/scene_fetcher.gd
+++ b/godot/src/logic/scene_fetcher.gd
@@ -909,9 +909,12 @@ func async_load_scene(
 	if _purge_cache_on_first_load:
 		_purge_cache_on_first_load = false
 		var files: PackedStringArray = content_mapping.get_files()
+		var purge_promises: Array = []
 		for file_path in files:
 			var file_hash = content_mapping.get_hash(file_path)
-			Global.content_provider.purge_file(file_hash)
+			purge_promises.push_back(Global.content_provider.purge_file(file_hash))
+		# Await all purge operations to complete before fetching
+		await PromiseUtils.async_all(purge_promises)
 
 	var local_main_js_path: String = ""
 	var script_promise: Promise = null


### PR DESCRIPTION
## Summary
- Fixed race condition in preview mode that caused ~50% failure rate when loading scenes
- `purge_file()` calls now properly awaited using `async_all()` before `fetch_file()` is called

## Problem
When opening preview mode, there was an intermittent "Failed to download file" error for script content. The root cause was that `purge_file()` returns a Promise and spawns an async Tokio task to delete files, but these promises were being ignored. This meant `fetch_file()` could start while files were still being deleted.

## Solution
Collect all purge promises and await them with `PromiseUtils.async_all()` before proceeding with the script fetch.

## Test plan
- [x] Run preview mode multiple times (10+ attempts) and verify consistent success:
  ```bash
  cargo run -- run -- --skip-lobby --emulate-ios --fake-deeplink "decentraland://open?preview=http://192.168.18.214:8000&position=0%2C0"
  ```
- [x] Verify hot-reload still works (modify scene, see changes)