### PR TITLE
fix: stuck detector not re-enabling colliders after spawn

### DIFF
--- a/godot/src/logic/player/player.gd
+++ b/godot/src/logic/player/player.gd
@@ -410,8 +410,8 @@ func get_avatar_under_crosshair() -> Avatar:
 	return null
 
 
-func move_to(target: Vector3):
+func move_to(target: Vector3, check_stuck: bool = true):
 	global_position = target
 	velocity = Vector3.ZERO
-	if stuck_detector:
+	if check_stuck and stuck_detector:
 		stuck_detector.check_stuck()

--- a/godot/src/logic/scene_fetcher.gd
+++ b/godot/src/logic/scene_fetcher.gd
@@ -128,7 +128,7 @@ func on_loading_finished():
 		if target_position != null:
 			# Trust the spawn point position, move up if inside a collider
 			var valid_position := _find_valid_spawn_position(target_position)
-			Global.get_explorer().move_to(valid_position, true)
+			Global.get_explorer().move_to(valid_position, true, false)  # skip stuck check, position already validated
 
 
 func on_scene_killed(killed_scene_id, _entity_id):
@@ -937,7 +937,7 @@ func _async_spawn_on_empty_parcel(parcel: Vector2i) -> void:
 	)
 	# Trust the spawn point position, move up if inside a collider
 	var valid_position := _find_valid_spawn_position(parcel_center)
-	Global.get_explorer().move_to(valid_position, true)
+	Global.get_explorer().move_to(valid_position, true, false)  # skip stuck check, position already validated
 
 
 ## Finds a valid spawn position by trusting the spawn point and moving up if inside a collider.

--- a/godot/src/ui/explorer.gd
+++ b/godot/src/ui/explorer.gd
@@ -639,7 +639,7 @@ func _on_control_menu_request_pause_scenes(enabled):
 ## @param skip_loading: When true, skips showing the loading screen.
 ##                      This is used when teleporting inside a scene to avoid
 ##                      showing the loading UI for an already-loaded area.
-func move_to(position: Vector3, skip_loading: bool):
+func move_to(position: Vector3, skip_loading: bool, check_stuck: bool = true):
 	if disable_move_to:
 		return
 
@@ -647,7 +647,7 @@ func move_to(position: Vector3, skip_loading: bool):
 	if player.avatar and player.avatar.emote_controller:
 		player.avatar.emote_controller.set_teleport_grace()
 
-	player.move_to(position)
+	player.move_to(position, check_stuck)
 	var cur_parcel_position = Vector2i(
 		floor(player.position.x * 0.0625), -floor(player.position.z * 0.0625)
 	)


### PR DESCRIPTION
## Summary
Fixes #1196

- **StuckDetector `body_exited` never fires for large colliders**: The stuck detector used a manual `intersect_shape` query to find overlapping colliders on teleport, but relied on the Area3D `body_exited` signal to re-enable them. When the Area3D never tracked the body (common with large floors), `body_exited` never fired and the collider stayed permanently disabled — causing the avatar to fall through the floor.
- **Added active overlap re-check in `_physics_process`**: Instead of relying solely on the Area3D signal, disabled colliders are now actively re-checked each physics frame. Their layer is temporarily restored, a shape query determines if the player still overlaps, and colliders are re-enabled once the player exits. Early-returns when no colliders are disabled (zero cost in the common case).
- **Skip stuck check on spawn**: Spawn paths (`on_loading_finished`, `_async_spawn_on_empty_parcel`) already validate the position via `_find_valid_spawn_position()`, so running `check_stuck` was redundant and harmful — the capsule shape is taller than the validation sphere, falsely detecting the floor as an overlap.

## Test plan
- [ ] Spawn in Fairyland (`fairyland.dcl.eth`) — avatar should stand on the floor, not fall through
- [ ] Spawn in Giftspire at -140,-141 — same, avatar on top of floor
- [ ] Teleport between scenes — stuck detector should still prevent getting stuck inside geometry
- [ ] Walk off a disabled collider after teleporting inside it — collider should re-enable once you exit