### PR TITLE
fix: blocked users list not persisting across restarts

### DIFF
--- a/godot/src/logic/player/player_identity.gd
+++ b/godot/src/logic/player/player_identity.gd
@@ -116,9 +116,11 @@ func _on_profile_changed(new_profile: DclUserProfile):
 	_current_profile = new_profile.duplicated()
 	_mutable_avatar = _mutable_profile.get_avatar()
 
-	# Note: blocked/muted lists are managed by the Social Service (get_blocking_status),
-	# not by the profile. Do NOT call init_from_profile here as it would overwrite
-	# the server's authoritative blocked list with stale profile data.
+	# Blocked users are managed by the Social Service (get_blocking_status), not the profile.
+	# Only load muted users from profile (no Social Service RPC for muted).
+	var muted_list = new_profile.get_muted()
+	if muted_list.size() > 0:
+		Global.social_blacklist.append_muted(muted_list)
 
 
 func get_mutable_avatar() -> DclAvatarWireFormat:

--- a/godot/src/logic/player/player_identity.gd
+++ b/godot/src/logic/player/player_identity.gd
@@ -116,8 +116,9 @@ func _on_profile_changed(new_profile: DclUserProfile):
 	_current_profile = new_profile.duplicated()
 	_mutable_avatar = _mutable_profile.get_avatar()
 
-	# Update social blacklist from the profile
-	Global.social_blacklist.init_from_profile(new_profile)
+	# Note: blocked/muted lists are managed by the Social Service (get_blocking_status),
+	# not by the profile. Do NOT call init_from_profile here as it would overwrite
+	# the server's authoritative blocked list with stale profile data.
 
 
 func get_mutable_avatar() -> DclAvatarWireFormat:

--- a/godot/src/ui/components/profile/profile.gd
+++ b/godot/src/ui/components/profile/profile.gd
@@ -368,7 +368,11 @@ func _async_block_user(user_address: String) -> void:
 	button_block_user.disabled = false
 
 	if promise.is_rejected():
-		printerr("Block failed: ", PromiseUtils.get_error_message(promise))
+		var error_msg := PromiseUtils.get_error_message(promise)
+		printerr("Block failed: ", error_msg)
+		NotificationsManager.show_system_toast(
+			"Block failed", error_msg, "error", "alert"
+		)
 		return
 
 	# Block User metric (track whether blocked user was a friend)
@@ -389,7 +393,11 @@ func _async_unblock_user_from_profile(user_address: String) -> void:
 	button_unblock_user.disabled = false
 
 	if promise.is_rejected():
-		printerr("Unblock failed: ", PromiseUtils.get_error_message(promise))
+		var error_msg := PromiseUtils.get_error_message(promise)
+		printerr("Unblock failed: ", error_msg)
+		NotificationsManager.show_system_toast(
+			"Unblock failed", error_msg, "error", "alert"
+		)
 		return
 
 	Global.social_blacklist.remove_blocked(user_address)  # Update local cache

--- a/godot/src/ui/components/profile/profile.gd
+++ b/godot/src/ui/components/profile/profile.gd
@@ -370,9 +370,7 @@ func _async_block_user(user_address: String) -> void:
 	if promise.is_rejected():
 		var error_msg := PromiseUtils.get_error_message(promise)
 		printerr("Block failed: ", error_msg)
-		NotificationsManager.show_system_toast(
-			"Block failed", error_msg, "error", "alert"
-		)
+		NotificationsManager.show_system_toast("Block failed", error_msg, "error", "alert")
 		return
 
 	# Block User metric (track whether blocked user was a friend)
@@ -395,9 +393,7 @@ func _async_unblock_user_from_profile(user_address: String) -> void:
 	if promise.is_rejected():
 		var error_msg := PromiseUtils.get_error_message(promise)
 		printerr("Unblock failed: ", error_msg)
-		NotificationsManager.show_system_toast(
-			"Unblock failed", error_msg, "error", "alert"
-		)
+		NotificationsManager.show_system_toast("Unblock failed", error_msg, "error", "alert")
 		return
 
 	Global.social_blacklist.remove_blocked(user_address)  # Update local cache

--- a/godot/src/ui/components/social/social_item/social_item.gd
+++ b/godot/src/ui/components/social/social_item/social_item.gd
@@ -480,7 +480,11 @@ func _async_unblock_user(address: String) -> void:
 		var unblock_button = %Button_Unblock
 		if unblock_button:
 			unblock_button.disabled = false
