### PR TITLE
fix: connection health checker bug + monitor cleanup

### DIFF
--- a/godot/src/connection_quality_monitor.gd
+++ b/godot/src/connection_quality_monitor.gd
@@ -40,12 +40,20 @@ func _ready() -> void:
 	_poll_timer.timeout.connect(_on_poll_timeout)
 	add_child(_poll_timer)
 	_poll_timer.start()
+	# Before a realm is set (lobby / backpack / discover), _get_health_url() falls
+	# back to peer_base() so we still detect real connection loss on those screens.
 
 	poor_connection_detected.connect(_on_poor_connection)
 	connection_lost_detected.connect(_async_on_connection_lost)
 	connection_restored.connect(_on_connection_restored)
 	Global.modal_manager.connection_lost_retry.connect(_on_retry)
 	Global.modal_manager.connection_lost_exit.connect(_on_exit)
+
+	# Pause polling while a realm change is in flight so 404s / slow /about calls
+	# on the new realm don't get counted as connection failures.
+	Global.realm.realm_changing.connect(_on_realm_changing)
+	Global.realm.realm_changed.connect(_on_realm_changed)
+	Global.realm.realm_change_failed.connect(_on_realm_change_failed)
 
 
 func _on_poll_timeout() -> void:
@@ -63,7 +71,9 @@ func _async_check_connection() -> void:
 		_is_checking = false
 		return
 
-	var promise: Promise = Global.http_requester.request_json(url, HTTPClient.METHOD_GET, "", {})
+	# HEAD instead of GET: we only care about reachability + status code, not the
+	# /about payload (which is several KB of realm metadata per poll).
+	var promise: Promise = Global.http_requester.request_json(url, HTTPClient.METHOD_HEAD, "", {})
 	var timeout_promise := _create_timeout_promise(REQUEST_TIMEOUT_SECONDS)
 
 	var start_ms := Time.get_ticks_msec()
@@ -211,3 +221,30 @@ func _on_retry() -> void:
 	_retrying = true
 	if OS.get_name() == "iOS":
 		_ios_retry_used = true
+
+
+func _on_realm_changing() -> void:
+	# Discard any in-flight check and stop pinging until the realm change settles.
+	_poll_timer.stop()
+	_check_generation += 1
+	_is_checking = false
+	_consecutive_errors = 0
+
+
+func _on_realm_changed() -> void:
+	# New realm is validated: (re)start polling from a clean slate.
+	_resume_polling()
+
+
+func _on_realm_change_failed(_new_realm_string: String, _reason: String) -> void:
+	# Realm change was rejected. Resume polling either against the previous realm
+	# (if any) or against the peer_base() fallback used in the pre-realm screens.
+	_resume_polling()
+
+
+func _resume_polling() -> void:
+	_state = State.GOOD
+	_consecutive_errors = 0
+	_retrying = false
+	_set_poll_interval(FAST_POLL_SECONDS)
+	_poll_timer.start()

--- a/godot/src/connection_quality_monitor.gd
+++ b/godot/src/connection_quality_monitor.gd
@@ -30,6 +30,10 @@ var _is_checking: bool = false
 var _check_generation: int = 0
 var _retrying: bool = false
 var _ios_retry_used: bool = false
+# True while a connection_lost modal opened *by us* is on screen. Used so that
+# _on_connection_restored only dismisses our own modal, not e.g. a teleport modal
+# that the user opened in the meantime.
+var _showing_our_modal: bool = false
 
 
 func _ready() -> void:
@@ -98,6 +102,17 @@ func _async_check_connection() -> void:
 					% [_consecutive_errors, result.get_error()]
 				)
 			)
