### PR TITLE
fix: release branch builds now correctly use --prod flag

### DIFF
--- a/.github/actions/set-prod-flag/action.yml
+++ b/.github/actions/set-prod-flag/action.yml
@@ -1,18 +1,28 @@
 name: Set Prod Flag
 description: Set PROD_FLAG environment variable based on the current branch (--prod for release, --staging for main and other branches)
 
+inputs:
+  ref:
+    description: 'Override ref to check (defaults to github.ref). Accepts both refs/heads/release and bare release formats.'
+    required: false
+    default: ''
+
 runs:
   using: composite
   steps:
     - name: Set prod/staging flag based on branch
       shell: bash
       run: |
-        if [ "${{ github.ref }}" = "refs/heads/release" ]; then
+        REF="${{ inputs.ref }}"
+        if [ -z "$REF" ]; then
+          REF="${{ github.ref }}"
+        fi
+        if [ "$REF" = "refs/heads/release" ] || [ "$REF" = "release" ]; then
           echo "PROD_FLAG=--prod" >> $GITHUB_ENV
-          echo "Running on release branch - setting PROD_FLAG=--prod"
+          echo "Running on release branch - setting PROD_FLAG=--prod (ref=$REF)"
         else
           echo "PROD_FLAG=--staging" >> $GITHUB_ENV
-          echo "Running on ${{ github.ref }} - setting PROD_FLAG=--staging"
+          echo "Running on $REF - setting PROD_FLAG=--staging"
         fi
     - name: Set branch name for Sentry tags
       shell: bash

--- a/.github/workflows/ios_builds.yml
+++ b/.github/workflows/ios_builds.yml
@@ -107,6 +107,8 @@ jobs:
 
       - name: Set prod flag
         uses: ./.github/actions/set-prod-flag
+        with:
+          ref: ${{ inputs.ref || github.event.inputs.ref }}
 
       - name: Build MacOS
         timeout-minutes: 20

--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -31,8 +31,11 @@ jobs:
       - name: Cargo install
         run: cargo run -- install --targets linux
 
+      - name: Set prod flag
+        uses: ./.github/actions/set-prod-flag
+
       - name: Build
-        run: cargo run -- build --release --features asset_server
+        run: cargo run -- build --release --features asset_server ${{ env.PROD_FLAG }}
 
       - name: Test
         working-directory: lib


### PR DESCRIPTION
## Summary

Cherry-picks the only unique commit from release that wasn't already in main.

This fix ensures release branch CI builds use the `--prod` flag correctly.

## Notes

The other release-specific commits were already present in main:
- `ceb302db` Fix MISSING_PKCE_METADATA error - already in main
- `38c6395c` Install referrer tracking - already in main

## Test plan
- [ ] CI passes