### PR TITLE
fix: video screen glitching and LiveKit audio issues

### DIFF
--- a/godot/src/decentraland_components/video_player.gd
+++ b/godot/src/decentraland_components/video_player.gd
@@ -41,6 +41,9 @@ var _last_effective_volume: float = -1.0  # -1 means uninitialized
 var _last_play_pause_time: float = 0.0
 var _pending_play_state: int = -1  # -1=none, 0=pause, 1=play
 
+# Track if we ever received a valid frame (to distinguish garbage from last frame)
+var _has_received_frame: bool = false
+
 
 # Called from Rust DclVideoPlayer::init_backend
 func _init_backend_impl(backend_type: int, source: String, playing: bool, looping: bool):
@@ -349,7 +352,7 @@ func _update_av_player_volume():
 ## LiveKit uses Godot's AudioStreamPlayer which goes through audio buses
 ## Godot buses handle master/scene volume, we only apply video's own volume
 func _update_livekit_volume():
-	var effective_volume: float = 0.0 if dcl_muted else dcl_volume
+	var effective_volume: float = 0.0 if (dcl_muted or not _is_playing) else dcl_volume
 
 	if absf(effective_volume - _last_effective_volume) < 0.001:
 		return
@@ -371,6 +374,9 @@ func _update_video_state():
 			_update_livekit_state()
 		_:
 			pass
+
+	if video_state == VIDEO_STATE_PLAYING:
+		_has_received_frame = true
 
 
 ## Poll ExoPlayer state and update video_state/position/length
@@ -432,6 +438,10 @@ func _update_av_player_state():
 func _update_livekit_state():
 	# LiveKit state is set to PLAYING by Rust when frames arrive
 	# Here we detect buffering/stopped when frames haven't arrived for a while
+	# Skip if user manually paused (state managed by _apply_pause/_apply_play)
+	if not _is_playing:
+		return
+
 	# Only check if we've received at least one frame
 	if last_frame_time <= 0:
 		return
@@ -444,9 +454,10 @@ func _update_livekit_state():
 		if time_since_last_frame > LIVEKIT_BUFFERING_THRESHOLD:
 			video_state = VIDEO_STATE_BUFFERING
 	elif video_state == VIDEO_STATE_BUFFERING:
-		# If no frames for a long time, stream is likely stopped
+		# If no frames for a long time, stream is likely stopped - show black
 		if time_since_last_frame > LIVEKIT_STOPPED_THRESHOLD:
 			video_state = VIDEO_STATE_PAUSED
+			_has_received_frame = false
 
 
 # Backend control methods called from Rust
@@ -465,6 +476,7 @@ func _backend_play():
 
 func _apply_play():
 	_is_playing = true
+	_last_effective_volume = -1.0  # Force volume recalculation
 	match current_backend:
 		BackendType.EXO_PLAYER:
 			if exo_player:
@@ -473,7 +485,7 @@ func _apply_play():
 			if av_player:
 				av_player.play()
 		BackendType.LIVEKIT:
-			pass  # LiveKit is always "playing" when receiving frames
+			pass  # Rust will resume updating texture when _is_playing is true
 		_:
 			pass
 
@@ -493,6 +505,7 @@ func _backend_pause():
 
 func _apply_pause():
 	_is_playing = false
+	_last_effective_volume = -1.0  # Force volume recalculation (mutes LiveKit audio)
 	match current_backend:
 		BackendType.EXO_PLAYER:
 			if exo_player:
@@ -501,7 +514,8 @@ func _apply_pause():
 			if av_player:
 				av_player.pause()
 		BackendType.LIVEKIT:
-			pass  # LiveKit doesn't support pause
+			# Freeze last frame - Rust will stop updating texture while _is_playing is false
+			video_state = VIDEO_STATE_PAUSED
 		_:
 			pass
 
@@ -562,6 +576,7 @@ func _backend_dispose():
 
 	current_backend = BackendType.NOOP
 	_source = ""
+	_has_received_frame = false
 	# Reset state when disposing - will trigger state change event on next source
 	video_state = VIDEO_STATE_NONE
 	video_position = 0.0
