### PR TITLE
fix: prevent unsaved scene changes lost on tab switch in mobile preview

### DIFF
--- a/godot/addons/dcl_mobile_preview/mobile_preview_plugin.gd
+++ b/godot/addons/dcl_mobile_preview/mobile_preview_plugin.gd
@@ -37,6 +37,7 @@ var _bezel: int = 0  # bezel thickness in game pixels
 var _confirm_dialog: ConfirmationDialog
 var _error_dialog: AcceptDialog
 var _pending_apply: bool = false
+var _tab_switch_pending: bool = false
 
 # State
 var _is_portrait: bool = true
@@ -251,7 +252,8 @@ func _on_scene_orient_selected(id: int) -> void:
 	if not scene_path.is_empty():
 		EditorInterface.save_scene()
 		_apply_current()
-		_record_clean_version()
+		# Erase so the post-reload scene_changed records a fresh baseline
+		_clean_versions.erase(scene_path)
 		EditorInterface.reload_scene_from_path(scene_path)
 	else:
 		_apply_current()
@@ -579,22 +581,36 @@ func _on_scene_changed_deferred() -> void:
 	var old_orient := _scene_orient
 	_sync_orient_from_scene()
 	_apply_current()
-	_record_clean_version()
+
+	# Only record the clean baseline for scenes we haven't tracked yet (first open).
+	# Re-recording on every tab switch would overwrite the original baseline and
+	# hide unsaved modifications from the _is_scene_modified() check below.
+	var root = EditorInterface.get_edited_scene_root()
+	var scene_path: String = root.scene_file_path if root else ""
+	if not scene_path.is_empty() and not _clean_versions.has(scene_path):
+		_record_clean_version()
+
 	# Reload when resolution changed: portrait flipped, or transitioning to/from NONE
 	var needs_reload := (
 		_is_portrait != old_portrait
 		or (_scene_orient == ORIENT_NONE) != (old_orient == ORIENT_NONE)
 	)
-	if needs_reload:
-		var root = EditorInterface.get_edited_scene_root()
-		if root and not root.scene_file_path.is_empty():
+	if needs_reload and root and not scene_path.is_empty():
+		if _is_scene_modified():
+			_pending_apply = true
+			_tab_switch_pending = true
+			_confirm_dialog.popup_centered()
+		else:
 			_reload_current_scene.call_deferred()
 
 
 func _reload_current_scene() -> void:
 	var root = EditorInterface.get_edited_scene_root()
 	if root and not root.scene_file_path.is_empty():
-		EditorInterface.reload_scene_from_path(root.scene_file_path)
+		var path: String = root.scene_file_path
+		# Erase so the post-reload scene_changed records a fresh baseline
+		_clean_versions.erase(path)
+		EditorInterface.reload_scene_from_path(path)
 
 
 # --- Scene change detection ---
@@ -634,6 +650,8 @@ func _request_apply_with_reload() -> void:
 		else:
 			var scene_path: String = root.scene_file_path
 			_apply_current()
+			# Erase so the post-reload scene_changed records a fresh baseline
+			_clean_versions.erase(scene_path)
 			EditorInterface.reload_scene_from_path(scene_path)
 	else:
 		_apply_current()
@@ -643,6 +661,7 @@ func _on_confirm_save_reload() -> void:
 	if not _pending_apply:
 		return
 	_pending_apply = false
+	_tab_switch_pending = false
 
 	var root = EditorInterface.get_edited_scene_root()
 	var scene_path: String = root.scene_file_path if root else ""
@@ -651,12 +670,20 @@ func _on_confirm_save_reload() -> void:
 
 	if not scene_path.is_empty():
 		EditorInterface.save_scene()
+		# Erase so the post-reload scene_changed records a fresh baseline
+		_clean_versions.erase(scene_path)
 		EditorInterface.reload_scene_from_path(scene_path)
 
 
 func _on_confirm_canceled() -> void:
 	if _pending_apply:
 		_pending_apply = false
+		# Tab-switch cancels: settings are already correct for the current scene,
+		# so don't revert device/orientation. The user keeps their unsaved changes
+		# and can save manually later.
+		if _tab_switch_pending:
+			_tab_switch_pending = false
+			return
 		var es := EditorInterface.get_editor_settings()
 		var prev: int = (
 			es.get_setting(SETTINGS_DEVICE_KEY) if es.has_setting(SETTINGS_DEVICE_KEY) else 0


### PR DESCRIPTION
Fix https://github.com/decentraland/godot-explorer/issues/1502
## Summary

- Fixes unsaved scene changes being silently discarded when switching between editor tabs with different orientations in the mobile preview plugin (#1448)
- The root cause was `_record_clean_version()` overwriting the undo/redo baseline on every tab switch, combined with unconditional `reload_scene_from_path()` calls
- Clean version baseline is now only recorded on first scene open, preserving accurate modification detection
- When a tab switch requires a reload and the scene has unsaved changes, a "Save & Reload" dialog is shown instead of silently reloading from disk
- `_clean_versions` entries are erased before all `reload_scene_from_path()` calls so post-reload `scene_changed` records a fresh baseline

## Test plan

- [ ] Open a scene with orientation metadata (e.g., portrait), make unsaved changes
- [ ] Switch to a scene with different orientation (e.g., landscape), then switch back
- [ ] Verify the "Save & Reload" dialog appears for the modified scene
- [ ] Confirm "Save & Reload" saves changes and updates the viewport orientation
- [ ] Confirm "Cancel" preserves unsaved changes (viewport may not resize)
- [ ] Verify switching between clean (unmodified) scenes with different orientations still reloads correctly without a dialog
- [ ] Verify changing scene orientation via the scene menu (save + reload) still works
- [ ] Verify changing device/orientation via toolbar still shows dialog when scene is modified