### PR TITLE
fix: resolve node-not-in-tree errors during startup

### DIFF
--- a/godot/src/config/hardware_benchmark.gd
+++ b/godot/src/config/hardware_benchmark.gd
@@ -196,24 +196,24 @@ func _async_create_benchmark_scene() -> void:
 	# Add a camera
 	var camera := Camera3D.new()
 	camera.position = Vector3(0, 8, 20)
-	camera.look_at(Vector3.ZERO)
 	_benchmark_viewport.add_child(camera)
+	camera.look_at(Vector3.ZERO)
 
 	# Add main directional light with shadows
 	var sun := DirectionalLight3D.new()
 	sun.position = Vector3(10, 20, 10)
-	sun.look_at(Vector3.ZERO)
 	sun.shadow_enabled = true
 	sun.light_energy = 1.2
 	sun.shadow_bias = 0.02
 	_benchmark_viewport.add_child(sun)
+	sun.look_at(Vector3.ZERO)
 
 	# Add secondary fill light
 	var fill_light := DirectionalLight3D.new()
 	fill_light.position = Vector3(-10, 5, -5)
-	fill_light.look_at(Vector3.ZERO)
 	fill_light.light_energy = 0.3
 	_benchmark_viewport.add_child(fill_light)
+	fill_light.look_at(Vector3.ZERO)
 
 	# Add multiple point lights for more realistic lighting
 	for i in range(4):

--- a/godot/src/logic/scene_fetcher.gd
+++ b/godot/src/logic/scene_fetcher.gd
@@ -889,8 +889,8 @@ func _create_floor_mesh(width: float, height: float, center_x: float, center_z: 
 	# The default grass_rect in the material already points to the bottom-left quadrant
 	mesh_instance.material_override = EMPTY_PARCEL_MATERIAL
 
-	mesh_instance.global_position = Vector3(center_x, -0.05, center_z)
 	_large_scene_floor.add_child(mesh_instance)
+	mesh_instance.global_position = Vector3(center_x, -0.05, center_z)
 
 
 ## Create the floor collision for simple floor mode
@@ -905,9 +905,9 @@ func _create_floor_collision(width: float, height: float, center_x: float, cente
 	collision_shape.shape = box_shape
 
 	static_body.add_child(collision_shape)
-	static_body.global_position = Vector3(center_x, -0.05, center_z)
 
 	_large_scene_floor.add_child(static_body)
+	static_body.global_position = Vector3(center_x, -0.05, center_z)
 
 
 ## Create a cliff plane on one side of the simple floor
@@ -921,10 +921,10 @@ func _create_cliff(position: Vector3, size: Vector2, rotation: Vector3) -> void:
 	mesh_instance.mesh = plane_mesh
 
 	mesh_instance.material_override = CLIFF_MATERIAL
-	mesh_instance.global_position = position
-	mesh_instance.rotation = rotation
 
 	_large_scene_floor.add_child(mesh_instance)
+	mesh_instance.global_position = position
+	mesh_instance.rotation = rotation
 
 
 func _async_spawn_on_empty_parcel(parcel: Vector2i) -> void:

--- a/godot/src/ui/explorer.tscn
+++ b/godot/src/ui/explorer.tscn
@@ -450,4 +450,3 @@ script = ExtResource("20_064cw")
 [connection signal="request_pause_scenes" from="UI/Control_Menu" to="." method="_on_control_menu_request_pause_scenes"]
 [connection signal="toggle_fps" from="UI/Control_Menu" to="." method="_on_control_menu_toggle_fps"]
 [connection signal="toggle_minimap" from="UI/Control_Menu" to="." method="_on_control_menu_toggle_minimap"]
-[connection signal="close_all" from="UI/SafeMarginContainerNavbar/Navbar" to="." method="_on_navbar_close_all"]


### PR DESCRIPTION
## Summary
- Fix `look_at()` calls on nodes before they're added to the scene tree in `hardware_benchmark.gd`
- Fix `global_position`/`rotation` being set before nodes are in the tree in `scene_fetcher.gd`
- Remove stale `close_all` signal connection in `explorer.tscn` (signal was renamed to `navbar_closed` and is already connected in code)

## Test plan
- [ ] Run the application and verify no "Node not inside tree" errors appear during startup
- [ ] Verify hardware benchmark runs correctly
- [ ] Verify floating islands/floor generation works correctly
- [ ] Verify navbar close functionality still works