@@ -570,6 +585,13 @@ func _backend_dispose():
 
 
 func _get_backend_texture() -> Texture2D:
+	# Before receiving the first valid frame, ExternalTexture (ExoPlayer/AVPlayer)
+	# may contain GPU garbage. Return null to let Rust use the black placeholder.
+	# After the first frame, always return the backend texture so that pause/buffering
+	# keeps showing the last valid frame instead of going black.
+	if not _has_received_frame:
+		return null
+
 	match current_backend:
 		BackendType.EXO_PLAYER:
 			if exo_player:
@@ -582,7 +604,7 @@ func _get_backend_texture() -> Texture2D:
 			return dcl_texture
 		_:
 			pass
-	return dcl_texture
+	return null
 
 
 # LiveKit audio streaming methods
@@ -592,8 +614,17 @@ func init_livekit_audio(sample_rate: int, _num_channels: int, _samples_per_chann
 
 	var stream = self.get_stream() as AudioStreamGenerator
 	if stream:
-		print("VideoPlayer: Setting LiveKit audio sample_rate=", sample_rate)
 		stream.mix_rate = sample_rate
+		# Clear buffer on re-init to avoid stale data
+		clear_audio_buffer()
+
+
+func clear_audio_buffer():
+	if current_backend != BackendType.LIVEKIT:
+		return
+	var playback = self.get_stream_playback() as AudioStreamGeneratorPlayback
+	if playback:
+		playback.clear_buffer()
 
 
 func stream_buffer(data: PackedVector2Array):
@@ -605,7 +636,8 @@ func stream_buffer(data: PackedVector2Array):
 
 	var playback = self.get_stream_playback() as AudioStreamGeneratorPlayback
 	if playback:
-		playback.push_buffer(data)
+		if playback.get_frames_available() >= data.size():
+			playback.push_buffer(data)
 
 
 # Legacy methods for backward compatibility with existing code

--- a/lib/src/comms/adapter/livekit.rs
+++ b/lib/src/comms/adapter/livekit.rs
@@ -338,6 +338,9 @@ fn spawn_livekit_task(
             });
         }
 
