### PR TITLE
fix: avatar Y-axis sway when orbiting camera

### DIFF
--- a/godot/src/logic/player/player.gd
+++ b/godot/src/logic/player/player.gd
@@ -152,6 +152,10 @@ func _ready():
 	Global.scene_runner.locomotion_settings_changed.connect(_on_locomotion_settings_changed)
 	_on_scene_changed(Global.scene_runner.get_current_parcel_scene_id())
 
+	# Avatar is top-level: initialize its world transform to match the player
+	avatar.global_position = global_position
+	avatar.rotation = Vector3(0, rotation.y, 0)
+
 
 func _on_player_profile_changed(new_profile: DclUserProfile):
 	var new_version = new_profile.get_profile_version()
@@ -193,6 +197,10 @@ func clamp_camera_rotation():
 
 
 func _physics_process(dt: float) -> void:
+	# Keep the top-level avatar co-located with the player (picks up teleports,
+	# external position changes, and ensures look_at below uses the correct origin)
+	avatar.global_position = global_position
+
 	# Handle hard landing cooldown
 	if _hard_landing_timer > 0:
 		_hard_landing_timer -= dt

--- a/godot/src/logic/player/player.gd
+++ b/godot/src/logic/player/player.gd
@@ -74,7 +74,7 @@ func set_camera_mode(mode: Global.CameraMode, play_sound: bool = true):
 			Tween.EASE_IN_OUT
 		)
 		avatar.set_hidden(false)
-		avatar.set_rotation(Vector3(0, 0, 0))
+		avatar.set_rotation(Vector3(0, rotation.y, 0))
 		if play_sound:
 			UiSounds.play_sound("ui_fade_out")
 	elif mode == Global.CameraMode.FIRST_PERSON:
@@ -319,6 +319,7 @@ func _physics_process(dt: float) -> void:
 	last_position = global_position
 	move_and_slide()
 	position.y = max(position.y, 0)
+	avatar.global_position = global_position
 
 
 func avatar_look_at(target_position: Vector3):
@@ -334,7 +335,7 @@ func avatar_look_at(target_position: Vector3):
 
 	# Set player body, avatar, and camera to look at same target (backward compatibility)
 	rotation.y = y_rot + PI
-	avatar.set_rotation(Vector3(0, 0, 0))
+	avatar.set_rotation(Vector3(0, y_rot + PI, 0))
 	mount_camera.rotation.x = x_rot
 
 	clamp_camera_rotation()
@@ -348,8 +349,8 @@ func set_avatar_rotation_independent(target_position: Vector3):
 
 	var y_rot = atan2(target_direction.x, target_direction.z)
 
-	# Set avatar rotation relative to player body
-	avatar.rotation.y = (y_rot + PI) - rotation.y
+	# Avatar is top-level, so set world-space Y rotation directly
+	avatar.rotation.y = y_rot + PI
 
 
 func camera_look_at(target_position: Vector3):
@@ -382,7 +383,7 @@ func get_broadcast_rotation_y() -> float:
 	var rotation_y := 0.0
 
 	if camera.get_camera_mode() == Global.CameraMode.THIRD_PERSON:
-		rotation_y = rotation.y + avatar.rotation.y
+		rotation_y = avatar.rotation.y
 	else:
 		rotation_y = rotation.y
 

--- a/godot/src/logic/player/player.tscn
+++ b/godot/src/logic/player/player.tscn
@@ -53,6 +53,7 @@ collide_with_bodies = false
 [node name="OutlineSystem" parent="Mount/Camera3D" instance=ExtResource("3_sxiuh")]
 
 [node name="Avatar" parent="." instance=ExtResource("2_n22nx")]
+top_level = true
 skip_process = true
 
 [node name="AudioStreamPlayer_Camera" type="AudioStreamPlayer" parent="."]

--- a/godot/src/logic/player/player_desktop_input.gd
+++ b/godot/src/logic/player/player_desktop_input.gd
@@ -38,10 +38,8 @@ func _input(event):
 		if _is_macos:
 			_mouse_position = _mouse_position * 0.8
 
