### PR TITLE
feat: implement PBAvatarLocomotionSettings component

### DIFF
--- a/lib/src/godot_classes/dcl_locomotion_settings.rs
+++ b/lib/src/godot_classes/dcl_locomotion_settings.rs
@@ -1,0 +1,80 @@
+use godot::prelude::*;
+
+use crate::dcl::components::proto_components::sdk::components::PbAvatarLocomotionSettings;
+
+/// Default locomotion values (matching current player.gd defaults)
+pub const DEFAULT_WALK_SPEED: f32 = 1.5;
+pub const DEFAULT_JOG_SPEED: f32 = 8.0;
+pub const DEFAULT_RUN_SPEED: f32 = 11.0;
+pub const DEFAULT_JUMP_HEIGHT: f32 = 1.8;
+pub const DEFAULT_RUN_JUMP_HEIGHT: f32 = 1.8;
+pub const DEFAULT_HARD_LANDING_COOLDOWN: f32 = 0.0;
+
+#[derive(GodotClass)]
+#[class(base=RefCounted)]
+pub struct DclLocomotionSettings {
+    #[export]
+    walk_speed: f32,
+
+    #[export]
+    jog_speed: f32,
+
+    #[export]
+    run_speed: f32,
+
+    #[export]
+    jump_height: f32,
+
+    #[export]
+    run_jump_height: f32,
+
+    #[export]
+    hard_landing_cooldown: f32,
+}
+
+#[godot_api]
+impl IRefCounted for DclLocomotionSettings {
+    fn init(_base: Base<RefCounted>) -> Self {
+        Self {
+            walk_speed: DEFAULT_WALK_SPEED,
+            jog_speed: DEFAULT_JOG_SPEED,
+            run_speed: DEFAULT_RUN_SPEED,
+            jump_height: DEFAULT_JUMP_HEIGHT,
+            run_jump_height: DEFAULT_RUN_JUMP_HEIGHT,
+            hard_landing_cooldown: DEFAULT_HARD_LANDING_COOLDOWN,
+        }
+    }
+}
+
+#[godot_api]
+impl DclLocomotionSettings {
+    /// Get a new instance with default locomotion settings
+    #[func]
+    pub fn create_default() -> Gd<DclLocomotionSettings> {
+        Gd::default()
+    }
+}
+
+impl DclLocomotionSettings {
+    /// Update from proto component (uses constants for unset fields)
+    pub fn set_from_proto(&mut self, proto: &PbAvatarLocomotionSettings) {
+        self.walk_speed = proto.walk_speed.unwrap_or(DEFAULT_WALK_SPEED);
+        self.jog_speed = proto.jog_speed.unwrap_or(DEFAULT_JOG_SPEED);
+        self.run_speed = proto.run_speed.unwrap_or(DEFAULT_RUN_SPEED);
+        self.jump_height = proto.jump_height.unwrap_or(DEFAULT_JUMP_HEIGHT);
+        self.run_jump_height = proto.run_jump_height.unwrap_or(DEFAULT_RUN_JUMP_HEIGHT);
+        self.hard_landing_cooldown = proto
+            .hard_landing_cooldown
+            .unwrap_or(DEFAULT_HARD_LANDING_COOLDOWN);
+    }
+
+    /// Reset to defaults
+    pub fn reset_to_defaults(&mut self) {
+        self.walk_speed = DEFAULT_WALK_SPEED;
+        self.jog_speed = DEFAULT_JOG_SPEED;
+        self.run_speed = DEFAULT_RUN_SPEED;
+        self.jump_height = DEFAULT_JUMP_HEIGHT;
+        self.run_jump_height = DEFAULT_RUN_JUMP_HEIGHT;
+        self.hard_landing_cooldown = DEFAULT_HARD_LANDING_COOLDOWN;
+    }
+}

--- a/lib/src/godot_classes/mod.rs
+++ b/lib/src/godot_classes/mod.rs
@@ -19,6 +19,7 @@ pub mod dcl_global_time;
 pub mod dcl_gltf_container;
 pub mod dcl_hashing;
 pub mod dcl_ios_plugin;
+pub mod dcl_locomotion_settings;
 pub mod dcl_node_entity_3d;
 pub mod dcl_parse_deep_link;
 pub mod dcl_realm;

