### PR TITLE
feat: remove mute/unmute button from social item

### DIFF
--- a/godot/src/ui/components/social/social_item/social_item.gd
+++ b/godot/src/ui/components/social/social_item/social_item.gd
@@ -10,8 +10,6 @@ const LOAD_TIMEOUT_SECONDS: float = 5.0
 
 var is_guest = false
 var trim_value = 20
-var mute_icon = load("res://assets/ui/audio_off.svg")
-var unmute_icon = load("res://assets/ui/audio_on.svg")
 var social_data: SocialItemData
 var current_friendship_status: int = Global.FriendshipStatus.UNKNOWN
 var load_state: LoadState = LoadState.UNLOADED
@@ -31,7 +29,6 @@ var _load_start_time: float = 0.0
 @onready var v_box_container_nickname: VBoxContainer = %VBoxContainer_Nickname
 @onready var texture_rect_claimed_checkmark: TextureRect = %TextureRect_ClaimedCheckmark
 @onready var button_add_friend: Button = %Button_AddFriend
-@onready var button_mute: Button = %Button_Mute
 @onready var button_accept: Button = %Button_Accept
 @onready var button_reject: Button = %Button_Reject
 @onready var label_pending_request: Label = %Label_PendingRequest
@@ -47,8 +44,6 @@ func _ready():
 	# Connect to locations signal to update jump button visibility
 	if Global.locations:
 		Global.locations.in_genesis_city_changed.connect(_on_in_genesis_city_changed)
-	# Connect to blacklist changes to update button states
-	Global.social_blacklist.blacklist_changed.connect(_on_blacklist_changed_for_buttons)
 
 
 func set_data(data: SocialItemData, should_load: bool = true) -> void:
@@ -119,7 +114,6 @@ func _async_load_item() -> void:
 
 	# If type is NEARBY, check if already a friend
 	if item_type == SOCIAL_TYPE.NEARBY and not social_data.address.is_empty():
-		_update_buttons()
 		_check_and_update_friend_status()
 
 
@@ -201,24 +195,6 @@ func _on_mouse_exited() -> void:
 	panel_nearby_player_item.self_modulate = "#ffffff00"
 
 
-func _on_button_mute_toggled(toggled_on: bool) -> void:
-	if toggled_on:
-		Global.social_blacklist.add_muted(social_data.address)
-	else:
-		Global.social_blacklist.remove_muted(social_data.address)
-	_update_buttons()
-	_notify_other_components_of_change()
-
-
-func _update_buttons() -> void:
-	var is_muted = Global.social_blacklist.is_muted(social_data.address)
-	button_mute.set_pressed_no_signal(is_muted)
-	if is_muted:
-		button_mute.icon = mute_icon
-	else:
-		button_mute.icon = unmute_icon
-
-
 func _notify_other_components_of_change() -> void:
 	if social_data.address:
 		Global.get_tree().call_group("blacklist_ui_sync", "_sync_blacklist_ui", social_data.address)
@@ -240,7 +216,6 @@ func _update_elements_visibility() -> void:
 			# Guest users cannot add friends
 			# Check if already a friend and hide/show ADD FRIEND button accordingly
 			if social_data and not social_data.address.is_empty():
-				_update_buttons()
 				# If status is already known (pre-checked), use it directly
 				if current_friendship_status != Global.FriendshipStatus.UNKNOWN:
 					_update_button_visibility_from_status()
@@ -591,11 +566,6 @@ func shorten_tittle(title: String, max_length: int) -> String:
 func _on_blacklist_changed() -> void:
 	# Handle blacklist changes for NEARBY and REQUEST items
 	_update_blocked_visibility_for_type()
-
-
-func _on_blacklist_changed_for_buttons() -> void:
-	# Update buttons state when blacklist changes
-	_update_buttons()
 
 
 func _update_blocked_visibility_for_type() -> void:

--- a/godot/src/ui/components/social/social_item/social_item.tscn
+++ b/godot/src/ui/components/social/social_item/social_item.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=22 format=3 uid="uid://d30nejywxmhpn"]
+[gd_scene load_steps=19 format=3 uid="uid://d30nejywxmhpn"]
 
 [ext_resource type="Script" uid="uid://01ks4grp4i30" path="res://src/ui/components/social/social_item/social_item.gd" id="1_qmekl"]
 [ext_resource type="Theme" uid="uid://chwr8vock83p4" path="res://assets/themes/dark_dcl_theme/dark_dcl_theme.tres" id="2_wvdds"]
@@ -8,7 +8,6 @@
 [ext_resource type="FontFile" uid="uid://0qlati8b2q8n" path="res://assets/themes/fonts/inter/inter_400.ttf" id="7_m2rwh"]
 [ext_resource type="Theme" uid="uid://bn7q4ap7m5gdu" path="res://assets/themes/dcl_theme.tres" id="10_2kre2"]
 [ext_resource type="StyleBox" uid="uid://p7xigefabmi8" path="res://assets/themes/seconday_pressed_hover_little.tres" id="12_lm8sy"]