-		printerr("Unblock failed: ", PromiseUtils.get_error_message(promise))
+		var error_msg := PromiseUtils.get_error_message(promise)
+		printerr("Unblock failed: ", error_msg)
+		NotificationsManager.show_system_toast(
+			"Unblock failed", error_msg, "error", "alert"
+		)
 		return
 
 	Global.social_blacklist.remove_blocked(address)  # Update local cache

--- a/godot/src/ui/components/social/social_item/social_item.gd
+++ b/godot/src/ui/components/social/social_item/social_item.gd
@@ -482,9 +482,7 @@ func _async_unblock_user(address: String) -> void:
 			unblock_button.disabled = false
 		var error_msg := PromiseUtils.get_error_message(promise)
 		printerr("Unblock failed: ", error_msg)
-		NotificationsManager.show_system_toast(
-			"Unblock failed", error_msg, "error", "alert"
-		)
+		NotificationsManager.show_system_toast("Unblock failed", error_msg, "error", "alert")
 		return
 
 	Global.social_blacklist.remove_blocked(address)  # Update local cache

--- a/godot/src/ui/components/social/social_list.gd
+++ b/godot/src/ui/components/social/social_list.gd
@@ -271,7 +271,6 @@ func async_update_list(_remote_avatars: Array = []) -> void:
 			_sync_nearby_list()
 			_update_list_size()
 		SOCIAL_TYPE.BLOCKED:
-			remove_items()
 			await _async_reload_blocked_list(current_request_id)
 		SOCIAL_TYPE.ONLINE:
 			await _async_reload_online_list(current_request_id)
@@ -283,22 +282,40 @@ func async_update_list(_remote_avatars: Array = []) -> void:
 
 
 func _async_reload_blocked_list(request_id: int) -> void:
-	var blocked_social_items = []
 	var blocked_addresses = Global.social_blacklist.get_blocked_list()
 
-	# Fetch profiles for each blocked address
+	# Fetch all profiles in parallel
+	var promises: Array = []
 	for address in blocked_addresses:
-		# Check if request is still valid before each fetch
-		if request_id != _update_request_id:
-			return
+		promises.append(Global.content_provider.fetch_profile(address))
 
-		var social_item_data = await _async_fetch_profile_for_address(address)
+	# Wait for all profile fetches to complete
+	var blocked_social_items: Array = []
+	for i in range(promises.size()):
+		var address = blocked_addresses[i]
+		await PromiseUtils.async_awaiter(promises[i])
+
+		var social_item_data = SocialItemData.new()
+		social_item_data.address = address
+
+		if promises[i].is_rejected():
+			social_item_data.name = address
+			social_item_data.has_claimed_name = false
+			social_item_data.profile_picture_url = ""
+		else:
+			var profile = promises[i].get_data() as DclUserProfile
+			social_item_data.name = profile.get_name()
+			social_item_data.has_claimed_name = profile.has_claimed_name()
+			social_item_data.profile_picture_url = profile.get_avatar().get_snapshots_face_url()
+
 		blocked_social_items.append(social_item_data)
 
 	# Check if this request is still valid (no newer request started)
 	if request_id != _update_request_id:
 		return
 
+	# Replace items only when all data is ready
+	remove_items()
 	var should_load = _is_panel_visible()
 	add_items_by_social_item_data(blocked_social_items, should_load)
 	_update_list_size()