--- a/lib/src/scene_runner/components/avatar_locomotion_settings.rs
+++ b/lib/src/scene_runner/components/avatar_locomotion_settings.rs
@@ -1,0 +1,41 @@
+use crate::{
+    dcl::{
+        components::{SceneComponentId, SceneEntityId},
+        crdt::{
+            last_write_wins::LastWriteWinsComponentOperation, SceneCrdtState,
+            SceneCrdtStateProtoComponents,
+        },
+    },
+    scene_runner::scene::Scene,
+};
+
+/// Updates the locomotion settings for the scene.
+/// Returns `true` if the settings were changed, `false` otherwise.
+pub fn update_avatar_locomotion_settings(
+    scene: &mut Scene,
+    crdt_state: &mut SceneCrdtState,
+) -> bool {
+    let dirty_lww_components = &scene.current_dirty.lww_components;
+
+    if let Some(locomotion_dirty) =
+        dirty_lww_components.get(&SceneComponentId::AVATAR_LOCOMOTION_SETTINGS)
+    {
+        // Only process ROOT_ENTITY (id = 0)
+        if locomotion_dirty.contains(&SceneEntityId::ROOT) {
+            let locomotion_component =
+                SceneCrdtStateProtoComponents::get_avatar_locomotion_settings(crdt_state);
+
+            if let Some(value) = locomotion_component.get(&SceneEntityId::ROOT) {
+                if let Some(proto) = &value.value {
+                    scene.locomotion_settings.bind_mut().set_from_proto(proto);
+                } else {
+                    scene.locomotion_settings.bind_mut().reset_to_defaults();
+                }
+            } else {
+                scene.locomotion_settings.bind_mut().reset_to_defaults();
+            }
+            return true;
+        }
+    }
+    false
+}

--- a/lib/src/scene_runner/components/mod.rs
+++ b/lib/src/scene_runner/components/mod.rs
@@ -3,6 +3,7 @@ pub mod audio_source;
 pub mod audio_stream;
 pub mod avatar_attach;
 pub mod avatar_data;
+pub mod avatar_locomotion_settings;
 pub mod avatar_modifier_area;
 pub mod avatar_shape;
 pub mod billboard;

--- a/lib/src/scene_runner/scene.rs
+++ b/lib/src/scene_runner/scene.rs
@@ -30,8 +30,8 @@ use crate::{
     },
     godot_classes::{
         dcl_audio_source::DclAudioSource, dcl_audio_stream::DclAudioStream,
-        dcl_ui_control::DclUiControl, dcl_video_player::DclVideoPlayer,
-        dcl_virtual_camera::DclVirtualCamera,
+        dcl_locomotion_settings::DclLocomotionSettings, dcl_ui_control::DclUiControl,
+        dcl_video_player::DclVideoPlayer, dcl_virtual_camera::DclVirtualCamera,
     },
     realm::scene_definition::SceneEntityDefinition,
 };
