### PR TITLE
fix: settings screen not showing when opened from backpack navbar

### DIFF
--- a/godot/src/ui/components/dropdown_list/dropdown_list.gd
+++ b/godot/src/ui/components/dropdown_list/dropdown_list.gd
@@ -215,9 +215,9 @@ func _async_open_popup() -> void:
 		_shadow_rect.size = shadow_size
 
 		# Update shader uniform with shadow rect size for correct corner radius calculation
-		var material := _shadow_rect.material as ShaderMaterial
-		if material:
-			material.set_shader_parameter("rect_size", shadow_size)
+		var shader_material := _shadow_rect.material as ShaderMaterial
+		if shader_material:
+			shader_material.set_shader_parameter("rect_size", shadow_size)
 
 	_popup_layer.visible = true
 	_button_panel.add_theme_stylebox_override("panel", _style_pressed)

--- a/godot/src/ui/components/menu/menu.gd
+++ b/godot/src/ui/components/menu/menu.gd
@@ -20,6 +20,9 @@ var selected_node: PlaceholderManager
 var current_screen_name: String = ""
 var fade_out_tween: Tween = null
 var fade_in_tween: Tween = null
+var _close_modulate_tween: Tween = null
+var _close_hide_tween: Tween = null
+var _close_node_to_free: PlaceholderManager = null
 
 @onready var group: ButtonGroup = ButtonGroup.new()
 
@@ -94,14 +97,21 @@ func close():
 	GraphicSettings.apply_full_processor_mode()
 	if Global.player_identity.has_changes():
 		Global.player_identity.async_save_profile()
