### PR TITLE
fix: camera mode button stays invisible when sidebar closed via clicking outside (#1693)

### DIFF
--- a/godot/src/decentraland_components/dcl_global_camera_controller.gd
+++ b/godot/src/decentraland_components/dcl_global_camera_controller.gd
@@ -81,9 +81,7 @@ func _process(delta: float) -> void:
 			# Going back to player camera - reparent to self conserving global transform
 			if global_virtual_camera.get_parent() != self:
 				global_virtual_camera.reparent(self)
-			Global.camera_mode_set.emit(
-				Global.player_camera_node.get_camera_mode() as Global.CameraMode
-			)
+			Global.set_camera_mode(Global.player_camera_node.get_camera_mode() as Global.CameraMode)
 		else:
 			# Switching to virtual camera - start from current viewport camera position
 			var current_camera = get_viewport().get_camera_3d()
@@ -92,7 +90,7 @@ func _process(delta: float) -> void:
 
 			# Make the global virtual camera current
 			global_virtual_camera.make_current()
-			Global.camera_mode_set.emit(Global.CameraMode.CINEMATIC)
+			Global.set_camera_mode(Global.CameraMode.CINEMATIC)
 
 			# When virtual camera is active we always show the primary avatar and hide outlines
 			var explorer = Global.get_explorer()

--- a/godot/src/global.gd
+++ b/godot/src/global.gd
@@ -97,6 +97,7 @@ var deep_link_url: String = ""
 var deep_link_router := DeepLinkRouter.new()
 
 var player_camera_node: DclCamera3D
+var current_camera_mode: CameraMode = CameraMode.THIRD_PERSON
 var session_id: String
 
 var _is_portrait: bool = true
@@ -881,4 +882,5 @@ func _on_player_profile_changed_sync_events(_profile: DclUserProfile) -> void:
 
 
 func set_camera_mode(camera_mode: Global.CameraMode) -> void:
+	current_camera_mode = camera_mode
 	camera_mode_set.emit(camera_mode)

--- a/godot/src/mobile/joystick/virtual_joystick.gd
+++ b/godot/src/mobile/joystick/virtual_joystick.gd
@@ -103,7 +103,8 @@ func _on_navbar_opened() -> void:
 
 
 func _on_navbar_closed() -> void:
-	_button_camera.show()
+	if Global.current_camera_mode != Global.CameraMode.CINEMATIC:
+		_button_camera.show()
 
 
 func _on_camera_mode_set(camera_mode: Global.CameraMode) -> void:

--- a/godot/src/ui/components/navbar/navbar.gd
+++ b/godot/src/ui/components/navbar/navbar.gd
@@ -65,7 +65,6 @@ func _on_size_changed():
 
 func _on_navbar_close() -> void:
 	collapse()
-	navbar_closed.emit()
 
 
 func _on_button_toggled(toggled_on: bool) -> void:
@@ -99,6 +98,7 @@ func capture_mouse():
 func collapse():
 	button.set_pressed_no_signal(false)
 	animation_player.play("close")
+	navbar_closed.emit()
 
 
 func _on_navbar_open_silently_on_backpack() -> void:

--- a/godot/src/ui/components/navbar/navbar.tscn
+++ b/godot/src/ui/components/navbar/navbar.tscn
@@ -318,5 +318,4 @@ grow_vertical = 2
 toggle_mode = true
 flat = true
 
-[connection signal="pressed" from="Control/Control/PanelContainer/VBoxContainer_Buttons/Control/Portrait_Button_Profile" to="." method="_on_portrait_button_profile_pressed"]
 [connection signal="toggled" from="Control/Button" to="." method="_on_button_toggled"]


### PR DESCRIPTION
## Summary                                                                                                                                                                                                       
  - `navbar.collapse()` now emits `navbar_closed` so all collapse paths (clicking outside, discover open, profile open) properly notify listeners                                                                  
  - Added `Global.current_camera_mode` to track camera mode state centrally                                                                                                                                        
  - `dcl_global_camera_controller.gd` now uses `Global.set_camera_mode()` instead of direct signal emits, keeping `current_camera_mode` in sync                                                                    
  - `_on_navbar_closed()` in `virtual_joystick.gd` skips showing the camera button when in CINEMATIC mode

  ## Test plan
  - [ ] Open sidebar → camera button hides
  - [ ] Close sidebar by clicking outside → camera button reappears
  - [ ] Close sidebar by clicking the sidebar icon → camera button reappears
  - [ ] Enter CINEMATIC camera mode (virtual camera scene), open and close sidebar → camera button stays hidden

  Closes #1693
