### PR TITLE
chore: bump iOS short version to 1.4

### DIFF
--- a/godot/export_presets.cfg
+++ b/godot/export_presets.cfg
@@ -283,7 +283,7 @@ application/provisioning_profile_specifier_release=""
 application/export_method_release=1
 application/bundle_identifier="org.decentraland.godotexplorer"
 application/signature=""
-application/short_version="1.3"
+application/short_version="1.4"
 application/version="64"
 application/additional_plist_content="	<key>CFBundleURLTypes</key>
 	<array>

--- a/godot/export_presets.cfg
+++ b/godot/export_presets.cfg
@@ -283,7 +283,7 @@ application/provisioning_profile_specifier_release=""
 application/export_method_release=1
 application/bundle_identifier="org.decentraland.godotexplorer"
 application/signature=""
-application/short_version="1.2"
+application/short_version="1.3"
 application/version="64"
 application/additional_plist_content="	<key>CFBundleURLTypes</key>
 	<array>


### PR DESCRIPTION
## Summary
- Bumps the iOS export preset `application/short_version` from `1.2` to `1.4` in `godot/export_presets.cfg`.

## Test plan
- [ ] Trigger an iOS CI build (add the `build-ios` label) and verify the resulting IPA reports `CFBundleShortVersionString = 1.4`.