-	var tween_m = create_tween()
-	tween_m.tween_property(self, "modulate", Color(1, 1, 1, 0), 0.3).set_ease(Tween.EASE_IN_OUT)
-	var tween_h = create_tween()
-	tween_h.tween_callback(hide).set_delay(0.3)
-	tween_h.tween_callback(
+	_close_modulate_tween = create_tween()
+	_close_modulate_tween.tween_property(self, "modulate", Color(1, 1, 1, 0), 0.3).set_ease(
+		Tween.EASE_IN_OUT
+	)
+	# Capture the node to free NOW, before the tween callback fires.
+	# If we reference `selected_node` directly in the lambda, it may have changed
+	# by the time the callback runs (e.g. user opened Settings while close tween is running).
+	_close_node_to_free = selected_node
+	_close_hide_tween = create_tween()
+	_close_hide_tween.tween_callback(hide).set_delay(0.3)
+	_close_hide_tween.tween_callback(
 		func():
-			if selected_node:
-				selected_node.queue_free_instance()
+			if _close_node_to_free:
+				_close_node_to_free.queue_free_instance()
+				_close_node_to_free = null
 	)
 
 
@@ -125,6 +135,9 @@ func async_show_backpack(on_emotes := false):
 
 func async_show_settings():
 	await control_settings._async_instantiate()
+
+	if not is_instance_valid(control_settings.instance):
+		return
 
 	control_settings.instance.request_pause_scenes.connect(
 		func(enabled): request_pause_scenes.emit(enabled)
@@ -150,6 +163,16 @@ func async_show_own_profile():
 func _open():
 	if is_open:
 		return
+	# Kill any pending close tweens so the old close() doesn't hide us again.
+	# But still free the node that close() intended to free (avoid memory leak).
+	if is_instance_valid(_close_modulate_tween) and _close_modulate_tween.is_running():
+		_close_modulate_tween.kill()
+	if is_instance_valid(_close_hide_tween) and _close_hide_tween.is_running():
+		_close_hide_tween.kill()
+		# The tween callback won't fire, so free the node manually
+		if _close_node_to_free:
+			_close_node_to_free.queue_free_instance()
+			_close_node_to_free = null
 	if selected_node and not selected_node.instance:
 		selected_node = null
 	if not selected_node:
@@ -213,6 +236,8 @@ func select_node(node: PlaceholderManager, play_sfx: bool = true):
 
 
 func fade_in(node: PlaceholderManager):
+	if not is_instance_valid(node.instance):
+		return
 	selected_node = node
 	node.instance.show()
 	if is_instance_valid(fade_in_tween):
@@ -225,6 +250,8 @@ func fade_in(node: PlaceholderManager):
 
 
 func fade_out(node: PlaceholderManager):
+	if not is_instance_valid(node.instance):
+		return
 	if is_instance_valid(fade_out_tween):
 		if fade_out_tween.is_running():
 			fade_out_tween.custom_step(100.0)

--- a/godot/src/ui/components/settings/settings.gd
+++ b/godot/src/ui/components/settings/settings.gd
@@ -32,8 +32,6 @@ var _dirty_connected: bool = false
 @onready var progress_bar_current_cache_size: ProgressBar = %ProgressBar_CurrentCacheSize
 @onready var button_clear_cache: Button = %Button_ClearCache
 
-@onready var h_slider_skybox_time: HSlider = %HSlider_SkyboxTime
-@onready var label_skybox_time: Label = %Label_SkyboxTime
 @onready
 var check_button_submit_message_closes_chat: CheckButton = %CheckButton_SubmitMessageClosesChat
 @onready var preview_camera_3d: Camera3D = %PreviewCamera3D
@@ -63,9 +61,8 @@ var check_button_submit_message_closes_chat: CheckButton = %CheckButton_SubmitMe
 @onready var dynamic_graphics_container: HBoxContainer = %DynamicGraphics
 @onready var check_button_dynamic_graphics: CheckButton = %CheckButton_DynamicGraphics
 
-# Dynamic graphics toggle
-@onready
-var dynamic_skybox: HBoxContainer = $ColorRect_Content/MarginContainer/MarginContainer/ScrollContainer/VBoxContainer/VBoxContainer_Graphics/VBoxContainer/SectionVisual/VBoxContainer/DynamicSkybox
+# Dynamic skybox toggle
+@onready var dynamic_skybox: HBoxContainer = %DynamicSkybox
 @onready var check_button_dynamic_skybox: CheckButton = %CheckButton_DynamicSkybox
 
 @onready var radio_selector_texture_quality = %RadioSelector_TextureQuality
@@ -297,12 +294,12 @@ func _on_line_edit_preview_url_focus_entered() -> void:
 	var line_edit_h: float = line_edit_custom_preview_url.size.y
 	var padding: float = 20.0
 	if line_edit_y_in_content < scroll_y + padding:
-		content_scroll_container.scroll_vertical = maxf(0, line_edit_y_in_content - padding)
+		content_scroll_container.scroll_vertical = int(maxf(0, line_edit_y_in_content - padding))
 	elif line_edit_y_in_content + line_edit_h > scroll_y + view_h - padding:
 		var v_bar = content_scroll_container.get_v_scroll_bar()
 		var max_scroll: float = v_bar.max_value if v_bar else 0.0
-		content_scroll_container.scroll_vertical = minf(
-			max_scroll, line_edit_y_in_content + line_edit_h - view_h + padding
+		content_scroll_container.scroll_vertical = int(
+			minf(max_scroll, line_edit_y_in_content + line_edit_h - view_h + padding)
 		)
 
 

--- a/godot/src/ui/components/settings/settings.tscn
+++ b/godot/src/ui/components/settings/settings.tscn
@@ -558,6 +558,7 @@ theme_override_constants/separation = 24
 theme_override_styles/separator = SubResource("StyleBoxEmpty_xewta")
 
 [node name="DynamicSkybox" type="HBoxContainer" parent="VBoxContainer/MarginContainer_Content/ContentScrollContainer/VBoxContainer_Sections/VBoxContainer_Graphics/VBoxContainer/SectionVisual/VBoxContainer"]
+unique_name_in_owner = true
 layout_mode = 2
 theme_override_constants/separation = 32
 
@@ -649,6 +650,7 @@ theme_override_font_sizes/font_size = 24
 text = "Graphic Profile"
 
 [node name="RadioSelector_GraphicProfile" parent="VBoxContainer/MarginContainer_Content/ContentScrollContainer/VBoxContainer_Sections/VBoxContainer_Graphics/VBoxContainer/SectionVisual/VBoxContainer/GraphicProfile" instance=ExtResource("7_u8bs2")]
+unique_name_in_owner = true
 layout_mode = 2
 theme = SubResource("Theme_7krp8")
 items = Array[String](["VERY LOW", "LOW", "MEDIUM", "HIGH", "CUSTOM"])

--- a/godot/src/ui/components/settings/slider.gd
+++ b/godot/src/ui/components/settings/slider.gd
@@ -75,9 +75,6 @@ func _ready():
 	_h_slider.value = value
 	_h_slider.editable = editable
 
-	_h_slider.value_changed.connect(_on_h_slider_value_changed)
-	_h_slider.drag_ended.connect(_on_h_slider_drag_ended)
-
 
 func _update_title():
 	if _title_label:


### PR DESCRIPTION
fixes #1519 

## Summary
- Fix race condition in menu `close()`/`_open()` where the close tween's lambda captured `selected_node` by reference, freeing the wrong screen when a new one was opened before the tween completed
- Cancel pending close tweens in `_open()` to prevent the old `hide()` callback from hiding the re-opened menu
- Remove dead `@onready` references, fix hardcoded node path, add missing `unique_name_in_owner`, remove duplicate signal connections, and fix minor warnings

## Test plan
- [ ] Open Explorer → Backpack → click Settings from navbar → settings screen should appear
- [ ] Navigate back and forth between Backpack and Settings multiple times
- [ ] Open Settings directly from the menu buttons
- [ ] Verify no errors/warnings in console related to `slider.gd`, `settings.gd`, or `dropdown_list.gd`