### PR TITLE
Fix MISSING_PKCE_METADATA error on iOS auth

### DIFF
--- a/godot/src/global.gd
+++ b/godot/src/global.gd
@@ -594,10 +594,7 @@ func open_webview_url(url):
 func open_url(url: String, use_webkit: bool = false):
 	if use_webkit and not Global.is_xr():
 		if DclIosPlugin.is_available():
-			if "provider=apple" in url:
-				DclIosPlugin.open_safari_auth_url(url)
-			else:
-				DclIosPlugin.open_auth_url(url)
+			DclIosPlugin.open_safari_auth_url(url)
 		elif DclAndroidPlugin.is_available():
 			if "provider=wallet-connect" in url:
 				DclAndroidPlugin.open_webview(url, "")  # FOR WALLET CONNECT


### PR DESCRIPTION
## Summary

Route all iOS OAuth providers through `SFSafariViewController` instead of only Apple Sign-In. `ASWebAuthenticationSession` loses `localStorage` during cross-origin redirect chains, causing Magic SDK's PKCE metadata lookup to fail with `MISSING_PKCE_METADATA` for Google, Discord, and X sign-in.

This extends the fix from `acefdf2e` (which solved this for Apple Sign-In only) to all providers.

## What could break

- If any OAuth provider relies on `ASWebAuthenticationSession`-specific behavior (unlikely — the callback already works via deep links)
- `SFSafariViewController` doesn't show the system "X wants to use Y to sign in" consent dialog, but this is cosmetic

## How to test

1. Build and deploy to an iOS device
2. Test sign-in with each provider:
   - Google → should complete without PKCE error
   - Apple → should still work (was already using SFSafariViewController)
   - Discord → should complete without PKCE error
   - X → should complete without PKCE error
3. Verify the app returns from Safari and SFSafariViewController auto-dismisses