-		# Only rotate the player on Y-axis, let avatar handle its own rotation
-		# Camera mount Y offset (from teleport) is preserved in local space
+		# Avatar is top-level, so player Y rotation does not propagate to it
 		_player.rotate_y(deg_to_rad(-_mouse_position.x) * h_sens)
-		_player.avatar.rotate_y(deg_to_rad(_mouse_position.x) * h_sens)
 		_player.mount_camera.rotate_x(deg_to_rad(-_mouse_position.y) * v_sens)
 		_player.clamp_camera_rotation()
 

--- a/godot/src/logic/player/player_gamepad_input.gd
+++ b/godot/src/logic/player/player_gamepad_input.gd
@@ -43,7 +43,6 @@ func _physics_process(_dt: float) -> void:
 
 	if right_x != 0.0 or right_y != 0.0:
 		_player.rotate_y(deg_to_rad(-right_x) * _camera_sensitivity_multiplier)
-		_player.avatar.rotate_y(deg_to_rad(right_x) * _camera_sensitivity_multiplier)
 		_player.mount_camera.rotate_x(deg_to_rad(-right_y) * _camera_sensitivity_multiplier)
 		_player.clamp_camera_rotation()
 

--- a/godot/src/logic/player/player_mobile_input.gd
+++ b/godot/src/logic/player/player_mobile_input.gd
@@ -54,9 +54,8 @@ func _input(event):
 
 		if event is InputEventScreenDrag and !_two_fingers:
 			_touch_position = event.relative
-			# Only rotate the player on Y-axis, camera mount Y offset is preserved in local space
+			# Avatar is top-level, so player Y rotation does not propagate to it
 			_player.rotate_y(deg_to_rad(-_touch_position.x) * HORIZONTAL_SENS)
-			_player.avatar.rotate_y(deg_to_rad(_touch_position.x) * HORIZONTAL_SENS)
 			_player.mount_camera.rotate_x(deg_to_rad(-_touch_position.y) * VERTICAL_SENS)
 			_player.clamp_camera_rotation()
 


### PR DESCRIPTION
## Summary
- Avatar was a child of Player, so Player's Y rotation (driven by camera yaw) propagated into the avatar. The three input handlers tried to cancel this with a counter-rotation (`_player.avatar.rotate_y(+Δ)` against `_player.rotate_y(-Δ)`), but the cancellation was fragile — floating-point drift from repeated basis multiplications and conflicts with `avatar.look_at` in `_physics_process` caused a long-standing subtle sway on the avatar's Y axis while the camera orbited.
- Fix decouples the avatar from Player's transform entirely by making it `top_level = true`, manually syncing its world position each physics frame, and updating all places that composed avatar world rotation as `player.rot + avatar.rot` to operate on world-space avatar rotation directly.

## Changes
- `player.tscn`: `top_level = true` on Avatar node.
- `player.gd`:
  - Sync `avatar.global_position = global_position` after `move_and_slide()`.
  - `avatar_look_at()` sets avatar's world Y to `y_rot + PI` (not zero).
  - `set_avatar_rotation_independent()` writes world Y directly (no `- rotation.y`).
  - `get_broadcast_rotation_y()` in third-person returns `avatar.rotation.y` (no sum).
  - Third-person switch aligns avatar world Y to player body.
- `player_desktop_input.gd`, `player_mobile_input.gd`, `player_gamepad_input.gd`: removed the `_player.avatar.rotate_y(...)` counter-rotations.

## Test plan
- [ ] Orbit camera while standing still → avatar stays perfectly frozen on its Y axis (no sway).
- [ ] Orbit camera while walking/jogging/running → avatar smoothly re-orients to face movement direction.
- [ ] First-person ↔ third-person toggle behaves correctly; avatar faces player body after switch.
- [ ] Scene-driven RPCs: `avatar_look_at`, `camera_look_at`, `avatar_look_at_independent` still point avatar/camera at the right world target.
- [ ] Broadcast rotation to remote peers looks correct (avatar facing matches what the local player sees).
- [ ] Teleport still lands avatar at player position (position sync runs each physics frame).
- [ ] Desktop mouse, mobile touch, and gamepad right-stick camera control all feel normal.
- [ ] iOS build (triggered via `build-ios` label).