-[ext_resource type="Texture2D" uid="uid://0w50cay6b2b6" path="res://assets/ui/mute.svg" id="12_m2rwh"]
 [ext_resource type="Texture2D" uid="uid://cnainsx10j8v1" path="res://assets/ui/add.svg" id="13_5r2pa"]
 [ext_resource type="StyleBox" uid="uid://cjr732avt4ugw" path="res://assets/themes/secondary_disabled_little.tres" id="13_pm4ta"]
 [ext_resource type="Texture2D" uid="uid://c5h83d44qsbhr" path="res://assets/themes/dark_dcl_theme/icons/Chat.svg" id="14_lm8sy"]
@@ -19,24 +18,6 @@
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_66h5u"]
 bg_color = Color(1, 1, 1, 0.0823529)
-corner_radius_top_left = 10
-corner_radius_top_right = 10
-corner_radius_bottom_right = 10
-corner_radius_bottom_left = 10
-
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_fkduy"]
-content_margin_top = 8.0
-content_margin_bottom = 8.0
-bg_color = Color(0, 0, 0, 0.4)
-corner_radius_top_left = 10
-corner_radius_top_right = 10
-corner_radius_bottom_right = 10
-corner_radius_bottom_left = 10
-
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_o0a4w"]
-content_margin_top = 8.0
-content_margin_bottom = 8.0
-bg_color = Color(0, 0, 0, 0.4)
 corner_radius_top_left = 10
 corner_radius_top_right = 10
 corner_radius_bottom_right = 10
@@ -215,33 +196,6 @@ mouse_filter = 2
 theme_override_constants/separation = 10
 alignment = 1
 
-[node name="Button_Mute" type="Button" parent="MarginContainer/Panel_NearbyPlayerItem/MarginContainer/HBoxContainer/HBoxContainer_Nearby"]
-unique_name_in_owner = true
-custom_minimum_size = Vector2(40, 40)
-layout_mode = 2
-size_flags_horizontal = 4
-size_flags_vertical = 4
-focus_mode = 0
-mouse_default_cursor_shape = 2
-theme = ExtResource("10_2kre2")
-theme_type_variation = &"SecondaryLittle"
-theme_override_constants/icon_max_width = 30
-theme_override_styles/normal = SubResource("StyleBoxFlat_fkduy")
-theme_override_styles/normal_mirrored = SubResource("StyleBoxFlat_o0a4w")
-theme_override_styles/pressed = ExtResource("12_lm8sy")
-theme_override_styles/pressed_mirrored = ExtResource("12_lm8sy")
-theme_override_styles/hover = ExtResource("12_lm8sy")
-theme_override_styles/hover_mirrored = ExtResource("12_lm8sy")
-theme_override_styles/hover_pressed = ExtResource("12_lm8sy")
-theme_override_styles/hover_pressed_mirrored = ExtResource("12_lm8sy")
-theme_override_styles/disabled = ExtResource("13_pm4ta")
-theme_override_styles/disabled_mirrored = ExtResource("13_pm4ta")
-theme_override_styles/focus = ExtResource("12_lm8sy")
-toggle_mode = true
-icon = ExtResource("12_m2rwh")
-icon_alignment = 1
-expand_icon = true
-
 [node name="Button_AddFriend" type="Button" parent="MarginContainer/Panel_NearbyPlayerItem/MarginContainer/HBoxContainer/HBoxContainer_Nearby"]
 unique_name_in_owner = true
 custom_minimum_size = Vector2(40, 40)
@@ -329,6 +283,5 @@ expand_icon = true
 [connection signal="mouse_entered" from="MarginContainer/Panel_NearbyPlayerItem" to="." method="_on_mouse_entered"]
 [connection signal="mouse_exited" from="MarginContainer/Panel_NearbyPlayerItem" to="." method="_on_mouse_exited"]
 [connection signal="pressed" from="MarginContainer/Panel_NearbyPlayerItem/MarginContainer/HBoxContainer/HBoxContainer_Online/Button_JumpIn" to="." method="_on_button_jump_in_pressed"]
-[connection signal="toggled" from="MarginContainer/Panel_NearbyPlayerItem/MarginContainer/HBoxContainer/HBoxContainer_Nearby/Button_Mute" to="." method="_on_button_mute_toggled"]
 [connection signal="pressed" from="MarginContainer/Panel_NearbyPlayerItem/MarginContainer/HBoxContainer/HBoxContainer_Nearby/Button_AddFriend" to="." method="_on_button_add_friend_pressed"]
 [connection signal="pressed" from="MarginContainer/Panel_NearbyPlayerItem/MarginContainer/HBoxContainer/HBoxContainer_Blocked/Button_Unblock" to="." method="_on_button_unblock_pressed"]


### PR DESCRIPTION
Closes #926 

This PR remove the mute/unmute button from social item (in nearby players).
To mute an user, you must now go to enter to their profile and use the three-dots menu on the right.