### PR TITLE
chore: update protocol to commit b829b38

### DIFF
--- a/src/install_dependency.rs
+++ b/src/install_dependency.rs
@@ -30,7 +30,7 @@ fn create_directory_all(path: &Path) -> io::Result<()> {
     Ok(())
 }
 
-const PROTOCOL_FIXED_VERSION_URL: Option<&str> = Some("https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-21650527315.commit-b658867.tgz");
+const PROTOCOL_FIXED_VERSION_URL: Option<&str> = Some("https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-22578236808.commit-b829b38.tgz");
 
 fn get_protocol_url() -> Result<String, anyhow::Error> {
     match PROTOCOL_FIXED_VERSION_URL {


### PR DESCRIPTION
## Summary
- Update DCL protocol from `b658867` to `b829b38`
- Resolves camera_layer component ID conflict (1211 -> 1503) with avatar_locomotion_settings (1211)

## Test plan
- [x] `cargo run -- install` downloads new protocol successfully
- [x] `cargo run -- build` compiles without errors
- [ ] `cargo run -- run` client runs correctly