### PR TITLE
fix: implement shadow distance optimization

### DIFF
--- a/godot/assets/environment/environment_selector.gd
+++ b/godot/assets/environment/environment_selector.gd
@@ -53,9 +53,13 @@ func set_shadow(shadow_quality: int):
 			sky.main_light.shadow_enabled = true
 			# Use base light energy when shadows are on
 			sky.main_light.light_energy = 0.7
+			# Shorter shadow distance for better performance
+			sky.main_light.directional_shadow_max_distance = 30.0
 		2:  # high res shadow
 			sky.main_light.shadow_enabled = true
 			sky.main_light.light_energy = 0.7
+			# Full shadow distance for high quality
+			sky.main_light.directional_shadow_max_distance = 50.0
 			quality = RenderingServer.SHADOW_QUALITY_SOFT_MEDIUM
 
 	RenderingServer.directional_soft_shadow_filter_set_quality(quality)

--- a/godot/assets/environment/sky_lights.tscn
+++ b/godot/assets/environment/sky_lights.tscn
@@ -9,3 +9,4 @@ light_energy = 0.7
 light_bake_mode = 0
 shadow_enabled = true
 shadow_opacity = 0.7
+directional_shadow_max_distance = 50.0


### PR DESCRIPTION
## Summary
- Adds `directional_shadow_max_distance` to limit shadow rendering distance
- Default: 50m for high quality shadows
- Low quality: 30m for better performance

## Related Issue
Closes #1191

## Test plan
- [x] Run client with `--skip-lobby`
- [x] Verify shadows disappear beyond ~50m distance
- [x] Change shadow quality to low and verify shorter distance (~30m)