### PR TITLE
fix: joystick blocks click/press in virtual camera mode

### DIFF
--- a/lib/src/scene_runner/components/gltf_node_modifiers/material.rs
+++ b/lib/src/scene_runner/components/gltf_node_modifiers/material.rs
@@ -109,20 +109,10 @@ pub fn apply_material_to_mesh(
     // Track the last material for texture loading (we'll return this one)
     let mut result_material: Option<Gd<StandardMaterial3D>> = None;
 
-    let material_type = match &dcl_material {
-        DclMaterial::Unlit(_) => "Unlit",
-        DclMaterial::Pbr(_) => "PBR",
-    };
-
     // Apply to specified surface(s)
     if let Some(idx) = surface_index {
         // Apply to specific surface only
         if idx < mesh.get_surface_override_material_count() {
-            tracing::debug!(
-                "GLTF modifier: applying {} material to surface {}",
-                material_type,
-                idx
-            );
             let mut godot_material = get_or_create_material(mesh, idx);
             apply_dcl_material_properties(&mut godot_material, &dcl_material);
             mesh.set_surface_override_material(idx, &godot_material.clone().upcast::<Material>());
@@ -131,11 +121,6 @@ pub fn apply_material_to_mesh(
     } else {
         // Apply to all surfaces
         let surface_count = mesh.get_surface_override_material_count();
-        tracing::debug!(
-            "GLTF modifier: applying {} material to all {} surfaces",
-            material_type,
-            surface_count
-        );
         for i in 0..surface_count {
             let mut godot_material = get_or_create_material(mesh, i);
             apply_dcl_material_properties(&mut godot_material, &dcl_material);

--- a/lib/src/scene_runner/components/material.rs
+++ b/lib/src/scene_runner/components/material.rs
@@ -315,17 +315,9 @@ pub fn apply_dcl_material_properties(
             godot_material.set_shading_mode(ShadingMode::UNSHADED);
             godot_material.set_flag(Flags::ALBEDO_TEXTURE_FORCE_SRGB, true);
             // Unity ignores diffuse_color alpha for unlit materials, force alpha to 1.0
-            // No color space conversion — matches Unity (SetColor with no conversion)
-            let mut albedo_color = unlit.diffuse_color.0.to_godot();
+            let mut albedo_color = unlit.diffuse_color.0.to_godot().linear_to_srgb();
             albedo_color.a = 1.0;
             godot_material.set_albedo(albedo_color);
-
-            tracing::debug!(
-                "Unlit material: diffuse_color=({}, {}, {}, {}), has_texture={}, has_alpha_texture={}",
-                albedo_color.r, albedo_color.g, albedo_color.b, albedo_color.a,
-                unlit.texture.is_some(),
-                unlit.alpha_texture.is_some()
-            );
 
             // Apply UV offset/tiling from main texture (only main texture supports this)
             if let Some(texture) = &unlit.texture {
@@ -346,41 +338,23 @@ pub fn apply_dcl_material_properties(
             }
 
             // Handle transparency for unlit materials
-            // Unity uses AlphaTest (ZWrite=ON, _ALPHATEST_ON) as the base for unlit,
-            // then ResolveAutoMode determines if AlphaBlend is needed.
-            // Only alpha_texture triggers AlphaBlend (matches Unity's ResolveAutoMode).
-            if unlit.alpha_texture.is_some() {
-                tracing::debug!("Unlit material: transparency=ALPHA (has alpha_texture)");
-                godot_material.set_transparency(Transparency::ALPHA);
-            } else if unlit.texture.is_some() {
-                // Texture present but no alpha_texture — use scissor for cutout
-                // (matches Unity's base unlit: _ALPHATEST_ON, ZWrite=1)
-                tracing::debug!(
-                    "Unlit material: transparency=ALPHA_SCISSOR (has texture, no alpha_texture)"
-                );
-                godot_material.set_transparency(Transparency::ALPHA_SCISSOR);
-                godot_material.set_alpha_scissor_threshold(unlit.alpha_test.0);
+            // Note: Unity ignores diffuse_color alpha for unlit materials
+            if unlit.alpha_texture.is_some() || unlit.texture.is_some() {
+                // Use alpha blend for smooth transparency
+                godot_material.set_transparency(Transparency::ALPHA_DEPTH_PRE_PASS);
             } else {
-                tracing::debug!("Unlit material: transparency=DISABLED (no textures)");
                 godot_material.set_transparency(Transparency::DISABLED);
             }
         }
         DclMaterial::Pbr(pbr) => {
             godot_material.set_metallic(pbr.metallic.0);
             godot_material.set_roughness(pbr.roughness.0);
-            // Unity: specularIntensity * directIntensity
-            godot_material.set_specular(pbr.specular_intensity.0 * pbr.direct_intensity.0);
+            godot_material.set_specular(pbr.specular_intensity.0);
 
             godot_material.set_shading_mode(ShadingMode::PER_PIXEL);
-
-            // Emission: only enable when color is non-black (matches Unity)
-            let emissive = pbr.emissive_color.0.to_godot();
-            let has_emission = emissive.r != 0.0 || emissive.g != 0.0 || emissive.b != 0.0;
-            godot_material.set_feature(Feature::EMISSION, has_emission);
-            if has_emission {
-                godot_material.set_emission(emissive);
-                godot_material.set_emission_energy_multiplier(pbr.emissive_intensity.0);
-            }
+            godot_material.set_emission(pbr.emissive_color.0.to_godot());
+            godot_material.set_emission_energy_multiplier(pbr.emissive_intensity.0);
+            godot_material.set_feature(Feature::EMISSION, true);
 
             // Use MULTIPLY operator when there's an emissive texture, ADD otherwise
             if pbr.emissive_texture.is_some() {
@@ -390,7 +364,6 @@ pub fn apply_dcl_material_properties(
             }
 
             godot_material.set_flag(Flags::ALBEDO_TEXTURE_FORCE_SRGB, true);
-            // No color space conversion — matches Unity (SetColor with no conversion)
             godot_material.set_albedo(pbr.albedo_color.0.to_godot());
 
             // Apply UV offset/tiling from main texture (only main texture supports this)
@@ -412,16 +385,6 @@ pub fn apply_dcl_material_properties(
             }
 
             // Handle transparency mode
-            // Unity: AlphaBlend → ZWrite=OFF, SrcAlpha/OneMinusSrcAlpha, no depth pre-pass
-            // Godot equivalent: Transparency::ALPHA (NOT ALPHA_DEPTH_PRE_PASS)
-            let albedo_color = pbr.albedo_color.0.to_godot();
-            tracing::debug!(
-                "PBR material: mode={:?}, albedo=({}, {}, {}, {}), metallic={}, roughness={}, specular={}, has_texture={}, has_emissive_tex={}",
-                pbr.transparency_mode,
-                albedo_color.r, albedo_color.g, albedo_color.b, albedo_color.a,
-                pbr.metallic.0, pbr.roughness.0, pbr.specular_intensity.0,
-                pbr.texture.is_some(), pbr.emissive_texture.is_some()
-            );
             match pbr.transparency_mode {
                 MaterialTransparencyMode::MtmOpaque => {
                     godot_material.set_transparency(Transparency::DISABLED);
@@ -431,17 +394,16 @@ pub fn apply_dcl_material_properties(
                     godot_material.set_alpha_scissor_threshold(pbr.alpha_test.0);
                 }
                 MaterialTransparencyMode::MtmAlphaBlend => {
-                    godot_material.set_transparency(Transparency::ALPHA);
+                    godot_material.set_transparency(Transparency::ALPHA_DEPTH_PRE_PASS);
                 }
                 MaterialTransparencyMode::MtmAlphaTestAndAlphaBlend => {
-                    godot_material.set_transparency(Transparency::ALPHA);
+                    godot_material.set_transparency(Transparency::ALPHA_DEPTH_PRE_PASS);
                     godot_material.set_alpha_scissor_threshold(pbr.alpha_test.0);
                 }
                 MaterialTransparencyMode::MtmAuto => {
-                    // Unity: alphaTexture != null || albedoColor.a < 1.0 → AlphaBlend, else Opaque
-                    // PBR passes null for alphaTexture, so only albedo alpha matters
-                    if pbr.albedo_color.0.a < 1.0 {
-                        godot_material.set_transparency(Transparency::ALPHA);
+                    // Auto-detect: use alpha blend if albedo has transparency
+                    if pbr.albedo_color.0.a < 1.0 || pbr.texture.is_some() {
+                        godot_material.set_transparency(Transparency::ALPHA_DEPTH_PRE_PASS);
                     } else {
                         godot_material.set_transparency(Transparency::DISABLED);
                     }


### PR DESCRIPTION
## Summary

- On mobile, when virtual camera mode is active, taps in the joystick area (bottom-left ~35% of screen) were consumed by `set_input_as_handled()` and never reached `_on_ui_root_gui_input()` in `explorer.gd`, preventing cursor position updates and `ia_pointer` clicks from reaching scenes.
- Skip `set_input_as_handled()` for `InputEventScreenTouch` events when `raycast_use_cursor_position` is `true` (virtual camera mode active), allowing both joystick movement and scene clicks to work simultaneously.
- Add a 250ms cooldown before showing the joystick visual so quick taps don't flash it on screen.

Closes #1238

## Test plan

- [ ] Enter a scene with a virtual camera on a mobile/touch device
- [ ] Tap in the joystick area (bottom-left) — should set cursor position AND allow joystick input
- [ ] Tap outside the joystick area — should set cursor position (already worked)
- [ ] Drag on joystick — character should move normally (drags still consumed)
- [ ] Quick tap on joystick area — joystick visual should NOT flash
- [ ] Hold on joystick area for 250ms+ — joystick visual should appear
- [ ] Exit virtual camera mode — joystick should behave exactly as before (touches consumed, no click propagation)