### PR TITLE
fix: day1 retention notif deeplink (0,0) and iOS scheduling

### DIFF
--- a/godot/src/notifications_manager.gd
+++ b/godot/src/notifications_manager.gd
@@ -860,6 +860,12 @@ func _check_and_handle_version_change() -> bool:
 	Global.get_config().local_notifications_version = LOCAL_NOTIFICATIONS_VERSION
 	Global.get_config().save_to_settings_file()
 
+	# Day 1 retention notif is local-only — server sync won't restore it after the wipe.
+	if Global.get_config().day1_notification_scheduled:
+		Global.get_config().day1_notification_scheduled = false
+		Global.get_config().save_to_settings_file()
+		async_schedule_day1_notification.call_deferred()
+
 	_debug_log("All notifications cleared, version updated to v%d" % LOCAL_NOTIFICATIONS_VERSION)
 	return true
 
@@ -888,6 +894,10 @@ func async_sync_attended_events() -> void:
 			_debug_log(
 				"Notification permission not granted yet, scheduling anyway (OS will handle)"
 			)
+
+	# iOS plugin doesn't emit permission_changed, so the lobby grant never reaches
+	# _on_permission_changed. Trigger day1 here instead — its own guards handle dedup.
+	async_schedule_day1_notification.call_deferred()
 
 	var url = DclUrls.mobile_events_api() + "/?only_attendee=true"
 	var response = await Global.async_signed_fetch(url, HTTPClient.METHOD_GET, "")
@@ -1217,7 +1227,7 @@ func async_schedule_day1_notification() -> void:
 		"People are hanging out in Decentraland.",
 		trigger_timestamp,
 		"",
-		"decentraland://open?position=-7,-2",
+		"decentraland://open?position=0,0",
 	)
 
 	if scheduled:


### PR DESCRIPTION
## Summary
- Updates the day1 retention push notification deeplink from `-7,-2` (old plaza, dead-end scene) to `0,0` (new spawn point)
- Fixes two scheduling regressions that prevented the day1 notif from firing sometimes:
  - **Version-change wipe**: `_check_and_handle_version_change()` clears the OS queue on first auth (when `LOCAL_NOTIFICATIONS_VERSION` mismatches the stored value), wiping the day1 along with stale event notifs. Now re-schedules day1 after the wipe.
  - **iOS missing signal**: The iOS plugin (`dcl_godot_ios.mm:678-687`) never emits `permission_changed` from its `requestAuthorizationWithOptions` completion handler — the lobby grant never reaches `_on_permission_changed`, so day1 was never scheduled on first launch. Workaround: trigger `async_schedule_day1_notification.call_deferred()` inside `async_sync_attended_events()` (which fires after auth, by which point `has_permission()` returns true). The function's own guards (`day1_notification_scheduled` flag + permission check) handle dedup safely.

Closes #1913

## Test plan
- [x] gdformat / gdlint clean
- [x] Pre-commit `full-tests --skip-visual` passes (cargo fmt, clippy, unit tests, gdscript validation, integration tests)
- [x] Manual end-to-end on iPhone 16e: fresh install → grant notification permission → sign in → 30s after auth → day1 notif fires on lock screen → tap → app opens at `position=0,0`
- [x] iOS syslog confirms `Adding notification request EA70-A0E3 to destinations: Default` post-cleanup, with `Schedule.plist with 1 items` saved
- [ ] Smoke test on Android (left for reviewer / QA — Android `_on_permission_changed` does fire, so the wipe-recovery path is the relevant one)

## Notes for reviewers
- The iOS plugin signal gap (`permission_changed` never emitted) is a deeper issue worth a follow-up ticket — the workaround in this PR keeps the fix scoped to GDScript.
- Both `call_deferred` paths converge on the same `async_schedule_day1_notification` whose `day1_notification_scheduled` config flag prevents double-scheduling.