### PR TITLE
fix: ensure landscape orientation when jumping in from Discover

### DIFF
--- a/godot/src/global.gd
+++ b/godot/src/global.gd
@@ -700,6 +700,7 @@ func set_orientation_portrait():
 
 
 func teleport_to(parcel_position: Vector2i, new_realm: String):
+	Global.set_orientation_landscape()
 	var explorer = Global.get_explorer()
 	if is_instance_valid(explorer):
 		explorer.teleport_to(parcel_position, new_realm)
@@ -717,6 +718,7 @@ func teleport_to(parcel_position: Vector2i, new_realm: String):
 
 
 func join_world(world_realm: String) -> void:
+	Global.set_orientation_landscape()
 	Global.on_chat_message.emit(
 		"system",
 		"[color=#ccc]Trying to change to world " + world_realm + "[/color]",

--- a/godot/src/ui/explorer.gd
+++ b/godot/src/ui/explorer.gd
@@ -1103,6 +1103,7 @@ func _on_discover_open():
 
 
 func _on_menu_close():
+	Global.set_orientation_landscape()
 	if !navbar.visible:
 		navbar.set_manually_hidden(false)
 		release_mouse()


### PR DESCRIPTION
Fix https://github.com/decentraland/godot-explorer/issues/1443
## Summary
- When pressing **Jump In** from the Discover screen (portrait), the orientation was not switching back to landscape because `teleport_to()` and `join_world()` never restored it — only the "Back to Explorer" button did
- Added `Global.set_orientation_landscape()` to `Global.teleport_to()` and `Global.join_world()` so any navigation to the explorer ensures landscape
- Added `Global.set_orientation_landscape()` in `explorer.gd`'s `_on_menu_close()` as a safety net for any menu-close path

## Test plan
- [ ] Open Discover (portrait), press Jump In on a place → verify orientation switches to landscape
- [ ] Open Discover, press Jump In on an event → verify orientation switches to landscape
- [ ] Open Discover, press Jump In on a world → verify orientation switches to landscape
- [ ] Open Discover, press Back to Explorer → verify orientation switches to landscape (regression)
- [ ] Open Settings/Backpack from explorer, close → verify stays landscape