### PR TITLE
fix: handle fixed-adapter comms for world scenes

### DIFF
--- a/lib/src/comms/communication_manager.rs
+++ b/lib/src/comms/communication_manager.rs
@@ -1940,11 +1940,7 @@ fn parse_comms_adapter_value(
     };
 
     // Strip "fixed-adapter:" prefix if present
-    raw.map(|s| {
-        s.strip_prefix("fixed-adapter:")
-            .unwrap_or(&s)
-            .to_string()
-    })
+    raw.map(|s| s.strip_prefix("fixed-adapter:").unwrap_or(&s).to_string())
 }
 
 #[cfg(test)]
@@ -2010,9 +2006,7 @@ mod tests {
         );
         assert_eq!(
             result,
-            Some(
-                "archipelago:wss://archipelago-ws-connector.decentraland.org/ws".to_string()
-            )
+            Some("archipelago:wss://archipelago-ws-connector.decentraland.org/ws".to_string())
         );
     }
 
@@ -2084,8 +2078,7 @@ mod tests {
     #[test]
     fn test_adapter_unknown_protocol_ignored() {
         // Unknown adapter values (not archipelago, not fixed-adapter) should be None
-        let result =
-            parse_comms_adapter_value(None, Some("unknown:something"), false, true);
+        let result = parse_comms_adapter_value(None, Some("unknown:something"), false, true);
         assert_eq!(result, None);
     }
 }


### PR DESCRIPTION
## Summary

Fixes #1719

- World about endpoints return comms adapter as `adapter: "fixed-adapter:signed-login:https://..."` but the parsing logic only handled `"archipelago:"` prefixed values in the `adapter` field, silently discarding world adapters
- This caused `commsAdapter` in `RealmInfo` to remain empty on fresh boot, preventing SDK room initialization (`checkRoomReady` never fires)
- Extract adapter parsing into a testable pure function (`parse_comms_adapter_value`)
- Add `"fixed-adapter:"` prefix handling in the adapter field branch

## Root cause

In `_internal_get_comms_from_realm()`, the `adapter` field handler (as opposed to `fixedAdapter`) only accepted values starting with `"archipelago:"`. World endpoints use `"fixed-adapter:signed-login:..."` in the `adapter` field, which fell through to `None`, causing the warning `"As far, only fixedAdapter is supported."` and preventing `change_adapter()` from ever being called.

## Test plan

- [x] Unit tests added covering all adapter scenarios (10 tests, including 2 bug reproduction tests)
- [x] Verified bug reproduction: without fix, `fixedAdapter: None` + warning logged
- [x] Verified fix: with fix, `fixedAdapter: Some("signed-login:...")` → signed-login → LiveKit connection successful
- [x] Tested with real wallet on `aesironline.dcl.eth` and `thecodingcave.dcl.eth`
- [x] `cargo clippy -- -D warnings` passes
- [x] Mobile build + fresh boot test to world