### PR TITLE
fix: resolve iOS log redaction in Console.app

### DIFF
--- a/lib/Cargo.lock
+++ b/lib/Cargo.lock
@@ -256,8 +256,6 @@ dependencies = [
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
- "log",
- "prettyplease 0.2.25",
  "proc-macro2",
  "quote",
  "regex",
@@ -796,6 +794,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "5.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
+dependencies = [
+ "cfg-if",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "dasp_sample"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -885,6 +896,7 @@ dependencies = [
  "num-derive",
  "num-traits",
  "once_cell",
+ "oslog",
  "paranoid-android",
  "poll-promise",
  "prost 0.11.9",
@@ -902,7 +914,6 @@ dependencies = [
  "tokio-tungstenite 0.20.1",
  "tokio-util",
  "tracing",
- "tracing-oslog",
  "tracing-subscriber",
  "tracing-test",
  "url",
@@ -1735,6 +1746,12 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
+name = "hashbrown"
 version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a9bfc1af68b1726ea47d3d5109de126281def866b33970e10fbab11b5dafab3"
@@ -2170,7 +2187,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.15.1",
 ]
 
 [[package]]
@@ -2373,7 +2390,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -2971,6 +2988,17 @@ name = "openssl-probe"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "oslog"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d2043d1f61d77cb2f4b1f7b7b2295f40507f5f8e9d1c8bf10a1ca5f97a3969"
+dependencies = [
+ "cc",
+ "dashmap",
+ "log",
+]
 
 [[package]]
 name = "outref"
@@ -4730,21 +4758,6 @@ dependencies = [
  "log",
  "once_cell",
  "tracing-core",
-]
-
-[[package]]
-name = "tracing-oslog"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "528bdd1f0e27b5dd9a4ededf154e824b0532731e4af73bb531de46276e0aab1e"
-dependencies = [
- "bindgen 0.70.1",
- "cc",
- "cfg-if",
- "once_cell",
- "parking_lot",
- "tracing-core",
- "tracing-subscriber",
 ]
 
 [[package]]

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -84,7 +84,7 @@ jni = { version = "0.21.1", features = ["invocation"] }
 paranoid-android = "0.2.1"
 
 [target.'cfg(target_os = "ios")'.dependencies]
-tracing-oslog = "0.2"
+oslog = "0.2"
 
 [features]
 default = ["use_livekit", "use_deno"]


### PR DESCRIPTION
## Summary
- Replace `tracing-oslog` with `oslog` crate for iOS logging — Apple's Unified Logging redacts dynamic strings by default, and `tracing-oslog` does not use `%{public}s`, causing all messages to appear as `Warning: <private>` in Console.app
- Implement a custom `IosOsLogLayer` (a `tracing_subscriber::Layer`) that formats messages as `[LEVEL] [target] message` and maps tracing levels to appropriate OSLog levels (ERROR/WARN → Error, INFO → Info, DEBUG/TRACE → Debug)
- Sentry layer is preserved (unlike the earlier PR #1106 which accidentally dropped it)

## Changes
- `lib/Cargo.toml`: `tracing-oslog = "0.2"` → `oslog = "0.2"`
- `lib/src/godot_classes/dcl_global.rs`: Replace `OsLogger` with custom `IosOsLogLayer` using the `oslog` crate
- `lib/Cargo.lock`: Updated automatically (removed `tracing-oslog`, added `oslog` + transitive deps)

## Context
This is a corrected version of the approach from PR #1106, which was never merged. The key difference is that the Sentry tracing layer is kept intact.

## Test plan
- [ ] Build for iOS: `cargo run -- build --target ios`
- [ ] Deploy to device and open Console.app
- [ ] Filter by process name and confirm logs show full messages like `[INFO] [dclgodot::comms] ...` instead of `Warning: <private>`
- [ ] Verify Sentry still receives error/warning events