### PR TITLE
fix: force portrait on logout and delete-account flow from landscape

### DIFF
--- a/godot/src/global.gd
+++ b/godot/src/global.gd
@@ -555,6 +555,9 @@ func sign_out() -> void:
 	social_blacklist.clear_muted()
 	get_config().session_account = {}
 	get_config().save_to_settings_file()
+	# Lobby/login is portrait-only; reset orientation so logging out from a
+	# landscape screen (e.g. settings panel) doesn't strand the user there.
+	set_orientation_portrait()
 	get_tree().change_scene_to_file("res://src/ui/components/auth/lobby.tscn")
 
 

--- a/godot/src/ui/components/menu/account_deletion_popup.gd
+++ b/godot/src/ui/components/menu/account_deletion_popup.gd
@@ -16,6 +16,11 @@ func _ready() -> void:
 
 func _on_button_cancel_delete_account_pressed() -> void:
 	hide()
+	# If the flow was opened from the explorer's landscape side panel, the menu
+	# was force-opened in portrait. Close it so the explorer flips back to
+	# landscape via _on_menu_close instead of stranding the user in portrait.
+	if Global.get_explorer():
+		Global.close_menu.emit()
 
 
 func _on_button_ok_pressed() -> void:

--- a/godot/src/ui/components/settings/settings.gd
+++ b/godot/src/ui/components/settings/settings.gd
@@ -498,6 +498,11 @@ func _on_button_account_pressed() -> void:
 
 
 func _on_button_delete_account_pressed() -> void:
+	# The deletion popup lives inside the fullscreen menu, which is hidden while
+	# the side panel is up. Promote to the menu first so it renders in portrait;
+	# closing the right panel + orientation flip happen via the menu's own hooks.
+	if panel_mode:
+		Global.open_settings.emit()
 	Global.delete_account.emit()
 
 


### PR DESCRIPTION
## Summary

Closes #1902
Closes https://github.com/decentraland/godot-explorer/issues/1905

Three related fixes for the landscape settings panel exit paths in the explorer:

- **`global.sign_out`** now flips orientation to portrait before transitioning to the lobby, so signing out from the landscape settings panel doesn't strand the user with a sideways login screen.
- **`settings._on_button_delete_account_pressed`** promotes to the fullscreen settings menu when invoked in `panel_mode`. The deletion popup is a child of the (hidden) menu node, so calling it directly from the side panel never rendered the modal; promoting via `Global.open_settings` drives the right-panel close and portrait flip through existing `_on_menu_open` / settings `_on_visibility_changed` hooks, then the modal renders normally on top of the portrait menu.
- **`account_deletion_popup` cancel** now closes the menu when running inside the explorer, letting `explorer._on_menu_close` flip orientation back to landscape so the user returns to the landscape explorer immediately instead of being stuck in portrait.

## Test plan

- [ ] iOS / Android: log in, rotate to landscape, open landscape settings panel, tap Sign Out → login screen appears in portrait.
- [ ] iOS / Android: log in, rotate to landscape, open landscape settings panel, tap Delete Account → side panel closes, fullscreen menu opens in portrait, deletion modal appears on top.
- [ ] From the deletion modal opened via the landscape side panel, hit Cancel → menu closes and explorer returns to landscape immediately.
- [ ] Verify the standalone delete-account flow from `auth/lobby` → menu still works (popup shows, Cancel just dismisses without forcing landscape since explorer isn't in tree).
- [ ] Desktop / non-mobile: verify sign-out still lands at the lobby cleanly (existing window-resize behavior of `set_orientation_portrait` is unchanged).