### PR TITLE
fix: plane mesh UV and unlit alpha texture

### DIFF
--- a/godot/assets/shaders/dcl_unlit_alpha.gdshader
+++ b/godot/assets/shaders/dcl_unlit_alpha.gdshader
@@ -6,12 +6,11 @@ uniform sampler2D alpha_texture : filter_linear_mipmap, repeat_disable;
 uniform vec4 diffuse_color : source_color = vec4(1.0, 1.0, 1.0, 1.0);
 uniform vec2 uv_offset = vec2(0.0, 0.0);
 uniform vec2 uv_scale = vec2(1.0, 1.0);
-
 void fragment() {
     vec2 uv = UV * uv_scale + uv_offset;
     // Only use RGB from diffuse_color (Unity ignores alpha for unlit)
     vec3 albedo = texture(albedo_texture, uv).rgb * diffuse_color.rgb;
 
     ALBEDO = albedo;
-    ALPHA = texture(alpha_texture, uv).r;
+    ALPHA = texture(albedo_texture, uv).a;
 }

--- a/godot/src/decentraland_components/mesh_renderer.gd
+++ b/godot/src/decentraland_components/mesh_renderer.gd
@@ -43,7 +43,7 @@ func set_plane(uvs: Array):
 	var data_array = DclMeshRenderer.get_plane_arrays()
 	var n = min(floor(float(uvs.size()) / 2.0), 8)
 	for i in range(n):
-		data_array[4][i] = Vector2(uvs[i * 2], -uvs[i * 2 + 1])
+		data_array[4][i] = Vector2(uvs[i * 2], 1.0 - uvs[i * 2 + 1])
 
 	self.mesh.add_surface_from_arrays(Mesh.PRIMITIVE_TRIANGLES, data_array)
 


### PR DESCRIPTION
## Summary

- Fix plane mesh UV Y-coordinate conversion: `1.0 - y` instead of `-y`, correctly mapping from Decentraland (0,0=bottom-left) to Godot (0,0=top-left). Negative UVs caused plane mesh textures (like Genesis Plaza event panel arrows) to be invisible.
- Use albedo texture alpha channel (`.a`) instead of alpha texture red channel (`.r`) in the unlit alpha shader, matching Unity's URP Lit behavior.
- Add ETC2 compression error handling with dimension padding and graceful fallback.
- Update iOS deploy tooling to use `xcrun devicectl` instead of `ios-deploy`.

Closes #1275
Partially resolves #1291 — fixes invisible buttons/textures on the try-on panel, but full try-on functionality still needs testing.

## Test plan

- [x] Verify Genesis Plaza event panel arrows are visible on desktop
- [x] Verify transparency renders correctly (no white bars)
- [ ] Test on iOS device
- [ ] Test try-on panel button visibility