### PR TITLE
fix: change screen orientation to use sensor landscape instead of fixed

### DIFF
--- a/godot/src/global.gd
+++ b/godot/src/global.gd
@@ -659,7 +659,7 @@ func set_orientation_landscape():
 	# Set orientation BEFORE changing window size so listeners get correct value
 	_is_portrait = false
 	if Global.is_mobile() and !Global.is_virtual_mobile():
-		DisplayServer.screen_set_orientation(DisplayServer.SCREEN_LANDSCAPE)
+		DisplayServer.screen_set_orientation(DisplayServer.SCREEN_SENSOR_LANDSCAPE)
 	elif cli.emulate_ios:
 		var presets := _get_safe_area_presets()
 		get_window().size = presets.get_ios_window_size(false)


### PR DESCRIPTION
## Summary
- Changes landscape orientation mode from `SCREEN_LANDSCAPE` to `SCREEN_SENSOR_LANDSCAPE`
- Allows the screen to rotate between both landscape orientations based on device sensor
- Improves UX on mobile devices by letting users hold the device in their preferred landscape orientation

## Test plan
- [ ] Test on Android device - verify screen rotates between landscape orientations when device is rotated
- [ ] Test on iOS device - verify same behavior
- [ ] Verify no regression on desktop