### PR TITLE
fix: livestream screens too dark due to double gamma correction

### DIFF
--- a/lib/src/scene_runner/components/material.rs
+++ b/lib/src/scene_runner/components/material.rs
@@ -313,7 +313,11 @@ pub fn apply_dcl_material_properties(
             godot_material.set_specular(0.0);
 
             godot_material.set_shading_mode(ShadingMode::UNSHADED);
-            godot_material.set_flag(Flags::ALBEDO_TEXTURE_FORCE_SRGB, true);
+            let is_video_texture = unlit
+                .texture
+                .as_ref()
+                .is_some_and(|t| matches!(t.source, DclSourceTex::VideoTexture(_)));
+            godot_material.set_flag(Flags::ALBEDO_TEXTURE_FORCE_SRGB, !is_video_texture);
             // Unity ignores diffuse_color alpha for unlit materials, force alpha to 1.0
             // No color space conversion — matches Unity (SetColor with no conversion)
             let mut albedo_color = unlit.diffuse_color.0.to_godot();
@@ -389,7 +393,11 @@ pub fn apply_dcl_material_properties(
                 godot_material.set_emission_operator(EmissionOperator::ADD);
             }
 
-            godot_material.set_flag(Flags::ALBEDO_TEXTURE_FORCE_SRGB, true);
+            let is_video_texture = pbr
+                .texture
+                .as_ref()
+                .is_some_and(|t| matches!(t.source, DclSourceTex::VideoTexture(_)));
+            godot_material.set_flag(Flags::ALBEDO_TEXTURE_FORCE_SRGB, !is_video_texture);
             // No color space conversion — matches Unity (SetColor with no conversion)
             godot_material.set_albedo(pbr.albedo_color.0.to_godot());
 


### PR DESCRIPTION
## Summary
- Disable `ALBEDO_TEXTURE_FORCE_SRGB` flag for video textures (LiveKit, ExoPlayer, AVPlayer) to prevent double gamma correction
- Video frames are already sRGB from YUV→RGB conversion; the flag was applying an extra sRGB→linear conversion, darkening the image
- Static image and avatar textures are unaffected (flag remains `true`)

Fixes #1151

## Test plan
- [x] Verified on iOS: livestream brightness now matches expected levels
- [ ] Verify on Android
- [ ] Verify non-video materials (walls, floors, avatars) have no color regression