### PR TITLE
fix: prevent iOS watchdog timeout (0x8BADF00D) crash

### DIFF
--- a/lib/src/godot_classes/dcl_global.rs
+++ b/lib/src/godot_classes/dcl_global.rs
@@ -621,4 +621,20 @@ impl DclGlobal {
     pub fn get_dcl_environment() -> GString {
         GString::from(crate::env::get_environment().suffix())
     }
+
+    /// Set the app lifecycle pause state for scene threads (iOS watchdog fix).
+    /// Call with `true` when app goes to background (NOTIFICATION_APPLICATION_PAUSED).
+    /// Call with `false` when app returns to foreground (NOTIFICATION_APPLICATION_RESUMED).
+    /// When paused, scene threads skip onUpdate processing to reduce CPU usage
+    /// and respond faster to kill signals, preventing iOS watchdog timeouts.
+    #[func]
+    pub fn set_app_lifecycle_paused(paused: bool) {
+        #[cfg(feature = "use_deno")]
+        crate::dcl::js::set_app_lifecycle_paused(paused);
+
+        #[cfg(not(feature = "use_deno"))]
+        {
+            let _ = paused;
+        }
+    }
 }

--- a/lib/src/scene_runner/scene_manager.rs
+++ b/lib/src/scene_runner/scene_manager.rs
@@ -35,6 +35,7 @@ use std::{
     cell::RefCell,
     collections::{HashMap, HashSet},
     sync::atomic::AtomicU32,
+    thread::JoinHandle,
     time::{Duration, Instant},
 };
 
@@ -117,6 +118,10 @@ pub struct SceneManager {
     // Loading session tracking
     current_loading_session: Option<LoadingSession>,
     next_session_id: u64,
+
+    // Non-blocking thread cleanup: stores join handles for threads that weren't finished
+    // when the scene was removed. These are periodically cleaned up without blocking.
+    pending_thread_cleanups: Vec<(SceneId, JoinHandle<()>)>,
 }
 
 // This value is the current global tick number, is used for marking the cronolgy of lamport timestamp
@@ -990,6 +995,9 @@ impl SceneManager {
         // Periodic pool health check and stats logging (handled by PoolManager)
         self.pool_manager.borrow_mut().tick();
 
+        // Non-blocking cleanup of deferred thread handles (iOS watchdog fix)
+        self.cleanup_pending_threads();
+
         for scene_id in scene_to_remove.iter() {
             let mut scene = self.scenes.remove(scene_id).unwrap();
             let signal_data = (*scene_id, scene.scene_entity_definition.id.clone());
@@ -1019,6 +1027,8 @@ impl SceneManager {
                 }
             }
 
+            // Non-blocking thread cleanup: only join if thread is already finished,
+            // otherwise defer cleanup to avoid blocking the main thread (iOS watchdog fix)
             if scene.dcl_scene.thread_join_handle.is_finished() {
                 if let Err(err) = scene.dcl_scene.thread_join_handle.join() {
                     let msg = if let Some(panic_info) = err.downcast_ref::<&str>() {
@@ -1030,6 +1040,14 @@ impl SceneManager {
                     };
                     tracing::error!("scene {} thread result: {:?}", scene_id.0, msg);
                 }
+            } else {
+                // Thread still running - defer cleanup to avoid blocking main thread
+                tracing::debug!(
+                    "scene {} thread still running, deferring cleanup",
+                    scene_id.0
+                );
+                self.pending_thread_cleanups
+                    .push((*scene_id, scene.dcl_scene.thread_join_handle));
             }
 
             self.base_mut().emit_signal(
@@ -1155,6 +1173,35 @@ impl SceneManager {
                 Err(std::sync::mpsc::TryRecvError::Disconnected) => {
                     panic!("render thread receiver exploded");
                 }
+            }
+        }
+    }
+
+    /// Non-blocking cleanup of deferred thread handles.
+    /// Called periodically to clean up threads that weren't finished when their scene was removed.
+    /// This prevents blocking the main thread (iOS watchdog fix).
+    fn cleanup_pending_threads(&mut self) {
+        // Find indices of finished threads
+        let mut finished_indices = Vec::new();
+        for (i, (_, handle)) in self.pending_thread_cleanups.iter().enumerate() {
+            if handle.is_finished() {
+                finished_indices.push(i);
+            }
+        }
+
+        // Remove and join finished threads in reverse order to maintain indices
+        for i in finished_indices.into_iter().rev() {
+            let (scene_id, handle) = self.pending_thread_cleanups.swap_remove(i);
+            tracing::debug!("deferred thread cleanup for scene {}", scene_id.0);
+            if let Err(err) = handle.join() {
+                let msg = if let Some(panic_info) = err.downcast_ref::<&str>() {
+                    format!("Thread panicked with: {}", panic_info)
+                } else if let Some(panic_info) = err.downcast_ref::<String>() {
+                    format!("Thread panicked with: {}", panic_info)
+                } else {
+                    "Thread panicked with an unknown payload".to_string()
+                };
+                tracing::error!("deferred scene {} thread result: {:?}", scene_id.0, msg);
             }
         }
     }
@@ -1619,6 +1666,7 @@ impl INode for SceneManager {
             pool_manager: RefCell::new(PoolManager::new()),
             current_loading_session: None,
             next_session_id: 0,
+            pending_thread_cleanups: Vec::new(),
         }
     }
 


### PR DESCRIPTION
## Summary

- Fixes iOS watchdog timeout crash (0x8BADF00D) when app goes to background
- Main thread was blocked waiting for scene threads to exit during physics_process
- iOS terminates apps if main thread is unresponsive for >10 seconds

## Changes

1. **Non-blocking thread cleanup** (`scene_manager.rs`)
   - Scene manager now defers thread join operations to a pending cleanup list
   - Threads are cleaned up in subsequent frames only when they're finished
   - Prevents main thread from blocking on thread.join()

2. **App lifecycle pause signal** (`mod.rs`, `dcl_global.rs`, `global.gd`)
   - Added `APP_LIFECYCLE_PAUSED` atomic flag for scene threads
   - Scene threads skip `onUpdate` processing and sleep briefly when app is backgrounded
   - Reduces CPU usage and helps threads respond faster to kill signals

3. **Early dying check in scene thread** (`mod.rs`)
   - Scene thread checks dying flag at the start of the loop (fast path)
   - Allows faster shutdown response

## Test plan

- [ ] Build for iOS: `cargo run -- build --target ios`
- [ ] Export IPA: `cargo run -- export --target ios`
- [ ] Deploy to device and test:
  - [ ] Launch app
  - [ ] Wait for scene to load
  - [ ] Press home button / switch apps
  - [ ] Return to app - should not crash
- [ ] Test rapid background/foreground cycling
- [ ] Test with voice chat active (LiveKit)