+
+		# A failure right after a retry goes straight to LOST: the user already
+		# acknowledged the problem once and asked us to verify, so a single fresh
+		# failure is enough to bring the modal back without waiting for the threshold.
+		if _retrying:
+			_retrying = false
+			if _state != State.LOST:
+				_state = State.LOST
+				_async_on_connection_lost()
+			_is_checking = false
+			return
 	else:
 		if _consecutive_errors > 0:
 			prints(
@@ -119,13 +134,6 @@ func _async_check_connection() -> void:
 
 func _update_state() -> void:
 	if _state == State.LOST:
-		return
-
-	# After retry: 1 failure goes straight to modal
-	if _retrying and _consecutive_errors >= 1:
-		_state = State.LOST
-		_retrying = false
-		_async_on_connection_lost()
 		return
 
 	var has_explorer := Global.get_explorer() != null
@@ -182,24 +190,19 @@ func _on_poor_connection() -> void:
 func _async_on_connection_lost() -> void:
 	# On iOS: first time show retry, second time show modal without buttons
 	var hide_buttons := OS.get_name() == "iOS" and _ios_retry_used
+	_showing_our_modal = true
 	await Global.modal_manager.async_show_connection_lost_modal(hide_buttons)
-	# Replace the default secondary (exit) handler so the modal stays visible while quitting
-	# On iOS the exit button is hidden, so no rewiring needed
-	if OS.get_name() != "iOS":
-		if (
-			Global.modal_manager.current_modal
-			and Global.modal_manager.current_modal.button_secondary
-		):
-			var btn = Global.modal_manager.current_modal.button_secondary
-			if btn.pressed.is_connected(Global.modal_manager._on_connection_lost_secondary):
-				btn.pressed.disconnect(Global.modal_manager._on_connection_lost_secondary)
-			btn.pressed.connect(_on_exit)
+	# Exit handling is wired via Global.modal_manager.connection_lost_exit → _on_exit
+	# in _ready(). modal_manager._on_connection_lost_secondary intentionally does not
+	# close the modal so it stays visible while get_tree().quit() runs.
 
 
 func _on_connection_restored() -> void:
 	_retrying = false
 	_ios_retry_used = false
-	Global.modal_manager.close_current_modal()
+	if _showing_our_modal:
+		_showing_our_modal = false
+		Global.modal_manager.close_current_modal()
 
 
 func _on_exit() -> void:
@@ -213,6 +216,8 @@ func _on_retry() -> void:
 	_state = State.GOOD
 	_is_checking = false
 	_retrying = true
+	# modal_manager._on_connection_lost_primary already closed the modal.
+	_showing_our_modal = false
 	if OS.get_name() == "iOS":
 		_ios_retry_used = true
 

--- a/godot/src/connection_quality_monitor.gd
+++ b/godot/src/connection_quality_monitor.gd
@@ -2,25 +2,23 @@ extends Node
 
 ## ConnectionQualityMonitor
 ##
-## Autoload that periodically pings a lightweight endpoint to assess
-## connection quality. Emits signals consumed by the toast and modal systems.
+## Autoload that periodically HEADs the current realm's /about (or peer_base when
+## no realm is set) to assess connection quality. Emits signals consumed by the
+## toast and modal systems.
 ##
 ## Polling:
-##   - Fast (0.5s): default, and while connection is degraded
-##   - Slow (2.0s): after a successful ping
+##   - Slow (10s): happy path, when the last ping succeeded
+##   - Fast (0.5s): investigation mode, triggered as soon as any ping fails so
+##     consecutive errors get counted quickly without waiting a full slow tick
 ##
-## After 2 consecutive failures:
-##   - With explorer UI: poor connection notification
-##   - Without explorer UI: connection lost modal
-
-signal poor_connection_detected
-signal connection_lost_detected
-signal connection_restored
+## Thresholds (consecutive failures):
+##   - With explorer UI:    2 → poor connection toast, 4 → connection lost modal
+##   - Without explorer UI: 2 → connection lost modal (no toast stage)
 
 enum State { GOOD, POOR, LOST }
 
 const FAST_POLL_SECONDS: float = 0.5
-const SLOW_POLL_SECONDS: float = 2.0
+const SLOW_POLL_SECONDS: float = 10.0
 const REQUEST_TIMEOUT_SECONDS: float = 3.0
 const CONSECUTIVE_ERRORS_FOR_DEGRADED: int = 2
 const CONSECUTIVE_ERRORS_FOR_LOST: int = 4
@@ -43,9 +41,6 @@ func _ready() -> void:
 	# Before a realm is set (lobby / backpack / discover), _get_health_url() falls
 	# back to peer_base() so we still detect real connection loss on those screens.
 
-	poor_connection_detected.connect(_on_poor_connection)
-	connection_lost_detected.connect(_async_on_connection_lost)
-	connection_restored.connect(_on_connection_restored)
 	Global.modal_manager.connection_lost_retry.connect(_on_retry)
 	Global.modal_manager.connection_lost_exit.connect(_on_exit)
 
@@ -90,14 +85,14 @@ func _async_check_connection() -> void:
 		_consecutive_errors += 1
 		_set_poll_interval(FAST_POLL_SECONDS)
 		if not promise.is_resolved():
-			print(
+			printerr(
 				(
 					"[ConnectionQualityMonitor] Request timed out after %d ms (%d consecutive errors)"
 					% [elapsed_ms, _consecutive_errors]
 				)
 			)
 		else:
-			print(
+			printerr(
 				(
 					"[ConnectionQualityMonitor] Request failed (%d consecutive errors): %s"
 					% [_consecutive_errors, result.get_error()]
@@ -105,17 +100,16 @@ func _async_check_connection() -> void:
 			)
 	else:
 		if _consecutive_errors > 0:
-			print(
-				(
-					"[ConnectionQualityMonitor] Connection recovered (was %d errors)"
-					% [_consecutive_errors]
-				)
+			prints(
+				"[ConnectionQualityMonitor] Connection recovered (was",
+				_consecutive_errors,
+				"errors)"
 			)
 		_consecutive_errors = 0
 		_set_poll_interval(SLOW_POLL_SECONDS)
 		if _state != State.GOOD:
 			_state = State.GOOD
-			connection_restored.emit()
+			_on_connection_restored()
 		_is_checking = false
 		return
 
@@ -131,7 +125,7 @@ func _update_state() -> void:
 	if _retrying and _consecutive_errors >= 1:
 		_state = State.LOST
 		_retrying = false
-		connection_lost_detected.emit()
+		_async_on_connection_lost()
 		return
 
 	var has_explorer := Global.get_explorer() != null
@@ -144,13 +138,13 @@ func _update_state() -> void:
 		and _consecutive_errors >= CONSECUTIVE_ERRORS_FOR_DEGRADED
 	):
 		_state = State.POOR
-		poor_connection_detected.emit()
+		_on_poor_connection()
 	elif (
 		_consecutive_errors
 		>= (CONSECUTIVE_ERRORS_FOR_LOST if has_explorer else CONSECUTIVE_ERRORS_FOR_DEGRADED)
 	):
 		_state = State.LOST
-		connection_lost_detected.emit()
+		_async_on_connection_lost()
 
 
 func _create_timeout_promise(timeout_seconds: float) -> Promise:

--- a/godot/src/global.gd
+++ b/godot/src/global.gd
@@ -234,6 +234,7 @@ func _ready():
 
 	self.realm = Realm.new()
 	self.realm.set_name("realm")
+	self.realm.realm_change_failed.connect(_on_realm_change_failed_toast)
 
 	self.dcl_tokio_rpc = DclTokioRpc.new()
 	self.dcl_tokio_rpc.set_name("dcl_tokio_rpc")
@@ -983,6 +984,19 @@ func _notification(what: int) -> void:
 func _on_player_profile_changed_sync_events(_profile: DclUserProfile) -> void:
 	# Sync attended events notifications from server after authentication
 	NotificationsManager.async_sync_attended_events()
+
+
+func _on_realm_change_failed_toast(new_realm_string: String, reason: String) -> void:
+	# User-visible feedback when a requested realm cannot be loaded (e.g. /world
+	# pointing at a non-existent world). Only fires for Global.realm — transient
+	# Realm instances created elsewhere (e.g. portable experiences) are not wired
+	# to this handler.
+	NotificationsManager.show_system_toast(
+		"World unavailable",
+		'Could not load "%s": %s' % [new_realm_string, reason],
+		"error",
+		"alert"
+	)
 
 
 func set_camera_mode(camera_mode: Global.CameraMode) -> void:

--- a/godot/src/logic/realm.gd
+++ b/godot/src/logic/realm.gd
@@ -2,6 +2,8 @@ class_name Realm
 extends DclRealm
 
 signal realm_changed
+signal realm_changing
+signal realm_change_failed(new_realm_string: String, reason: String)
 
 const DAO_SERVERS: Array[String] = [
 	"https://peer-ec1.decentraland.org/",
@@ -137,138 +139,152 @@ func async_clear_realm():
 	Global.scene_runner.kill_all_scenes()
 
 
-func async_set_realm(new_realm_string: String, search_new_pos: bool = false) -> void:
-	realm_string = new_realm_string
-	realm_url = Realm.ensure_ends_with_slash(Realm.resolve_realm_url(realm_string))
-	realm_url = Realm.ensure_starts_with_https(realm_url)
+func async_set_realm(new_realm_string: String, search_new_pos: bool = false) -> bool:
+	var candidate_realm_url := Realm.ensure_ends_with_slash(
+		Realm.resolve_realm_url(new_realm_string)
+	)
+	candidate_realm_url = Realm.ensure_starts_with_https(candidate_realm_url)
 
-	prints("[REALM] async_set_realm", new_realm_string, search_new_pos, "resolved", realm_url)
+	prints(
+		"[REALM] async_set_realm", new_realm_string, search_new_pos, "resolved", candidate_realm_url
+	)
+	realm_changing.emit()
+
 	var promise: Promise = Global.http_requester.request_json(
-		realm_url + "about", HTTPClient.METHOD_GET, "", {}
+		candidate_realm_url + "about", HTTPClient.METHOD_GET, "", {}
 	)
 
 	var res = await PromiseUtils.async_awaiter(promise)
 	if res is PromiseError:
+		var reason: String = res.get_error()
 		printerr(
 			"[REALM] Rejected request change realm to: ",
 			new_realm_string,
 			" error message: ",
-			res.get_error()
+			reason
 		)
-	elif res is RequestResponse:
-		var response: RequestResponse = res
+		_emit_realm_change_failed(new_realm_string, reason)
+		return false
 
-		var json = response.get_string_response_as_json()
-		if json == null:
-			printerr("[REALM] do_request_json failed because json_string is not a valid json")
-			return
+	if not res is RequestResponse:
+		_emit_realm_change_failed(new_realm_string, "invalid response")
+		return false
 
-		var about_response = json
-		if about_response == null or not about_response is Dictionary:
-			printerr("[REALM] Failed setting new realm " + realm_string)
-			return
+	var response: RequestResponse = res
+	var json = response.get_string_response_as_json()
+	if json == null or not json is Dictionary:
+		var reason := "invalid /about response"
+		printerr("[REALM] ", reason, " for ", new_realm_string)
+		_emit_realm_change_failed(new_realm_string, reason)
+		return false
 
-		realm_about = about_response
+	# /about was validated — now it's safe to commit the new realm state.
+	realm_string = new_realm_string
+	realm_url = candidate_realm_url
+	realm_about = json
 
-		var configuration = realm_about.get("configurations", {})
+	var configuration = realm_about.get("configurations", {})
 
-		realm_scene_urns.clear()
-		for urn in configuration.get("scenesUrn", []):
-			var parsed_urn = Realm.parse_urn(urn)
-			if parsed_urn != null:
-				realm_scene_urns.push_back(parsed_urn)
+	realm_scene_urns.clear()
+	for urn in configuration.get("scenesUrn", []):
+		var parsed_urn = Realm.parse_urn(urn)
+		if parsed_urn != null:
+			realm_scene_urns.push_back(parsed_urn)
 
-		# For DCL worlds, the /about endpoint only returns the last deployed scene.
-		# Fetch all scenes from the /scenes endpoint to support multi-scene worlds.
-		var resolved_realm_name = configuration.get("realmName", "")
-		if Realm.is_dcl_ens(resolved_realm_name):
-			# Use the worlds content server /contents/ URL for baseUrl,
-			# not content.publicUrl (which points to Genesis City peer)
-			# worlds_content_server() returns ".../world/", we need ".../contents/"
-			var worlds_base = DclUrls.worlds_content_server().replace("/world/", "/")
-			var world_content_url = worlds_base + "contents/"
-			var all_urns = await _async_fetch_world_scenes(resolved_realm_name, world_content_url)
-			if not all_urns.is_empty():
-				realm_scene_urns.clear()
-				var urns_array: Array = []
-				for urn_data in all_urns:
-					realm_scene_urns.push_back(urn_data)
-					urns_array.push_back(urn_data.urn + "?=&baseUrl=" + urn_data.baseUrl)
-				# Update scenesUrn in realm_about so scene_fetcher reads the full list
-				configuration["scenesUrn"] = urns_array
+	# For DCL worlds, the /about endpoint only returns the last deployed scene.
+	# Fetch all scenes from the /scenes endpoint to support multi-scene worlds.
+	var resolved_realm_name = configuration.get("realmName", "")
+	if Realm.is_dcl_ens(resolved_realm_name):
+		# Use the worlds content server /contents/ URL for baseUrl,
+		# not content.publicUrl (which points to Genesis City peer)
+		# worlds_content_server() returns ".../world/", we need ".../contents/"
+		var worlds_base = DclUrls.worlds_content_server().replace("/world/", "/")
+		var world_content_url = worlds_base + "contents/"
+		var all_urns = await _async_fetch_world_scenes(resolved_realm_name, world_content_url)
+		if not all_urns.is_empty():
+			realm_scene_urns.clear()
+			var urns_array: Array = []
+			for urn_data in all_urns:
+				realm_scene_urns.push_back(urn_data)
+				urns_array.push_back(urn_data.urn + "?=&baseUrl=" + urn_data.baseUrl)
+			# Update scenesUrn in realm_about so scene_fetcher reads the full list
+			configuration["scenesUrn"] = urns_array
 
-		realm_global_scene_urns.clear()
-		for urn in configuration.get("globalScenesUrn", []):
-			var parsed_urn = Realm.parse_urn(urn)
-			if parsed_urn != null:
-				realm_global_scene_urns.push_back(parsed_urn)
+	realm_global_scene_urns.clear()
+	for urn in configuration.get("globalScenesUrn", []):
+		var parsed_urn = Realm.parse_urn(urn)
+		if parsed_urn != null:
+			realm_global_scene_urns.push_back(parsed_urn)
 
-		realm_city_loader_content_base_url = configuration.get("cityLoaderContentServer", "")
-		if not realm_city_loader_content_base_url.is_empty():
-			realm_city_loader_content_base_url = Realm.ensure_ends_with_slash(
-				configuration.get("cityLoaderContentServer", "")
-			)
-
-		var new_lambda_server_base_url = realm_about.get("lambdas", {}).get(
-			"publicUrl", DclUrls.peer_lambdas()
-		)
-		if not new_lambda_server_base_url.is_empty():
-			new_lambda_server_base_url = Realm.ensure_ends_with_slash(new_lambda_server_base_url)
-
-		self.set_lambda_server_base_url(new_lambda_server_base_url)
-
-		realm_name = configuration.get("realmName", "no_realm_name")
-		network_id = int(configuration.get("networkId", 1))  # 1=Ethereum
-
-		# get minimap
-		var map_config = configuration.get("map", {})
-		var sizes = map_config.get("sizes", [])
-
-		# Initialize with extreme values
-		var min_bounds: Vector2i = Vector2i(INF, INF)
-		var max_bounds: Vector2i = Vector2i(-INF, -INF)
-
-		# Process each size entry
-		for size_dict in sizes:
-			var left = size_dict.get("left", 0)
-			var top = size_dict.get("top", 0)
-			var right = size_dict.get("right", 0)
-			var bottom = size_dict.get("bottom", 0)
-
-			# Update minimum bounds (leftmost and bottommost points)
-			min_bounds.x = mini(min_bounds.x, left)
-			min_bounds.y = mini(min_bounds.y, bottom)
-
-			# Update maximum bounds (rightmost and topmost points)
-			max_bounds.x = maxi(max_bounds.x, right)
-			max_bounds.y = maxi(max_bounds.y, top)
-
-		# Handle empty array case
-		if sizes.is_empty():
-			min_bounds = Vector2i(-150, -150)
-			max_bounds = Vector2i(163, 158)
-
-		set_realm_min_bounds(min_bounds)
-		set_realm_max_bounds(max_bounds)
-
-		content_base_url = Realm.ensure_ends_with_slash(
-			realm_about.get("content", {}).get("publicUrl")
+	realm_city_loader_content_base_url = configuration.get("cityLoaderContentServer", "")
+	if not realm_city_loader_content_base_url.is_empty():
+		realm_city_loader_content_base_url = Realm.ensure_ends_with_slash(
+			configuration.get("cityLoaderContentServer", "")
 		)
 
-		# For DCL worlds, always resolve spawn position from scene metadata
-		# since the caller may not know the correct parcel coordinates.
-		# For other realms, only resolve if explicitly requested.
-		var should_resolve_pos = search_new_pos or Realm.is_dcl_ens(resolved_realm_name)
-		if not realm_scene_urns.is_empty() and should_resolve_pos:
-			await async_request_set_position(realm_scene_urns.back())
+	var new_lambda_server_base_url = realm_about.get("lambdas", {}).get(
+		"publicUrl", DclUrls.peer_lambdas()
+	)
+	if not new_lambda_server_base_url.is_empty():
+		new_lambda_server_base_url = Realm.ensure_ends_with_slash(new_lambda_server_base_url)
 
-		Global.get_config().last_realm_joined = realm_url
-		Global.get_config().save_to_settings_file()
+	self.set_lambda_server_base_url(new_lambda_server_base_url)
 
-		Global.metrics.update_realm(realm_url)
+	realm_name = configuration.get("realmName", "no_realm_name")
+	network_id = int(configuration.get("networkId", 1))  # 1=Ethereum
 
-		_has_realm = true
-		realm_changed.emit()
+	# get minimap
+	var map_config = configuration.get("map", {})
+	var sizes = map_config.get("sizes", [])
+
+	# Initialize with extreme values
+	var min_bounds: Vector2i = Vector2i(INF, INF)
+	var max_bounds: Vector2i = Vector2i(-INF, -INF)
+
+	# Process each size entry
+	for size_dict in sizes:
+		var left = size_dict.get("left", 0)
+		var top = size_dict.get("top", 0)
+		var right = size_dict.get("right", 0)
+		var bottom = size_dict.get("bottom", 0)
+
+		# Update minimum bounds (leftmost and bottommost points)
+		min_bounds.x = mini(min_bounds.x, left)
+		min_bounds.y = mini(min_bounds.y, bottom)
+
+		# Update maximum bounds (rightmost and topmost points)
+		max_bounds.x = maxi(max_bounds.x, right)
+		max_bounds.y = maxi(max_bounds.y, top)
+
+	# Handle empty array case
+	if sizes.is_empty():
+		min_bounds = Vector2i(-150, -150)
+		max_bounds = Vector2i(163, 158)
+
+	set_realm_min_bounds(min_bounds)
+	set_realm_max_bounds(max_bounds)
+
+	content_base_url = Realm.ensure_ends_with_slash(realm_about.get("content", {}).get("publicUrl"))
+
+	# For DCL worlds, always resolve spawn position from scene metadata
+	# since the caller may not know the correct parcel coordinates.
+	# For other realms, only resolve if explicitly requested.
+	var should_resolve_pos = search_new_pos or Realm.is_dcl_ens(resolved_realm_name)
+	if not realm_scene_urns.is_empty() and should_resolve_pos:
+		await async_request_set_position(realm_scene_urns.back())
+
+	Global.get_config().last_realm_joined = realm_url
+	Global.get_config().save_to_settings_file()
+
+	Global.metrics.update_realm(realm_url)
+
+	_has_realm = true
+	realm_changed.emit()
+	return true
+
+
+func _emit_realm_change_failed(new_realm_string: String, reason: String) -> void:
+	realm_change_failed.emit(new_realm_string, reason)
 
 
 func _async_fetch_world_scenes(world_name: String, base_content_url: String) -> Array:

--- a/godot/src/ui/components/modal/modal_manager.gd
+++ b/godot/src/ui/components/modal/modal_manager.gd
@@ -391,8 +391,10 @@ func _on_connection_lost_primary() -> void:
 
 
 func _on_connection_lost_secondary() -> void:
+	# Intentionally does NOT close the modal: the listener (e.g. CQM) handles
+	# get_tree().quit() and we want the modal to stay visible until the app is gone,
+	# otherwise the user briefly sees the broken UI underneath before exit.
 	connection_lost_exit.emit()
-	close_current_modal()
 
 
 func _on_teleport_primary(location: Vector2i, realm: String) -> void:

--- a/godot/src/ui/components/notifications/alert_toast.gd
+++ b/godot/src/ui/components/notifications/alert_toast.gd
@@ -10,6 +10,7 @@ const SLIDE_OUT_DURATION = 0.2
 const ICON_MAP: Dictionary = {
 	"poor_connection": "res://assets/ui/modal-connection-icon.svg",
 	"system": "res://assets/ui/notifications/DefaultNotification.png",
+	"error": "res://assets/ui/modal-alert-icon.svg"
 }
 
 var notification_data: Dictionary = {}


### PR DESCRIPTION
## Summary

Fixes a bug where loading a non-existent world (e.g. `/world world-that-does-not-exist`) wrongly triggered the *Connection Lost* modal, and reworks the `ConnectionQualityMonitor` to be lighter, simpler and decoupled from `ModalManager` internals.

## Bug fix: `/world non-existent` no longer shows "Connection Lost"

**Root cause** — `Realm.async_set_realm` mutated `realm_url` / `realm_string` *before* validating the new `/about` endpoint. When the endpoint returned 404, the explorer was left in a half-state pointing to a broken URL, and `ConnectionQualityMonitor` started counting those 404s as connection failures, eventually showing the *Connection Lost* modal.

**Fix**
- `Realm.async_set_realm` now validates `/about` against a *candidate* URL and only commits the new realm state on success. On failure (network error, non-2xx, invalid JSON) the previous realm state is left intact.
- New signals: `realm_changing` (emitted at the start of every realm change) and `realm_change_failed(new_realm_string, reason)` (emitted on validation failure).
- `async_set_realm` now returns `bool`. All existing call-sites are unchanged because they ignored the (previously `void`) return value.
- A "World unavailable" toast is shown on `realm_change_failed`, wired only to `Global.realm` so transient `Realm.new()` instances (e.g. portable experiences) don't generate spurious user-facing toasts.

## ConnectionQualityMonitor improvements

### Pause polling during realm changes
The monitor subscribes to the new `realm_changing` / `realm_changed` / `realm_change_failed` signals and stops the poll timer while a realm change is in flight. Any in-flight check is discarded via a generation counter. This prevents 404s from a broken realm switch from being counted as connection errors.

### Lower polling cost (~25× less traffic)
- `SLOW_POLL_SECONDS`: `2.0 → 10.0`. The monitor now polls every 10s on the happy path instead of every 2s. `FAST_POLL_SECONDS` stays at `0.5s` so detection remains fast once a failure is observed.
- `GET` → `HEAD` against `/about`. Same status-code signal, no JSON payload downloaded.
- Combined: roughly **5× fewer requests × 10–50× less bytes per request**.

Worst-case detection latency: ~12s for *poor connection*, ~16s for *connection lost* — acceptable for a UX-level monitor that previously cost 2 req/s of multi-KB responses against the catalyst.

### Decoupled from ModalManager internals
- Removed a 12-line hack in `_async_on_connection_lost` that reached into `modal_manager.current_modal.button_secondary`, disconnected a private handler and connected its own. The hack existed so the *Connection Lost* modal would stay visible while `get_tree().quit()` runs (instead of flashing the broken UI underneath for a frame).
- `ModalManager._on_connection_lost_secondary` no longer calls `close_current_modal()`; the listener is now responsible for both quitting and modal lifecycle. The signal-based wiring (`connection_lost_exit → CQM._on_exit`) handles everything cleanly.

### Modal type guard
`_on_connection_restored` no longer dismisses *any* current modal — it only closes the *Connection Lost* modal if it was the one **we** opened (tracked via `_showing_our_modal`). This prevents accidentally dismissing unrelated modals that may have been opened in the meantime.

### `_retrying` removed from the state machine
The "post-retry single failure goes straight to LOST" rule was previously a flag inspected inside `_update_state`, mixing retry handling with the GOOD/POOR/LOST transitions. It now lives in `_async_check_connection` as an explicit branch on the failure path. `_update_state` is back to being a pure function of `_consecutive_errors`.

### Other cleanups
- Removed three internal signals (`poor_connection_detected`, `connection_lost_detected`, `connection_restored`) that were only being bounced through to private methods on the same class. Replaced with direct calls. No external listeners existed.
- `print` → `printerr` for error/timeout cases so they show up in the right log channel.
- The poll timer now starts in `_ready()` again (after briefly being gated on the first realm). It uses the existing `peer_base()` fallback so connection monitoring still works on the lobby / backpack / discover screens before any realm is loaded.

## Test plan

- [ ] Type `/world some-world-that-does-not-exist` while in a valid realm → "World unavailable" toast appears, no Connection Lost modal, the previous realm stays loaded.
- [ ] Disconnect the network in-game → Connection Lost modal appears within ~12s.
- [ ] Press *Retry* on the Connection Lost modal with the network still down → modal reappears immediately on the next failed ping (no waiting 4 fails).
- [ ] Press *Retry* on the Connection Lost modal after restoring the network → modal closes and gameplay resumes.
- [ ] Press *Exit* on the Connection Lost modal → modal stays visible until the app fully closes (no flash of the broken UI).
- [ ] Disconnect the network on the lobby / backpack / discover screens (no realm loaded) → Connection Lost modal still appears (uses `peer_base()` fallback).
- [ ] `/changerealm` to a valid realm → realm loads normally, monitor resumes against the new realm.
- [ ] Switch between several valid worlds in quick succession → no false Connection Lost notifications.