### PR TITLE
ci: simplify iOS build labels and remove external branch prefix

### DIFF
--- a/.github/workflows/android_builds.yml
+++ b/.github/workflows/android_builds.yml
@@ -293,7 +293,7 @@ jobs:
             echo ""
             echo "### 🍏 iOS"
             echo ""
-            echo "> iOS builds are triggered manually. Add the \`build-ios-internal\` label to trigger an iOS build."
+            echo "> iOS builds are triggered manually. Add the \`build-ios\` label to trigger an iOS build."
             echo ""
             echo "---"
             echo ""

--- a/.github/workflows/ios_builds.yml
+++ b/.github/workflows/ios_builds.yml
@@ -12,11 +12,6 @@ on:
         required: false
         type: string
         default: ''
-      external:
-        description: 'Use EXT- prefix instead of PR- for deploy branch'
-        required: false
-        type: boolean
-        default: false
     secrets:
       DEPLOY_SSH_KEY:
         required: true
@@ -36,11 +31,6 @@ on:
         options:
           - main
           - release
-      external:
-        description: 'Use EXT- prefix instead of PR- for deploy branch'
-        required: false
-        type: boolean
-        default: false
 permissions:
   pull-requests: write
   contents: read
@@ -155,11 +145,7 @@ jobs:
           PR_NUMBER="${{ inputs.pr_number || github.event.inputs.pr_number }}"
           REF="${{ inputs.ref || github.event.inputs.ref }}"
           if [ -n "$PR_NUMBER" ]; then
-            if [ "${{ inputs.external }}" == "true" ]; then
-              BRANCH_NAME="EXT-${PR_NUMBER}-${REF}"
-            else
-              BRANCH_NAME="PR-${PR_NUMBER}-${REF}"
-            fi
+            BRANCH_NAME="PR-${PR_NUMBER}-${REF}"
           else
             BRANCH_NAME="${REF}"
           fi
@@ -279,11 +265,7 @@ jobs:
           PR_NUMBER="${{ inputs.pr_number || github.event.inputs.pr_number }}"
           REF="${{ inputs.ref || github.event.inputs.ref }}"
           if [ -n "$PR_NUMBER" ]; then
-            if [ "${{ inputs.external }}" == "true" ]; then
-              BRANCH_NAME="EXT-${PR_NUMBER}-${REF}"
-            else
-              BRANCH_NAME="PR-${PR_NUMBER}-${REF}"
-            fi
+            BRANCH_NAME="PR-${PR_NUMBER}-${REF}"
           else
             BRANCH_NAME="${REF}"
           fi
@@ -346,11 +328,7 @@ jobs:
           PR_NUMBER="${{ inputs.pr_number || github.event.inputs.pr_number }}"
           REF="${{ inputs.ref || github.event.inputs.ref }}"
           if [ -n "$PR_NUMBER" ]; then
-            if [ "${{ inputs.external }}" == "true" ]; then
-              BRANCH_NAME="EXT-${PR_NUMBER}-${REF}"
-            else
-              BRANCH_NAME="PR-${PR_NUMBER}-${REF}"
-            fi
+            BRANCH_NAME="PR-${PR_NUMBER}-${REF}"
           else
             BRANCH_NAME="${REF}"
           fi
@@ -411,11 +389,7 @@ jobs:
         run: |
           PR_NUMBER="${{ inputs.pr_number || github.event.inputs.pr_number }}"
           REF="${{ inputs.ref || github.event.inputs.ref }}"
-          if [ "${{ inputs.external }}" == "true" ]; then
-            BRANCH_NAME="EXT-${PR_NUMBER}-${REF}"
-          else
-            BRANCH_NAME="PR-${PR_NUMBER}-${REF}"
-          fi
+          BRANCH_NAME="PR-${PR_NUMBER}-${REF}"
           WORKFLOW_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           DEPLOY_REPO_URL="https://github.com/decentraland/godot-mobile-deploy-pipeline/tree/${BRANCH_NAME}"
 
@@ -449,11 +423,7 @@ jobs:
         run: |
           PR_NUMBER="${{ inputs.pr_number || github.event.inputs.pr_number }}"
           REF="${{ inputs.ref || github.event.inputs.ref }}"
