### PR TITLE
feat: implement block list RPC integration

### DIFF
--- a/godot/src/decentraland_components/avatar/avatar.gd
+++ b/godot/src/decentraland_components/avatar/avatar.gd
@@ -162,8 +162,19 @@ func set_hidden(value):
 	hidden = value
 	if hidden:
 		hide()
+		# Disable click detection so blocked/hidden avatars can't be interacted with
+		_set_click_area_enabled(false)
 	else:
 		try_show()
+		# Re-enable click detection
+		_set_click_area_enabled(true)
+
+
+func _set_click_area_enabled(enabled: bool) -> void:
+	if click_area:
+		var collision_shape = click_area.get_node_or_null("CollisionShape3D")
+		if collision_shape:
+			collision_shape.disabled = not enabled
 
 
 func _unset_avatar_modifier_area():

--- a/godot/src/ui/components/auth/lobby.gd
+++ b/godot/src/ui/components/auth/lobby.gd
@@ -345,6 +345,9 @@ func _on_button_different_account_pressed():
 	Global.metrics.track_click_button("use_another_account", current_screen_name, "")
 	Global.get_config().session_account = {}
 
+	# Unsubscribe from block updates before clearing
+	Global.social_service.unsubscribe_from_block_updates()
+
 	# Clear the current social blacklist when switching accounts
 	Global.social_blacklist.clear_blocked()
 	Global.social_blacklist.clear_muted()

--- a/godot/src/ui/explorer.gd
+++ b/godot/src/ui/explorer.gd
@@ -303,8 +303,39 @@ func _on_player_profile_changed(_profile: DclUserProfile) -> void:
 
 func _async_initialize_social_service() -> void:
 	# Initialize the social service with player identity
-	# Note: Subscriptions are now handled by FriendsPanel when it opens/closes
+	# Note: Friendship subscriptions are handled by FriendsPanel when it opens/closes
 	Global.social_service.initialize_from_player_identity(Global.player_identity)
+
+	# Connect to block update signal for real-time sync
+	if not Global.social_service.block_update_received.is_connected(_on_block_update_received):
+		Global.social_service.block_update_received.connect(_on_block_update_received)
+
+	# Fetch blocked users from server and initialize local cache (fire-and-forget)
+	_async_fetch_blocking_status()
+
+	# Subscribe to block updates for real-time sync across devices
+	Global.social_service.subscribe_to_block_updates()
+
+
+func _async_fetch_blocking_status() -> void:
+	var promise = Global.social_service.get_blocking_status()
+	await PromiseUtils.async_awaiter(promise)
+
+	if promise.is_rejected():
+		printerr("Failed to get blocking status: ", PromiseUtils.get_error_message(promise))
+		return
+
+	var data = promise.get_data()
+	if data is Dictionary:
+		var blocked_users: Array = data.get("blocked_users", [])
+		Global.social_blacklist.init_from_blocking_status(blocked_users)
+
+
+func _on_block_update_received(address: String, is_blocked: bool) -> void:
+	if is_blocked:
+		Global.social_blacklist.add_blocked(address)
+	else:
+		Global.social_blacklist.remove_blocked(address)
 
 
 func _on_scene_console_message(scene_id: int, level: int, timestamp: float, text: String) -> void:


### PR DESCRIPTION
Fix #969
## Summary

Implements Block List RPC Integration for issue #969. The mobile client's block list now syncs with the desktop Foundation client via the Social Service RPC instead of using local storage only.

### Changes:
- **Rust (`dcl_social_service.rs`)**: Added blocking RPC methods exposed to GDScript:
  - `block_user(address)` / `unblock_user(address)`
  - `get_blocked_users(limit, offset)` / `get_blocking_status()`
  - `subscribe_to_block_updates()` / `unsubscribe_from_block_updates()`
  - Signals: `user_blocked`, `user_unblocked`, `block_update_received`
  
- **Rust (`dcl_social_blacklist.rs`)**: Added `init_from_blocking_status()` to initialize local cache from server response

- **GDScript (`profile.gd`)**: Updated block button to use RPC calls instead of local storage

- **GDScript (`social_item.gd`)**: Updated unblock button to use RPC calls

- **GDScript (`explorer.gd`)**: 
  - Fetch blocking status on login and initialize local cache
  - Subscribe to real-time block updates for cross-device sync

- **GDScript (`lobby.gd`)**: Unsubscribe from block updates on logout/account switch

- **GDScript (`avatar.gd`)**: Fixed blocked avatars still being clickable by disabling ClickArea collider when hidden

## Test plan

- [ ] Login with an account
- [ ] Block a user via the profile UI
- [ ] Verify the RPC call succeeds (check logs)
- [ ] Verify blocked user's avatar is hidden AND cannot be clicked
- [ ] Logout and login again - blocked user should still be blocked
- [ ] Test cross-device sync: block a user on mobile, verify blocked on desktop Foundation client
- [ ] Test real-time sync: open two clients with same account, block on one, verify other receives update

Closes #969