### PR TITLE
fix: pass raw main.crdt bytes to JS instead of filtering

### DIFF
--- a/lib/src/scene_runner/components/pointer_events.rs
+++ b/lib/src/scene_runner/components/pointer_events.rs
@@ -109,6 +109,12 @@ pub fn update_scene_pointer_events(scene: &mut Scene, crdt_state: &mut SceneCrdt
                 None
             };
 
+            tracing::debug!(
+                "PointerEvents update: entity {:?}, has_pointer_events={}",
+                entity,
+                new_value.is_some()
+            );
+
             let godot_entity_node = godot_dcl_scene.ensure_godot_entity_node(entity);
 
             if let Some(base_ui) = godot_entity_node.base_ui.as_mut() {
@@ -243,6 +249,16 @@ pub fn pointer_events_system(
         &current_raycast_scene_id,
         &current_raycast_entity_id,
     );
+
+    if pointer_event.is_none() {
+        if let Some(raycast) = current_raycast.as_ref() {
+            tracing::debug!(
+                "Raycast hit entity {:?} in scene {:?} but NO PointerEvents configured",
+                raycast.entity_id,
+                raycast.scene_id
+            );
+        }
+    }
 
     if pointer_event.is_none() || changed_inputs.is_empty() {
         return;


### PR DESCRIPTION
## Summary

- **Fixes PointerEvents regression** introduced by the main.crdt re-serialization in #1107. The re-serialization was dropping components unknown to Godot (e.g. `3864921337`, `2357605385`) before the JS SDK received them, breaking scenes like SlidePenguin where the SDK needs those components to configure PointerEvents dynamically.
- **Passes raw main.crdt bytes directly to JS**, matching how [bevy-explorer](https://github.com/nicholasgasior/bevy-explorer) handles it (`filter_components = false` for initial CRDT). The Godot renderer side still receives only known components via `take_dirty`.
- **Adds diagnostic logging** for CRDT processing (unknown component warnings, dirty state summary) and PointerEvents (entity updates, raycast misses).

## Root cause

The old code parsed main.crdt into `SceneCrdtState`, then re-serialized only known components back to bytes for JS. Components the SDK needs but Godot doesn't know about (scene-specific SDK components with high IDs) were silently dropped. In the SlidePenguin scene this meant 24635 → 4652 bytes (81% loss), and the JS code never received the data it needed to set up PointerEvents on penguin entities.

## Test plan

- [ ] Run `RUST_LOG=warn,dclgodot::dcl::js=info cargo run -- run` and navigate to "slide pinguin" world
- [ ] Verify penguins respond to hover and click (PointerEvents working)
- [ ] Verify no `[receiveMessages] ERROR processing message` errors in JS console
- [ ] Verify other scenes with main.crdt still load correctly