### PR TITLE
fix: sample sentry attach_log to 1% of sessions to cut attachment quota

### DIFF
--- a/godot/project.godot
+++ b/godot/project.godot
@@ -245,6 +245,7 @@ options/auto_init=false
 options/dsn="https://03559fa545b3fa2bc9e876a41d6aab2f@o4510187684298752.ingest.us.sentry.io/4510187688361984"
 options/debug_printing=0
 options/diagnostic_level=4
+options/attach_log=false
 
 [shader_globals]
 

--- a/godot/src/project_main_loop.gd
+++ b/godot/src/project_main_loop.gd
@@ -1,10 +1,16 @@
 class_name ProjectMainLoop
 extends SceneTree
 
+# attach_log uploads godot.log on every event. The SDK reads this once at
+# init, so we sample per-session: ~1% of sessions upload logs, the rest don't.
+const ATTACH_LOG_SAMPLE_RATE := 0.01
+
 # Environment detection based on version string suffix
 var is_dev_version = false
 var is_staging_version = false
 var is_prod_version = false
+
+var attach_log_sampled := false
 
 
 func _initialize() -> void:
@@ -15,10 +21,13 @@ func _initialize() -> void:
 	self.is_staging_version = DclGlobal.is_staging()
 	self.is_prod_version = DclGlobal.is_production()
 
+	self.attach_log_sampled = randf() < ATTACH_LOG_SAMPLE_RATE
+
 	SentrySDK.init(
 		func(options: SentryOptions) -> void:
 			options.release = release_string
 			options.before_send = _before_send
+			options.attach_log = self.attach_log_sampled
 
 			# Set environment based on build type
 			# production: report to production env
@@ -36,6 +45,9 @@ func _initialize() -> void:
 			# for custom sampling rate, use _before_send
 			options.sample_rate = 1.0
 	)
+
+	# Tag every event so we can filter sampled-vs-unsampled in the Sentry UI.
+	SentrySDK.set_tag("attach_log_sampled", str(self.attach_log_sampled))
 
 	# Add Sentry tags for staging and development builds (for filtering)
 	if self.is_staging_version or self.is_dev_version:

--- a/godot/src/project_main_loop.gd
+++ b/godot/src/project_main_loop.gd
@@ -1,8 +1,12 @@
 class_name ProjectMainLoop
 extends SceneTree
 
-# attach_log uploads godot.log on every event. The SDK reads this once at
-# init, so we sample per-session: ~1% of sessions upload logs, the rest don't.
+# godot.log is normally attached on every event. We disable that globally via
+# project setting `sentry/options/attach_log=false` and re-add the log only
+# for ~1% of sessions, sampled here. We can't toggle attach_log from the init
+# callback in this SDK version (1.0.0): _get_global_attachments() runs before
+# the callback, so the runtime override never takes effect. add_attachment()
+# at scope level works and is honored for every event in the session.
 const ATTACH_LOG_SAMPLE_RATE := 0.01
 
 # Environment detection based on version string suffix
@@ -27,7 +31,6 @@ func _initialize() -> void:
 		func(options: SentryOptions) -> void:
 			options.release = release_string
 			options.before_send = _before_send
-			options.attach_log = self.attach_log_sampled
 
 			# Set environment based on build type
 			# production: report to production env
@@ -48,6 +51,13 @@ func _initialize() -> void:
 
 	# Tag every event so we can filter sampled-vs-unsampled in the Sentry UI.
 	SentrySDK.set_tag("attach_log_sampled", str(self.attach_log_sampled))
+
+	if self.attach_log_sampled:
+		var log_path: String = ProjectSettings.get_setting(
+			"debug/file_logging/log_path", "user://logs/godot.log"
+		)
+		if FileAccess.file_exists(log_path):
+			SentrySDK.add_attachment(SentryAttachment.create_with_path(log_path))
 
 	# Add Sentry tags for staging and development builds (for filtering)
 	if self.is_staging_version or self.is_dev_version:


### PR DESCRIPTION
fixes #1867 

## Summary                                                                                                                                                       
                                                                                                                                                                   
  The Sentry Godot plugin defaults `attach_log = true`, which uploads the entire `godot.log` file as an attachment on **every** captured event. We never overrode  
  this, so every error in prod has been carrying a copy of the session log.                                                                                        
                                                                                                                                                                   
  This is overkill for our needs:                                                                                                                                  
  - We already capture **100 breadcrumbs** per event (SDK default), which give us the recent log lines leading up to the error.                                    
  - We also send rich `contexts` (`app`, `device`, `gpu`, `os`, `godot_engine`, `godot_performance`, `trace`) and tags on every event.                             
  - Stack traces come through the SDK directly, not from the log file.                                                                                             
                                                                                                                                                                   
  In short: breadcrumbs + contexts are enough to debug 99% of issues. The full log is only occasionally useful for hard-to-repro bugs.                             
                                                                                                                                                                   
  ### Why this matters                                                                                                                                             
                             
  Attachments dominate our Sentry quota. On a recent spike day we burned **~92 GB of attachments in 24h**, vs ~140 MB on a normal day — a >600× swing — driven by: 
  - `attach_log = true` (every event uploads the log),
  - a few engine-level errors firing in tight loops (500–900 events per user from Vulkan/GPU paths),                                                               
  - long sessions producing larger logs over time.                                                                                                                 
                                                                                                                                                                   
  Each of those tight-loop events was re-uploading the same growing log file.                                                                                      
                                                                                                                                                                   
  ### What changes                                                                                                                                                 
                             
  Per-session sampling instead of per-event (the SDK reads `attach_log` once at `init`, so per-event isn't possible without patching the plugin):                  
  
  - Roll once at startup: ~1% of sessions get `attach_log = true`, the rest get `false`.                                                                           
  - A new `attach_log_sampled` tag is set on every event so the sampled vs. unsampled population is filterable from the Sentry UI (and we can multiply metrics by
  ~100 to extrapolate when needed).                                                                                                                                
  - Constant `ATTACH_LOG_SAMPLE_RATE` makes it trivial to tune.
                                                                                                                                                                   
  For the 1% of sessions that do upload, we still get **complete** logs — which is more useful for debugging than fragments from many sessions.                    
                                                                                                                                                                   
  Expected reduction in attachment volume: **~99%**.                                                                                                               
                             
  ### What this does NOT change                                                                                                                                    
   
  - Errors, breadcrumbs, contexts, tags, and stack traces are still sent at 100% — debugging signal is preserved.                                                  
  - Tight-loop engine errors (Vulkan, `vkWaitForFences`, `POTENTIAL LEAK`, etc.) are still being captured as events. Filtering or rate-limiting those is a
  follow-up.                                                                                                                                                       
                             
  ## Test plan                                                                                                                                                     
                             
  - [ ] Run a staging build, confirm in Sentry that ~99% of new events have tag `attach_log_sampled:false` and no `godot.log` attachment.                          
  - [ ] Confirm the remaining ~1% of events have tag `attach_log_sampled:true` and a `godot.log` attachment.
  - [ ] Confirm breadcrumbs (up to 100), contexts, and tags are still present on every event.                                                                      
  - [ ] Verify dev builds continue to send nothing (existing `_before_send` short-circuit).                                                                        
                                                                                                