### PR TITLE
fix: scene crash reload button not working (#1644)

### DIFF
--- a/godot/src/ui/components/modal/modal_manager.gd
+++ b/godot/src/ui/components/modal/modal_manager.gd
@@ -327,8 +327,8 @@ func _on_change_realm_primary(realm_name: String) -> void:
 	close_current_modal()
 
 
-func _on_scene_crash_reload(entity_id: String) -> void:
-	Global.scene_fetcher.reload_scene(entity_id)
+func _on_scene_crash_reload(_entity_id: String) -> void:
+	Global.realm.async_set_realm(Global.realm.get_realm_string())
 	close_current_modal()
 
 


### PR DESCRIPTION
## Summary
- Fix the RELOAD button in the scene crash modal which silently did nothing
- The crashed scene is already dead and removed from `loaded_scenes` by the time the user clicks RELOAD, so `reload_scene(entity_id)` was a no-op
- Now uses `Global.realm.async_set_realm(Global.realm.get_realm_string())` — the same realm reload approach used by `/reload` chat command and scene timeout

Closes #1644

## Test plan
- [ ] Run the client and enter a scene
- [ ] Type `/scenecrash` in chat to trigger a crash
- [ ] Click RELOAD in the crash modal
- [ ] Verify the realm reloads and the scene comes back