### PR TITLE
feat: implement hide passport avatar modifier

### DIFF
--- a/godot/src/decentraland_components/avatar/avatar.gd
+++ b/godot/src/decentraland_components/avatar/avatar.gd
@@ -31,6 +31,7 @@ var is_local_player: bool = false
 # Public
 var avatar_id: String = ""
 var hidden: bool = false
+var passport_disabled: bool = false
 var avatar_ready: bool = false
 var has_connected_web3: bool = false  # Whether the user has connected a web3 wallet (not a guest)
 
@@ -154,7 +155,7 @@ func _input(event):
 	if event.is_action_pressed("ia_pointer"):
 		# Only handle input if this avatar is currently selected and not blocked/hidden
 		var selected = Global.get_selected_avatar()
-		if selected and selected == self and avatar_id and not hidden:
+		if selected and selected == self and avatar_id and not hidden and not passport_disabled:
 			if Input.mouse_mode == Input.MOUSE_MODE_CAPTURED:
 				Global.open_profile_by_avatar.emit(self)
 
@@ -174,7 +175,7 @@ func _on_set_avatar_modifier_area(area: DclAvatarModifierArea3D):
 		if modifier == 0:  # hide avatar
 			hide()
 		elif modifier == 1:  # disable passport
-			pass  # TODO: Passport (disable functionality)
+			passport_disabled = true
 
 
 func set_hidden(value):
@@ -199,7 +200,7 @@ func _set_click_area_enabled(enabled: bool) -> void:
 func _unset_avatar_modifier_area():
 	if not hidden:
 		show()
-	# TODO: Passport (enable functionality)
+	passport_disabled = false
 
 
 func async_update_avatar_from_profile(profile: DclUserProfile):

--- a/lib/src/scene_runner/scene_manager.rs
+++ b/lib/src/scene_runner/scene_manager.rs
@@ -1815,7 +1815,10 @@ impl INode for SceneManager {
                                 true // Default to true if global not available
                             };
 
-                            if ui_has_focus {
+                            let passport_disabled: bool =
+                                avatar.get("passport_disabled").try_to().unwrap_or(false);
+
+                            if ui_has_focus && !passport_disabled {
                                 // Emit open_profile_by_avatar signal on the Global singleton
                                 if let Some(mut global) = DclGlobal::try_singleton() {
                                     global.emit_signal(
@@ -1919,11 +1922,13 @@ impl INode for SceneManager {
 
         // Add avatar profile tooltip if there's an avatar under crosshair with a valid ID
         // Skip AvatarShapes (NPCs from scenes) which don't have valid profile IDs
+        // Skip avatars inside an AvatarModifierArea with DisablePassports
         if let Some(RaycastResult::Avatar(avatar)) = &current_raycast {
             // Check if avatar has a valid avatar_id (non-empty and not just "npc-*")
             let avatar_id: GString = avatar.get("avatar_id").try_to().unwrap_or_default();
             let is_avatar_shape: bool = avatar.get("is_avatar_shape").try_to().unwrap_or(false);
-            if !is_avatar_shape && !avatar_id.is_empty() {
+            let passport_disabled: bool = avatar.get("passport_disabled").try_to().unwrap_or(false);
+            if !is_avatar_shape && !avatar_id.is_empty() && !passport_disabled {
                 let mut profile_dict = VarDictionary::new();
                 profile_dict.set("text_pet_down", "View profile");
                 profile_dict.set("action", "ia_pointer");


### PR DESCRIPTION
## Summary
- Implement the `DisablePassports` avatar modifier area by tracking a `passport_disabled` flag on each avatar.
- Click handling on the avatar and the crosshair tooltip both skip the open-profile flow when the flag is set.

fix #1741

## Test plan
- [ ] Enter a scene that defines an `AvatarModifierArea` with `DisablePassports`.
- [ ] Verify that clicking an affected avatar does NOT open the profile popup.
- [ ] Verify that the crosshair tooltip ("View profile") is hidden for affected avatars.
- [ ] Verify that leaving the area restores normal profile-opening behavior.