@@ -120,6 +120,7 @@ pub enum SceneUpdateState {
     VideoPlayer,
     AudioStream,
     AvatarModifierArea,
+    AvatarLocomotionSettings,
     CameraModeArea,
     InputModifier,
     SkyboxTime,
@@ -157,7 +158,8 @@ impl SceneUpdateState {
             Self::Raycasts => Self::VideoPlayer,
             Self::VideoPlayer => Self::AudioStream,
             Self::AudioStream => Self::AvatarModifierArea,
-            Self::AvatarModifierArea => Self::CameraModeArea,
+            Self::AvatarModifierArea => Self::AvatarLocomotionSettings,
+            Self::AvatarLocomotionSettings => Self::CameraModeArea,
             Self::CameraModeArea => Self::InputModifier,
             Self::InputModifier => Self::SkyboxTime,
             Self::SkyboxTime => Self::TriggerArea,
@@ -268,6 +270,8 @@ pub struct Scene {
     pub last_player_scene_id: SceneId,
 
     pub virtual_camera: Gd<DclVirtualCamera>,
+
+    pub locomotion_settings: Gd<DclLocomotionSettings>,
 
     pub paused: bool,
 
@@ -381,6 +385,7 @@ impl Scene {
             last_player_scene_id: SceneId(-1), // Sentinel: never matches real scene IDs
             paused: false,
             virtual_camera: Default::default(),
+            locomotion_settings: Default::default(),
             deno_memory_stats: None,
         }
     }
@@ -454,6 +459,7 @@ impl Scene {
             last_player_scene_id: SceneId(-1), // Sentinel: never matches real scene IDs
             paused: false,
             virtual_camera: Default::default(),
+            locomotion_settings: Default::default(),
             deno_memory_stats: None,
         }
     }

--- a/lib/src/scene_runner/scene_manager.rs
+++ b/lib/src/scene_runner/scene_manager.rs
@@ -17,7 +17,8 @@ use crate::{
     },
     godot_classes::{
         dcl_avatar::DclAvatar, dcl_camera_3d::DclCamera3D, dcl_global::DclGlobal,
-        dcl_ui_control::DclUiControl, dcl_virtual_camera::DclVirtualCamera,
+        dcl_locomotion_settings::DclLocomotionSettings, dcl_ui_control::DclUiControl,
+        dcl_virtual_camera::DclVirtualCamera,
         rpc_sender::take_and_compare_snapshot_response::DclRpcSenderTakeAndCompareSnapshotResponse,
         JsonGodotClass,
     },
@@ -1388,6 +1389,9 @@ impl SceneManager {
     #[signal]
     fn on_change_scene_id(scene_id: i32);
 
+    #[signal]
+    fn locomotion_settings_changed(settings: Gd<DclLocomotionSettings>);
+
     pub fn get_all_scenes_mut(&mut self) -> &mut HashMap<SceneId, Scene> {
         &mut self.scenes
     }
@@ -1426,6 +1430,24 @@ impl SceneManager {
         self.scenes
             .get(&SceneId(scene_id))
             .map(|x| x.virtual_camera.clone())
+    }
+
+    #[func]
+    pub fn get_scene_locomotion_settings(
+        &self,
+        scene_id: i32,
+    ) -> Option<Gd<DclLocomotionSettings>> {
+        self.scenes
+            .get(&SceneId(scene_id))
+            .map(|x| x.locomotion_settings.clone())
+    }
+
+    #[func]
+    pub fn get_current_scene_locomotion_settings(&self) -> Gd<DclLocomotionSettings> {
+        self.scenes
+            .get(&self.current_parcel_scene_id)
+            .map(|x| x.locomotion_settings.clone())
+            .unwrap_or_default()
     }
 
     #[func]

--- a/src/install_dependency.rs
+++ b/src/install_dependency.rs
@@ -30,7 +30,7 @@ fn create_directory_all(path: &Path) -> io::Result<()> {
     Ok(())
 }
 
-const PROTOCOL_FIXED_VERSION_URL: Option<&str> = Some("https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-21486655362.commit-ec8b96e.tgz");
+const PROTOCOL_FIXED_VERSION_URL: Option<&str> = Some("https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-21650527315.commit-b658867.tgz");
 
 fn get_protocol_url() -> Result<String, anyhow::Error> {
     match PROTOCOL_FIXED_VERSION_URL {


### PR DESCRIPTION
## Summary

Implements the `PBAvatarLocomotionSettings` component (ID: 1211) from [protocol PR #320](https://github.com/decentraland/protocol/pull/320). This component allows scenes to customize player movement parameters when the player is inside the scene.

## Changes

### Rust
- Added `DclLocomotionSettings` class exposed to Godot with locomotion parameters
- Added `update_avatar_locomotion_settings` function to process the component on ROOT entity
- Added `locomotion_settings_changed` signal (emitted deferred) to notify when settings change
- Added `get_current_scene_locomotion_settings()` method in SceneManager

### GDScript
- Player now subscribes to `on_change_scene_id` and `locomotion_settings_changed` signals
- Settings are applied via `_apply_locomotion_settings()` when entering a scene or when the component updates
- Settings reset to defaults when leaving the scene

## Supported Parameters

| Parameter | Default | Description |
|-----------|---------|-------------|
| `walk_speed` | 1.5 | Walking speed (m/s) |
| `jog_speed` | 8.0 | Jogging speed (m/s) |
| `run_speed` | 11.0 | Running/sprinting speed (m/s) |
| `jump_height` | 1.8 | Normal jump height (m) |
| `run_jump_height` | 1.8 | Jump height while sprinting (m) |
| `hard_landing_cooldown` | 0.0 | Cooldown after landing from height (s) |

## Test Plan

1. Go to world `mannakia.dcl.eth`
2. Select the scene **"Locomotion test"**
3. Test different locomotion presets using the UI buttons
4. Verify speed changes take effect immediately
5. Walk outside the scene bounds and verify defaults are restored
6. Re-enter the scene and verify custom settings are reapplied


fixes #1185 