### PR TITLE
fix: joystick area dont covers top left corner

### DIFF
--- a/godot/src/mobile/joystick/virtual_joystick.tscn
+++ b/godot/src/mobile/joystick/virtual_joystick.tscn
@@ -52,14 +52,13 @@ deadzone_size = 10.0
 _joystick_default_position = Vector2(160, 165)
 joystick_mode = 1
 visibility_mode = 1
+metadata/mobile_preview_orientation = "landscape"
 
 [node name="ActiveArea" type="Control" parent="."]
 layout_mode = 1
-anchor_top = 1.0
 anchor_right = 0.352
 anchor_bottom = 1.0
-offset_top = -425.0
-offset_right = 171.458
+offset_right = 171.45801
 grow_horizontal = 2
 grow_vertical = 0
 mouse_filter = 2


### PR DESCRIPTION
## Summary                                                                                                                                                                                                      
  - Fix joystick active area to cover the full top-left region of the screen, preventing unintended camera movement when tapping that area                                                                        
  - Removed incorrect anchor/offset configuration that left a gap in the top-left corner                                                                                                                          
                                                                                                                                                                                                                  
  ## Test plan                                                                                                                                                                                                    
  - [ ] On iOS/Android, tap the top-left corner of the screen                                                                                                                                                     
  - [ ] Verify it triggers the joystick instead of camera movement

  Closes #1645