### PR TITLE
fix: hide avatar nameplate on entry funnel welcome screen

### DIFF
--- a/godot/src/decentraland_components/avatar/avatar.gd
+++ b/godot/src/decentraland_components/avatar/avatar.gd
@@ -21,7 +21,10 @@ const TOON_SHADER_ALPHA_BLEND_DOUBLE = preload(
 )
 
 @export var skip_process: bool = false
-@export var hide_name: bool = false
+@export var hide_name: bool = false:
+	set(value):
+		hide_name = value
+		_apply_nickname_visibility()
 @export var non_3d_audio: bool = false
 
 # Entity info for trigger area detection


### PR DESCRIPTION
## Summary                                                                                                                                                                                                 
  - Adds a setter to `Avatar.hide_name` that calls `_apply_nickname_visibility()` immediately when the property is written                                                                                   
  - Fixes the Comeback (Welcome Back) screen showing "nickname#xxxx" nameplate on the placeholder `AvatarPreview` that lives in the Comeback container
                                                                                                                                                                                                             
  ## Root cause                                                                                                                                                                                              
  `Avatar._ready()` calls `_apply_nickname_visibility()` before `AvatarPreview._ready()` runs (child nodes initialize first). At that point `hide_name` is still `false`, so `nickname_quad.show()` is       
  called. When `AvatarPreview._ready()` later sets `avatar.hide_name = true`, there was no corresponding `_apply_nickname_visibility()` call — leaving the nameplate visible with the default `NicknameUI`   
  placeholder text ("nickname#xxxx").
                                                                                                                                                                                                             
  ## Test plan    
  - [ ] Open app on mobile, reach the "Welcome Back" screen — avatar nameplate should not be visible
  - [ ] Confirm nameplate still appears correctly for avatars in the world (not hidden when `hide_name = false`)                                                                                             
  - [ ] Confirm backpack/avatar customization preview also has no nameplate                                                                                                                                  
                                                                                                                                                                                                             
  Closes #1773 