-          if [ "${{ inputs.external }}" == "true" ]; then
-            BRANCH_NAME="EXT-${PR_NUMBER}-${REF}"
-          else
-            BRANCH_NAME="PR-${PR_NUMBER}-${REF}"
-          fi
+          BRANCH_NAME="PR-${PR_NUMBER}-${REF}"
           WORKFLOW_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
           COMMENT_BODY="---
@@ -484,11 +454,7 @@ jobs:
         run: |
           PR_NUMBER="${{ inputs.pr_number || github.event.inputs.pr_number }}"
           REF="${{ inputs.ref || github.event.inputs.ref }}"
-          if [ "${{ inputs.external }}" == "true" ]; then
-            BRANCH_NAME="EXT-${PR_NUMBER}-${REF}"
-          else
-            BRANCH_NAME="PR-${PR_NUMBER}-${REF}"
-          fi
+          BRANCH_NAME="PR-${PR_NUMBER}-${REF}"
           WORKFLOW_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
           COMMENT_BODY="---

--- a/.github/workflows/ios_label_trigger.yml
+++ b/.github/workflows/ios_label_trigger.yml
@@ -13,7 +13,7 @@ jobs:
   pre-build:
     name: Prepare iOS Build
     runs-on: ubuntu-latest
-    if: ${{ github.event.label.name == 'build-ios-internal' || github.event.label.name == 'build-ios-external' }}
+    if: ${{ github.event.label.name == 'build-ios' }}
     steps:
       - name: Remove iOS build label
         env:
@@ -80,10 +80,9 @@ jobs:
   ios-build:
     name: iOS Build
     needs: pre-build
-    if: ${{ github.event.label.name == 'build-ios-internal' || github.event.label.name == 'build-ios-external' }}
+    if: ${{ github.event.label.name == 'build-ios' }}
     uses: ./.github/workflows/ios_builds.yml
     with:
       ref: ${{ github.event.pull_request.head.ref }}
       pr_number: ${{ github.event.pull_request.number }}
-      external: ${{ github.event.label.name == 'build-ios-external' }}
     secrets: inherit

--- a/.github/workflows/runner.yml
+++ b/.github/workflows/runner.yml
@@ -42,7 +42,7 @@ jobs:
       SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
 
   # iOS builds are triggered separately via:
-  # - Label 'build-ios-internal' on PRs (see ios_label_trigger.yml)
+  # - Label 'build-ios' on PRs (see ios_label_trigger.yml)
   # - Manual workflow dispatch (see ios_builds.yml)
 
   linux-build:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -184,8 +184,8 @@ cargo run -- export --target ios
 5. **Triggering iOS CI builds**:
    iOS builds are skipped by default to save CI resources. To trigger an iOS build:
    ```bash
-   # On a PR: add the build-ios-internal label
-   gh pr edit --add-label "build-ios-internal"
+   # On a PR: add the build-ios label
+   gh pr edit --add-label "build-ios"
 
    # Manual trigger: use the GitHub Actions UI or gh CLI
    gh workflow run "🍏 iOS" --ref main

--- a/README.md
+++ b/README.md
@@ -153,8 +153,8 @@ cargo run -- strip-ios-templates
 iOS builds are skipped by default to save CI resources. To trigger an iOS build:
 
 ```bash
-# On a PR: add the build-ios-internal label
-gh pr edit --add-label "build-ios-internal"
+# On a PR: add the build-ios label
+gh pr edit --add-label "build-ios"
 
 # Manual trigger: use the GitHub Actions UI or gh CLI
 gh workflow run "🍏 iOS" --ref main


### PR DESCRIPTION
## Summary
- Rename iOS build trigger labels from `build-ios-internal`/`build-ios-external` to `build-ios-dev`/`build-ios-playtest`
- Remove the `external` input parameter and `EXT-` branch prefix logic from `ios_builds.yml`, always using the `PR-` prefix for deploy branches
- Update references in `android_builds.yml`, `runner.yml`, `CLAUDE.md`, and `README.md` to reflect the new label names

## Test plan
- [ ] Verify `build-ios-dev` label triggers a PR iOS build correctly
- [ ] Verify `build-ios-playtest` label triggers a PR iOS build correctly
- [ ] Verify manual workflow dispatch still works
- [ ] Confirm deploy branches use `PR-` prefix consistently