--- a/lib/src/godot_classes/dcl_social_service.rs
+++ b/lib/src/godot_classes/dcl_social_service.rs
@@ -1149,11 +1149,24 @@ impl DclSocialService {
             .as_ref()
             .ok_or("Social service not initialized")?;
 
-        mgr.block_user(address)
+        let response = mgr
+            .block_user(address)
             .await
             .map_err(|e| format!("Failed to block user: {}", e))?;
 
-        Ok(())
+        match response.response {
+            Some(block_user_response::Response::Ok(_)) => Ok(()),
+            Some(block_user_response::Response::InternalServerError(e)) => {
+                Err(format!("Server error blocking user: {}", e.message.unwrap_or_default()))
+            }
+            Some(block_user_response::Response::InvalidRequest(e)) => {
+                Err(format!("Invalid request blocking user: {}", e.message.unwrap_or_default()))
+            }
+            Some(block_user_response::Response::ProfileNotFound(_)) => {
+                Err("Profile not found when blocking user".to_string())
+            }
+            None => Err("Empty response from server when blocking user".to_string()),
+        }
     }
 
     async fn async_unblock_user(
@@ -1165,11 +1178,24 @@ impl DclSocialService {
             .as_ref()
             .ok_or("Social service not initialized")?;
 
-        mgr.unblock_user(address)
+        let response = mgr
+            .unblock_user(address)
             .await
             .map_err(|e| format!("Failed to unblock user: {}", e))?;
 
-        Ok(())
+        match response.response {
+            Some(unblock_user_response::Response::Ok(_)) => Ok(()),
+            Some(unblock_user_response::Response::InternalServerError(e)) => {
+                Err(format!("Server error unblocking user: {}", e.message.unwrap_or_default()))
+            }
+            Some(unblock_user_response::Response::InvalidRequest(e)) => {
+                Err(format!("Invalid request unblocking user: {}", e.message.unwrap_or_default()))
+            }
+            Some(unblock_user_response::Response::ProfileNotFound(_)) => {
+                Err("Profile not found when unblocking user".to_string())
+            }
+            None => Err("Empty response from server when unblocking user".to_string()),
+        }
     }
 
     /// Returns Vec of (address, name, has_claimed_name, profile_picture_url, blocked_at)

--- a/lib/src/godot_classes/dcl_social_service.rs
+++ b/lib/src/godot_classes/dcl_social_service.rs
@@ -1156,12 +1156,14 @@ impl DclSocialService {
 
         match response.response {
             Some(block_user_response::Response::Ok(_)) => Ok(()),
-            Some(block_user_response::Response::InternalServerError(e)) => {
-                Err(format!("Server error blocking user: {}", e.message.unwrap_or_default()))
-            }
-            Some(block_user_response::Response::InvalidRequest(e)) => {
-                Err(format!("Invalid request blocking user: {}", e.message.unwrap_or_default()))
-            }
+            Some(block_user_response::Response::InternalServerError(e)) => Err(format!(
+                "Server error blocking user: {}",
+                e.message.unwrap_or_default()
+            )),
+            Some(block_user_response::Response::InvalidRequest(e)) => Err(format!(
+                "Invalid request blocking user: {}",
+                e.message.unwrap_or_default()
+            )),
             Some(block_user_response::Response::ProfileNotFound(_)) => {
                 Err("Profile not found when blocking user".to_string())
             }
@@ -1185,12 +1187,14 @@ impl DclSocialService {
 
         match response.response {
             Some(unblock_user_response::Response::Ok(_)) => Ok(()),
-            Some(unblock_user_response::Response::InternalServerError(e)) => {
-                Err(format!("Server error unblocking user: {}", e.message.unwrap_or_default()))
-            }
-            Some(unblock_user_response::Response::InvalidRequest(e)) => {
-                Err(format!("Invalid request unblocking user: {}", e.message.unwrap_or_default()))
-            }
+            Some(unblock_user_response::Response::InternalServerError(e)) => Err(format!(
+                "Server error unblocking user: {}",
+                e.message.unwrap_or_default()
+            )),
+            Some(unblock_user_response::Response::InvalidRequest(e)) => Err(format!(
+                "Invalid request unblocking user: {}",
+                e.message.unwrap_or_default()
+            )),
             Some(unblock_user_response::Response::ProfileNotFound(_)) => {
                 Err("Profile not found when unblocking user".to_string())
             }


### PR DESCRIPTION
## Summary
- **Root cause**: `_on_profile_changed` called `init_from_profile()` which overwrote the Social Service's authoritative blocked list with stale profile data
- Removed `init_from_profile()` for blocked users; muted users still load from profile via `append_muted`
- Validate `BlockUserResponse`/`UnblockUserResponse` oneof response instead of silently ignoring server errors
- Show error toast when block/unblock fails
- Fetch blocked profiles in parallel and defer `remove_items()` until all data is ready to prevent partial list rendering from race conditions

## Test plan
- [ ] Block a user, restart the app, verify the user is still blocked
- [ ] Open blocked list tab, verify all blocked users appear
- [ ] Block/unblock from profile panel and social panel, verify toast appears on failure
- [ ] Mute a user, restart, verify mute persists
- [ ] Test on a second device, verify blocked list replicates

Closes #1809