### PR TITLE
fix: stop per-frame panic loop in SceneManager::physics_process

### DIFF
--- a/lib/src/godot_classes/dcl_global.rs
+++ b/lib/src/godot_classes/dcl_global.rs
@@ -231,7 +231,9 @@ pub struct DclGlobal {
     #[var(get)]
     pub dynamic_graphics_manager: Gd<DclDynamicGraphicsManager>,
 
-    pub selected_avatar: Option<Gd<DclAvatar>>,
+    // Stored as InstanceId, not Gd<DclAvatar>: the underlying Node3D may be freed
+    // between physics ticks. Resolve via get_selected_avatar() to drop stale ids.
+    pub selected_avatar: Option<InstanceId>,
 
     // Scene Inspector active flag — set from GDScript when deeplink/CLI activates the Scene Inspector.
     // Checked by scene_manager when spawning scenes to decide if they should be instrumented.
@@ -502,8 +504,16 @@ impl DclGlobal {
     }
 
     #[func]
-    fn get_selected_avatar(&self) -> Option<Gd<DclAvatar>> {
-        self.selected_avatar.clone()
+    fn get_selected_avatar(&mut self) -> Option<Gd<DclAvatar>> {
+        let id = self.selected_avatar?;
+        match Gd::<DclAvatar>::try_from_instance_id(id) {
+            Ok(gd) => Some(gd),
+            Err(_) => {
+                // Avatar node was freed; drop the stale id so we stop trying.
+                self.selected_avatar = None;
+                None
+            }
+        }
     }
 
     #[func]

--- a/lib/src/scene_runner/scene_manager.rs
+++ b/lib/src/scene_runner/scene_manager.rs
@@ -38,6 +38,7 @@ use std::{
     sync::atomic::AtomicU32,
     time::{Duration, Instant},
 };
+use tokio::sync::mpsc::error::TrySendError;
 
 use super::{
     components::pointer_events::{
@@ -109,8 +110,9 @@ pub struct SceneManager {
     #[var]
     pointer_tooltips: VarArray,
 
-    // Track avatar under crosshair
-    last_avatar_under_crosshair: Option<Gd<DclAvatar>>,
+    // Stored as InstanceId, not Gd<DclAvatar>: the underlying Node3D may be freed
+    // between physics ticks (despawn, scene unload, teleport).
+    last_avatar_under_crosshair: Option<InstanceId>,
 
     // Track when pointer was pressed on avatar for click-and-release mechanism
     avatar_pointer_press_time: Option<Instant>,
@@ -988,14 +990,28 @@ impl SceneManager {
             let scene = self.scenes.get_mut(scene_id).unwrap();
             match scene.state {
                 SceneState::ToKill => {
-                    if let Err(_e) = scene
+                    match scene
                         .dcl_scene
                         .main_sender_to_thread
                         .try_send(RendererResponse::Kill)
                     {
-                        tracing::error!("error sending kill signal to thread");
-                    } else {
-                        scene.state = SceneState::KillSignal(current_time_us);
+                        Ok(()) => {
+                            scene.state = SceneState::KillSignal(current_time_us);
+                        }
+                        // Receiver already exited (e.g. scene thread panicked). The kill
+                        // signal is moot; advance to KillSignal so the next tick's
+                        // is_finished() check moves the state to Dead and the scene
+                        // gets cleaned up. Without this, the loop body would re-fire
+                        // try_send every physics tick and spam the logger at ~60 Hz.
+                        Err(TrySendError::Closed(_)) => {
+                            tracing::warn!(
+                                "scene channel closed before kill signal; advancing to KillSignal scene_id={:?}",
+                                scene_id
+                            );
+                            scene.state = SceneState::KillSignal(current_time_us);
+                        }
+                        // Capacity-1 channel with the receiver still alive; retry next tick.
+                        Err(TrySendError::Full(_)) => {}
                     }
                 }
                 SceneState::KillSignal(kill_time_us) => {
@@ -1781,18 +1797,17 @@ impl INode for SceneManager {
         // Handle avatar detection
         match &current_raycast {
             Some(RaycastResult::Avatar(avatar)) => {
-                // Update selected avatar if changed
-                let avatar_changed = match &self.last_avatar_under_crosshair {
-                    None => true,
-                    Some(last) => last.instance_id() != avatar.instance_id(),
-                };
+                // The fresh `avatar` from raycast is alive, so calling instance_id() on it
+                // is safe; we never deref the previously-stored value.
+                let avatar_id = avatar.instance_id();
+                let avatar_changed = self.last_avatar_under_crosshair != Some(avatar_id);
 
                 if avatar_changed {
-                    self.last_avatar_under_crosshair = Some(avatar.clone());
+                    self.last_avatar_under_crosshair = Some(avatar_id);
 
                     // Update Global.selected_avatar directly
                     if let Some(mut global) = DclGlobal::try_singleton() {
-                        global.bind_mut().selected_avatar = Some(avatar.clone());
+                        global.bind_mut().selected_avatar = Some(avatar_id);
                     }
 
                     // Emit signal for tooltip change


### PR DESCRIPTION
## Summary

Closes #1917. Two independent bugs in `SceneManager::physics_process` each produced a per-frame error loop (~60 Hz) on mobile sessions, between them generating ~36k Sentry events on 2026-04-28 (12.5k in one hour). User-impact was small (98% crash-free) but Sentry quota burn was significant. Both fixes confined to two files, no new dependencies.

### Bug A — `instance_id()` on freed `Gd<DclAvatar>`

`last_avatar_under_crosshair` (`scene_manager.rs:113`) and `DclGlobal::selected_avatar` (`dcl_global.rs:234`) both held `Gd<DclAvatar>` across physics ticks. `DclAvatar` is `Node3D`-based; Godot frees the underlying node on avatar despawn / scene unload / teleport. Neither field was cleared on those events, so the next tick that touched one panicked at `godot-core-0.4.5/src/obj/gd.rs:263`. The panic re-fired every tick because `physics_process` re-enters every tick.

**Fix**: both fields now store `Option<InstanceId>`. The avatar-detection comparison uses the fresh raycast `avatar.instance_id()` (always alive) against the stored id. `DclGlobal::get_selected_avatar()` resolves lazily via `Gd::<DclAvatar>::try_from_instance_id` and clears the field if the id is stale (self-healing). Matches the existing codebase idiom at `lib/src/content/content_provider.rs:93,247-254`.

### Bug B — Stuck `SceneState::ToKill` after scene-worker panic

`main_sender_to_thread` is a tokio mpsc capacity-1. When the scene worker thread exited early (e.g. JS panic), the channel became permanently `Closed`. `try_send(Kill)` then failed forever, state never advanced, and `tracing::error!("error sending kill signal to thread")` fired every physics tick.

**Fix**: discriminate `TrySendError`. `Full` is transient backpressure → silent retry. `Closed` means the receiver is gone → log one `warn!` and transition straight to `SceneState::KillSignal`; the existing `is_finished()` branch then sweeps the scene to `Dead`.

## Out of scope (separate fixes / issues)

- `base_ui` / `player_avatar_node` / `player_body_node` are also `Gd<Node>` held across frames, but point at long-lived player/UI nodes; left intact pending Sentry evidence.
- `PoolManager INVALID STATE`, `Basis must be normalized`, `Entity not found`, Vulkan errors — independent bugs surfaced in the same investigation, not addressed here.
- Min-version gate for `0.58.0-1c2b5f1-prod` (which produces ~97% of Android error volume) — operational follow-up after this lands on stores.

## Test plan

- [ ] **Bug A repro**: load a scene with NPC avatars, hover crosshair on one, then teleport away while still hovering. Expected: no `gd.rs:263` panic, no `physics_process` error loop in console.
- [ ] **Bug B repro**: trigger a scene worker thread panic (force JS engine panic), then unload the scene. Expected: a single `warn!` line `scene channel closed before kill signal; advancing to KillSignal`, scene cleans up within a couple of frames.
- [ ] **CI lint/format**: `cd lib && cargo fmt --all && cargo clippy -- -D warnings` and `gdformat godot/ && gdlint godot/` clean (already verified locally).
- [ ] **Sentry post-release watch**: after the fix release reaches mobile, monitor `GODOT-EXPLORER-1A2`, `1EG`, `GA`, `FF`, `1HP`, `1C5`. Event counts on the new release tag should drop to single digits/day; older releases will keep producing volume until users update.