+        // Track the current streamer audio task so we can abort it when a new one arrives
+        let mut streamer_audio_task: Option<tokio::task::JoinHandle<()>> = None;
+
         'stream: loop {
             tokio::select!(
                 incoming = network_rx.recv() => {
@@ -444,6 +447,12 @@ fn spawn_livekit_task(
                             match track {
                                 livekit::track::RemoteTrack::Audio(audio) => {
                                     if is_streamer {
+                                        // Abort previous streamer audio task if any
+                                        if let Some(prev_task) = streamer_audio_task.take() {
+                                            tracing::debug!("Aborting previous streamer audio task before starting new one");
+                                            prev_task.abort();
+                                        }
+
                                         // Streamer audio -> video player audio
                                         let sender = sender.clone();
                                         let room_id_clone = room_id.clone();
@@ -451,7 +460,7 @@ fn spawn_livekit_task(
                                         // Use zero address for streamers
                                         let address = address.unwrap_or_default();
 
-                                        rt2.spawn(async move {
+                                        streamer_audio_task = Some(rt2.spawn(async move {
                                             let mut stream = livekit::webrtc::audio_stream::native::NativeAudioStream::new(audio.rtc_track(), 48000, 1);
 
                                             tracing::debug!("streamer audio track from {:?}", identity_owned);
@@ -504,7 +513,7 @@ fn spawn_livekit_task(
                                             }
 
                                             tracing::debug!("streamer audio track ended, exiting task");
-                                        });
+                                        }));
                                     } else if let Some(address) = address {
                                         // Regular participant audio -> voice chat
                                         let sender = sender.clone();

--- a/lib/src/scene_runner/components/material.rs
+++ b/lib/src/scene_runner/components/material.rs
@@ -18,8 +18,9 @@ use crate::{
 use godot::{
     classes::{
         base_material_3d::{EmissionOperator, Feature, Flags, ShadingMode, Transparency},
-        Material, MeshInstance3D, ResourceLoader, Shader, ShaderMaterial, StandardMaterial3D,
-        Texture2D,
+        image::Format,
+        Image, ImageTexture, Material, MeshInstance3D, ResourceLoader, Shader, ShaderMaterial,
+        StandardMaterial3D, Texture2D,
     },
     global::weakref,
     prelude::*,
@@ -540,6 +541,27 @@ fn is_valid_texture(texture: &Gd<Texture2D>) -> bool {
     texture.get_width() > 0 && texture.get_height() > 0
 }
 
+/// Returns a cached 2x2 black opaque texture for use as a placeholder when no video is playing.
+fn get_black_placeholder_texture() -> Gd<ImageTexture> {
+    thread_local! {
+        static BLACK_TEXTURE: std::cell::RefCell<Option<Gd<ImageTexture>>> = const { std::cell::RefCell::new(None) };
+    }
+    BLACK_TEXTURE.with(|cell| {
+        let mut borrow = cell.borrow_mut();
+        if let Some(tex) = borrow.as_ref() {
+            tex.clone()
+        } else {
+            let mut image = Image::create(2, 2, false, Format::RGBA8)
+                .expect("couldn't create black placeholder image");
+            image.fill(Color::BLACK);
+            let tex = ImageTexture::create_from_image(&image)
+                .expect("couldn't create black placeholder texture");
+            *borrow = Some(tex.clone());
+            tex
+        }
+    })
+}
+
 fn check_texture(
     param: godot::classes::base_material_3d::TextureParam,
     dcl_texture: &Option<DclTexture>,
@@ -718,44 +740,55 @@ pub fn update_video_material_textures(scene: &mut Scene) {
         }
     }
 
+    if !video_texture_updates.is_empty() {
+        tracing::debug!(
+            "update_video_material_textures: {} video texture bindings to process",
+            video_texture_updates.len()
+        );
+    }
+
     // Now apply the video textures (we can mutably borrow video_players here)
     for (material_ref, param, video_entity_id) in video_texture_updates {
         if let Some(video_player) = scene.video_players.get_mut(&video_entity_id) {
+            let video_state: i32 = video_player.bind().get_video_state();
             let mut material = material_ref.to::<Gd<StandardMaterial3D>>();
 
             // Get current texture to check if update is needed
-            // This prevents calling set_texture every frame which exhausts descriptor pools
             let current_texture = material.get_texture(param);
 
-            // Try get_backend_texture first (works for ExoPlayer's ExternalTexture)
+            // get_backend_texture returns null before the first valid frame (GDScript guard).
             let backend_texture = video_player.bind_mut().get_backend_texture();
-            if let Some(texture) = backend_texture {
-                // Validate texture has actual data before using to prevent GPU crashes
-                if is_valid_texture(&texture) {
-                    // Only set texture if it's different (compare by instance ID)
-                    let needs_update = current_texture
-                        .as_ref()
-                        .is_none_or(|current| current.instance_id() != texture.instance_id());
-                    if needs_update {
-                        material.set_texture(param, &texture.upcast::<Texture2D>());
-                    }
-                }
-            } else {
-                // Fallback to dcl_texture (works for LiveKit's ImageTexture)
-                if let Some(texture) = video_player.bind().get_dcl_texture() {
-                    let texture_2d = texture.upcast::<Texture2D>();
-                    // Validate texture has actual data before using to prevent GPU crashes
-                    if is_valid_texture(&texture_2d) {
-                        // Only set texture if it's different (compare by instance ID)
-                        let needs_update = current_texture.as_ref().is_none_or(|current| {
-                            current.instance_id() != texture_2d.instance_id()
-                        });
-                        if needs_update {
-                            material.set_texture(param, &texture_2d);
-                        }
-                    }
-                }
+            let has_backend = backend_texture.is_some();
+            let resolved_texture: Option<Gd<Texture2D>> = backend_texture
+                .filter(is_valid_texture)
+                .map(|t| t.upcast::<Texture2D>());
+
+            let using_placeholder = resolved_texture.is_none();
+
+            // Use resolved texture or fall back to a black placeholder
+            let texture_to_set = resolved_texture
+                .unwrap_or_else(|| get_black_placeholder_texture().upcast::<Texture2D>());
+
+            // Only set texture if it's different (compare by instance ID)
+            let needs_update = current_texture
+                .as_ref()
+                .is_none_or(|current| current.instance_id() != texture_to_set.instance_id());
+            if needs_update {
+                tracing::debug!(
+                    "update_video_material_textures: entity {:?} video_state={} has_backend={} using_placeholder={} param={:?}",
+                    video_entity_id,
+                    video_state,
+                    has_backend,
+                    using_placeholder,
+                    param
+                );
+                material.set_texture(param, &texture_to_set);
             }
+        } else {
+            tracing::warn!(
+                "update_video_material_textures: video_player not found for entity {:?}",
+                video_entity_id
+            );
         }
     }
 }

--- a/lib/src/scene_runner/components/video_player.rs
+++ b/lib/src/scene_runner/components/video_player.rs
@@ -293,8 +293,9 @@ fn get_or_create_video_player_node(parent: &mut Gd<Node3D>, scene_id: i32) -> Gd
     video_player_node.bind_mut().set_dcl_scene_id(scene_id);
     video_player_node.set_name("VideoPlayer");
 
-    // Create initial placeholder texture for LiveKit (will be updated by video frames)
-    let image = Image::create(8, 8, false, Format::RGBA8).expect("couldn't create video image");
+    // Create initial black placeholder texture (will be updated when video frames arrive)
+    let mut image = Image::create(2, 2, false, Format::RGBA8).expect("couldn't create video image");
+    image.fill(Color::BLACK);
     let texture = ImageTexture::create_from_image(&image).expect("couldn't create video texture");
     video_player_node.bind_mut().set_dcl_texture(Some(texture));
 
@@ -485,19 +486,17 @@ pub fn update_video_texture_from_livekit(
 
     let data_arr = PackedByteArray::from_vec(data);
 
+    let image =
+        Image::create_from_data(width as i32, height as i32, false, Format::RGBA8, &data_arr)
+            .unwrap();
+
     // Check if resize needed
     let current_size = texture.get_size();
     if current_size.x != width as f32 || current_size.y != height as f32 {
-        // Create new image with new dimensions
-        let image =
-            Image::create_from_data(width as i32, height as i32, false, Format::RGBA8, &data_arr)
-                .unwrap();
+        // Resize: set_image replaces internal image and uploads to GPU
         texture.set_image(&image);
-        texture.update(&image);
     } else {
-        // Update existing texture in-place
-        let mut image = texture.get_image().unwrap();
-        image.set_data(width as i32, height as i32, false, Format::RGBA8, &data_arr);
+        // Same size: update in-place (avoids GPU reallocation)
         texture.update(&image);
     }
 }

--- a/lib/src/scene_runner/scene.rs
+++ b/lib/src/scene_runner/scene.rs
@@ -4,11 +4,7 @@ use std::{
     time::Instant,
 };
 
-use godot::{
-    obj::{NewAlloc, Singleton},
-    prelude::Gd,
-    prelude::ToGodot,
-};
+use godot::{obj::NewAlloc, prelude::Gd, prelude::ToGodot};
 
 use crate::{
     content::content_mapping::{ContentMappingAndUrl, ContentMappingAndUrlRef},
@@ -490,23 +486,42 @@ impl Scene {
         use crate::godot_classes::dcl_video_player::VIDEO_STATE_PLAYING;
         use crate::scene_runner::components::video_player::update_video_texture_from_livekit;
         use godot::classes::Time;
+        use godot::prelude::*;
 
         let current_time = Time::singleton().get_ticks_msec() as f64 / 1000.0;
 
         // Send video frames to all registered livekit video players
         for entity_id in self.livekit_video_player_entities.clone() {
-            // Update the texture
-            if let Some(node) = self.godot_dcl_scene.get_godot_entity_node_mut(&entity_id) {
-                if let Some(vp_data) = &mut node.video_player_data {
-                    update_video_texture_from_livekit(vp_data, width, height, data);
-                }
-            }
-
-            // Update video player state to PLAYING when receiving frames
             if let Some(video_player) = self.video_players.get_mut(&entity_id) {
-                video_player.set("video_state", &VIDEO_STATE_PLAYING.to_variant());
-                video_player.set("video_length", &(-1.0_f64).to_variant());
+                // Always update last_frame_time so timeout detection works
                 video_player.set("last_frame_time", &current_time.to_variant());
+
+                // Check if the scene SDK has paused this player
+                let is_playing: bool = video_player
+                    .get("_is_playing")
+                    .try_to::<bool>()
+                    .unwrap_or(true);
+
+                if is_playing {
+                    // Detect stream resuming after a gap — clear stale audio buffer
+                    let prev_state: i32 =
+                        video_player.get("video_state").try_to::<i32>().unwrap_or(0);
+                    if prev_state != VIDEO_STATE_PLAYING {
+                        video_player.call("clear_audio_buffer", &[]);
+                    }
+
+                    // Update the texture only when playing
+                    if let Some(node) = self.godot_dcl_scene.get_godot_entity_node_mut(&entity_id) {
+                        if let Some(vp_data) = &mut node.video_player_data {
+                            update_video_texture_from_livekit(vp_data, width, height, data);
+                        }
+                    }
+
+                    // Update state to PLAYING
+                    video_player.set("video_state", &VIDEO_STATE_PLAYING.to_variant());
+                    video_player.set("video_length", &(-1.0_f64).to_variant());
+                }
+                // When paused: texture keeps the last frame, state stays as-is
             }
         }
     }
@@ -540,11 +555,20 @@ impl Scene {
     }
 
     pub fn process_livekit_audio_frame(&mut self, frame: godot::prelude::PackedVector2Array) {
+        use godot::prelude::*;
+
         // Send audio frames to all registered livekit video players
         for entity_id in self.livekit_video_player_entities.clone() {
             if let Some(video_player) = self.video_players.get_mut(&entity_id) {
-                // Call the stream_buffer method on the video player (GDScript)
-                video_player.call("stream_buffer", &[frame.to_variant()]);
+                // Skip audio when paused to avoid buffer accumulation
+                let is_playing: bool = video_player
+                    .get("_is_playing")
+                    .try_to::<bool>()
+                    .unwrap_or(true);
+
+                if is_playing {
+                    video_player.call("stream_buffer", &[frame.to_variant()]);
+                }
             }
         }
     }


### PR DESCRIPTION
Fixes #1400

## Summary

- **Black placeholder texture** before the first valid frame arrives, preventing GPU garbage/glitchy screens on Android (ExternalTexture can contain uninitialized GPU data)
- **LiveKit pause/resume support**: pausing freezes on the last frame and mutes audio instead of showing garbage or continuing playback
- **Fix audio task duplication on stream reconnect**: when a LiveKit stream pauses and resumes, `TrackSubscribed` fires again spawning a new audio task while the old one was still running — both pushed audio frames causing saturated/duplicated audio and progressive FPS drops. Now the previous task is aborted before spawning a new one
- **Audio buffer cleanup on state transitions**: clears stale audio data when stream resumes after a gap, and on `init_livekit_audio` re-init
- **Stream buffer overflow protection**: checks `get_frames_available()` before pushing audio to avoid overflow
- **Texture update optimization**: removed per-frame `texture.get_image()` GPU download and redundant `set_image` + `update` double call in LiveKit texture path

## Test plan

- [ ] Visit a LiveKit streaming location (e.g. aesironline.dcl.eth) on Android — verify no glitchy/garbage textures before stream starts
- [ ] Verify video screens show black when no stream is active
- [ ] Pause/resume a LiveKit stream — should freeze frame and mute, then resume cleanly
- [ ] Let a stream disconnect and reconnect — audio should not duplicate or saturate
- [ ] Visit locations from issue #1400 (La Cantina -150,92 or Gallery 78,-105) on Android
- [ ] Verify regular (non-LiveKit) video playback still works on Android/iOS