### PR TITLE
feat: pass analytics user id and session id to mobile auth flow

### DIFF
--- a/godot/src/global.gd
+++ b/godot/src/global.gd
@@ -55,6 +55,9 @@ const FORCE_TEST_LOCATION = Vector2i(54, -55)
 #const FORCE_TEST_ARG = "[[52,-56]]"
 # const FORCE_TEST_REALM = "http://localhost:8000"
 
+const FORCE_DEEPLINK = ""
+#const FORCE_DEEPLINK = "decentraland://open?dclenv=today"
+
 # Increase this value for new terms and conditions
 const TERMS_AND_CONDITIONS_VERSION: int = 1
 
@@ -168,10 +171,13 @@ func _ready():
 		get_window().move_to_center()
 		_instantiate_phone_frame_overlay()
 
-	# Handle fake deep link from CLI (for testing mobile deep links on desktop)
-	if not cli.fake_deeplink.is_empty():
-		deep_link_url = cli.fake_deeplink
-		deep_link_obj = DclParseDeepLink.parse_decentraland_link(cli.fake_deeplink)
+	# Handle fake deep link from CLI or FORCE_DEEPLINK constant (for testing mobile deep links on desktop)
+	var fake_deeplink = cli.fake_deeplink
+	if fake_deeplink.is_empty() and not FORCE_DEEPLINK.is_empty():
+		fake_deeplink = FORCE_DEEPLINK
+	if not fake_deeplink.is_empty():
+		deep_link_url = fake_deeplink
+		deep_link_obj = DclParseDeepLink.parse_decentraland_link(fake_deeplink)
 		print(
 			"[DEEPLINK] Parsed fake deep_link_obj: location=",
 			deep_link_obj.location,

--- a/godot/src/ui/components/auth/login.gd
+++ b/godot/src/ui/components/auth/login.gd
@@ -62,7 +62,9 @@ func async_login(provider: String = ""):
 	# Desktop uses polling-based flow even when --force-mobile is used for UI testing
 	var is_real_mobile = Global.is_android() or Global.is_ios()
 	if is_real_mobile:
-		Global.player_identity.start_mobile_connect_account(provider)
+		Global.player_identity.start_mobile_connect_account(
+			provider, Global.config.analytics_user_id, Global.session_id
+		)
 	else:
 		Global.player_identity.try_connect_account()
 

--- a/lib/src/auth/auth_identity.rs
+++ b/lib/src/auth/auth_identity.rs
@@ -77,10 +77,12 @@ pub async fn try_create_remote_ephemeral(
 pub async fn start_mobile_auth(
     url_reporter_sender: tokio::sync::mpsc::Sender<GodotTokioCall>,
     provider: Option<String>,
+    user_id: Option<String>,
+    session_id: Option<String>,
 ) -> Result<(), anyhow::Error> {
     // For mobile auth, we use an empty request since the server will generate everything
     let request = CreateRequest::from_new_ephemeral("");
-    do_request_mobile(request, url_reporter_sender, provider).await?;
+    do_request_mobile(request, url_reporter_sender, provider, user_id, session_id).await?;
 
     Ok(())
 }

--- a/lib/src/auth/dcl_player_identity.rs
+++ b/lib/src/auth/dcl_player_identity.rs
@@ -236,7 +236,12 @@ impl DclPlayerIdentity {
     /// The app should wait for a deep link with signin identity ID,
     /// then call complete_mobile_connect_account with that ID.
     #[func]
-    fn start_mobile_connect_account(&mut self, provider: GString) {
+    fn start_mobile_connect_account(
+        &mut self,
+        provider: GString,
+        user_id: GString,
+        session_id: GString,
+    ) {
         let Some(handle) = TokioRuntime::static_clone_handle() else {
             panic!("tokio runtime not initialized")
         };
@@ -253,9 +258,19 @@ impl DclPlayerIdentity {
         } else {
             Some(provider.to_string())
         };
+        let user_id = if user_id.is_empty() {
+            None
+        } else {
+            Some(user_id.to_string())
+        };
+        let session_id = if session_id.is_empty() {
+            None
+        } else {
+            Some(session_id.to_string())
+        };
 
         handle.spawn(async move {
-            let result = start_mobile_auth(sender, provider).await;
+            let result = start_mobile_auth(sender, provider, user_id, session_id).await;
             let Ok(mut this) = Gd::<DclPlayerIdentity>::try_from_instance_id(instance_id) else {
                 return;
             };

--- a/lib/src/auth/decentraland_auth_server.rs
+++ b/lib/src/auth/decentraland_auth_server.rs
@@ -380,17 +380,29 @@ pub async fn do_request_mobile(
     _message: CreateRequest,
     url_reporter: tokio::sync::mpsc::Sender<GodotTokioCall>,
     provider: Option<String>,
+    user_id: Option<String>,
+    session_id: Option<String>,
 ) -> Result<(), anyhow::Error> {
     tracing::debug!(
         "do_request_mobile: starting mobile auth request, provider={:?}",
         provider
     );
 
-    // Build URL with optional provider parameter
-    let url = if let Some(provider) = provider {
-        format!("{}?provider={}", urls::auth_mobile_frontend(), provider)
-    } else {
+    // Build URL with optional query parameters
+    let mut params = Vec::new();
+    if let Some(provider) = provider {
+        params.push(format!("provider={provider}"));
+    }
+    if let Some(user_id) = user_id {
+        params.push(format!("u={user_id}"));
+    }
+    if let Some(session_id) = session_id {
+        params.push(format!("s={session_id}"));
+    }
+    let url = if params.is_empty() {
         urls::auth_mobile_frontend()
+    } else {
+        format!("{}?{}", urls::auth_mobile_frontend(), params.join("&"))
     };
     tracing::debug!("do_request_mobile: opening auth URL={}", url);
 

--- a/lib/src/urls/mod.rs
+++ b/lib/src/urls/mod.rs
@@ -10,16 +10,32 @@ fn env() -> &'static str {
 
 // Auth
 pub fn auth_frontend() -> String {
-    format!("https://decentraland.{}/auth/requests", env())
+    if env() == "today" {
+        "http://localhost:5173/auth/requests".to_string()
+    } else {
+        format!("https://decentraland.{}/auth/requests", env())
+    }
 }
 pub fn auth_mobile_frontend() -> String {
-    format!("https://decentraland.{}/auth/mobile", env())
+    if env() == "today" {
+        "http://localhost:5173/auth/mobile".to_string()
+    } else {
+        format!("https://decentraland.{}/auth/mobile", env())
+    }
 }
 pub fn auth_api_base() -> String {
-    format!("https://auth-api.decentraland.{}", env())
+    if env() == "today" {
+        "https://auth-api.decentraland.zone".to_string()
+    } else {
+        format!("https://auth-api.decentraland.{}", env())
+    }
 }
 pub fn auth_api_requests() -> String {
-    format!("https://auth-api.decentraland.{}/requests", env())
+    if env() == "today" {
+        "https://auth-api.decentraland.zone/requests".to_string()
+    } else {
+        format!("https://auth-api.decentraland.{}/requests", env())
+    }
 }
 
 // Content


### PR DESCRIPTION
## Summary
- Pass `user_id` and `session_id` as query parameters (`u=` and `s=`) to the mobile auth frontend URL, enabling analytics tracking through the auth flow
- Add `FORCE_DEEPLINK` constant and refactor fake deep link handling to support testing mobile deep links on desktop via both CLI arg and hardcoded constant
- Add `dclenv=today` support in auth/API URLs, routing to `localhost:5173` for local frontend development
- Fix gdlint warning: rename `_fake_deeplink` to `fake_deeplink`

## Test plan
- [ ] Verify mobile auth flow opens URL with `u=` and `s=` query params
- [ ] Test `FORCE_DEEPLINK` constant triggers deep link parsing on desktop
- [ ] Test `--fake-deeplink` CLI arg still works
- [ ] Verify `dclenv=today` routes auth URLs to localhost