### PR TITLE
fix: sentry - drop engine noise, demote ops logs, fix scene_manager panics

### DIFF
--- a/godot/project.godot
+++ b/godot/project.godot
@@ -245,7 +245,6 @@ options/auto_init=false
 options/dsn="https://03559fa545b3fa2bc9e876a41d6aab2f@o4510187684298752.ingest.us.sentry.io/4510187688361984"
 options/debug_printing=0
 options/diagnostic_level=4
-options/attach_log=false
 
 [shader_globals]
 

--- a/godot/sentry.gdextension
+++ b/godot/sentry.gdextension
@@ -1,22 +1,26 @@
 [configuration]
 
-entry_symbol = "gdextension_init"
-compatibility_minimum = "4.6"
+entry_symbol = "sentry_gdextension_init"
+compatibility_minimum = "4.5"
 
 [libraries]
 
-macos.debug = "res://addons/sentry/bin/macos/libsentry.macos.debug.framework"
-macos.release = "res://addons/sentry/bin/macos/libsentry.macos.release.framework"
+macos.debug = "res://addons/sentry/bin/macos/libsentry.macos.debug.dylib"
+macos.release = "res://addons/sentry/bin/macos/libsentry.macos.release.dylib"
 
 windows.debug.x86_64 = "res://addons/sentry/bin/windows/x86_64/libsentry.windows.debug.x86_64.dll"
 windows.release.x86_64 = "res://addons/sentry/bin/windows/x86_64/libsentry.windows.release.x86_64.dll"
 windows.debug.x86_32 = "res://addons/sentry/bin/windows/x86_32/libsentry.windows.debug.x86_32.dll"
 windows.release.x86_32 = "res://addons/sentry/bin/windows/x86_32/libsentry.windows.release.x86_32.dll"
+windows.debug.arm64 = "res://addons/sentry/bin/windows/arm64/libsentry.windows.debug.arm64.dll"
+windows.release.arm64 = "res://addons/sentry/bin/windows/arm64/libsentry.windows.release.arm64.dll"
 
 linux.debug.x86_64 = "res://addons/sentry/bin/linux/x86_64/libsentry.linux.debug.x86_64.so"
 linux.release.x86_64 = "res://addons/sentry/bin/linux/x86_64/libsentry.linux.release.x86_64.so"
 linux.debug.x86_32 = "res://addons/sentry/bin/linux/x86_32/libsentry.linux.debug.x86_32.so"
 linux.release.x86_32 = "res://addons/sentry/bin/linux/x86_32/libsentry.linux.release.x86_32.so"
+linux.debug.arm64 = "res://addons/sentry/bin/linux/arm64/libsentry.linux.debug.arm64.so"
+linux.release.arm64 = "res://addons/sentry/bin/linux/arm64/libsentry.linux.release.arm64.so"
 
 android.debug.arm64 = "res://addons/sentry/bin/android/libsentry.android.debug.arm64.so"
 android.release.arm64 = "res://addons/sentry/bin/android/libsentry.android.release.arm64.so"
@@ -24,19 +28,18 @@ android.debug.arm32 = "res://addons/sentry/bin/android/libsentry.android.debug.a
 android.release.arm32 = "res://addons/sentry/bin/android/libsentry.android.release.arm32.so"
 android.debug.x86_64 = "res://addons/sentry/bin/android/libsentry.android.debug.x86_64.so"
 android.release.x86_64 = "res://addons/sentry/bin/android/libsentry.android.release.x86_64.so"
+android.debug.x86_32 = "res://addons/sentry/bin/android/libsentry.android.debug.x86_32.so"
+android.release.x86_32 = "res://addons/sentry/bin/android/libsentry.android.release.x86_32.so"
 
 ios.debug = "res://addons/sentry/bin/ios/libsentry.ios.debug.xcframework"
 ios.release = "res://addons/sentry/bin/ios/libsentry.ios.release.xcframework"
 
+web.debug.wasm32 = "res://addons/sentry/bin/web/libsentry.web.debug.wasm32.nothreads.wasm"
+web.release.wasm32 = "res://addons/sentry/bin/web/libsentry.web.release.wasm32.nothreads.wasm"
+web.debug.threads.wasm32 = "res://addons/sentry/bin/web/libsentry.web.debug.wasm32.wasm"
+web.release.threads.wasm32 = "res://addons/sentry/bin/web/libsentry.web.release.wasm32.wasm"
+
 ; noop libs for unsupported platforms
-web.debug.wasm32 = "res://addons/sentry/bin/noop/libsentry.web.debug.wasm32.nothreads.wasm"
-web.release.wasm32 = "res://addons/sentry/bin/noop/libsentry.web.release.wasm32.nothreads.wasm"
-web.debug.threads.wasm32 = "res://addons/sentry/bin/noop/libsentry.web.debug.wasm32.wasm"
-web.release.threads.wasm32 = "res://addons/sentry/bin/noop/libsentry.web.release.wasm32.wasm"
-windows.debug.arm64 = "res://addons/sentry/bin/noop/libsentry.windows.debug.arm64.dll"
-windows.release.arm64 = "res://addons/sentry/bin/noop/libsentry.windows.release.arm64.dll"
-linux.debug.arm64 = "res://addons/sentry/bin/noop/libsentry.linux.debug.arm64.so"
-linux.release.arm64 = "res://addons/sentry/bin/noop/libsentry.linux.release.arm64.so"
 linux.debug.rv64 = "res://addons/sentry/bin/noop/libsentry.linux.debug.rv64.so"
 linux.release.rv64 = "res://addons/sentry/bin/noop/libsentry.linux.release.rv64.so"
 
@@ -50,6 +53,10 @@ linux.x86_32 = {
 	"res://addons/sentry/bin/linux/x86_32/crashpad_handler" : ""
 }
 
+linux.arm64 = {
+	"res://addons/sentry/bin/linux/arm64/crashpad_handler" : ""
+}
+
 windows.x86_64 = {
 	"res://addons/sentry/bin/windows/x86_64/crashpad_handler.exe" : "",
 	"res://addons/sentry/bin/windows/x86_64/crashpad_wer.dll": ""
@@ -60,12 +67,17 @@ windows.x86_32 = {
 	"res://addons/sentry/bin/windows/x86_32/crashpad_wer.dll": ""
 }
 
+windows.arm64 = {
+	"res://addons/sentry/bin/windows/arm64/crashpad_handler.exe" : "",
+	"res://addons/sentry/bin/windows/arm64/crashpad_wer.dll": ""
+}
+
 macos.debug = {
-	"res://addons/sentry/bin/macos/Sentry.framework" : ""
+	"res://addons/sentry/bin/macos/libSentry.dylib" : ""
 }
 
 macos.release = {
-	"res://addons/sentry/bin/macos/Sentry.framework" : ""
+	"res://addons/sentry/bin/macos/libSentry.dylib" : ""
 }
 
 ios.debug = {

--- a/godot/src/project_main_loop.gd
+++ b/godot/src/project_main_loop.gd
@@ -9,7 +9,7 @@ const ATTACH_LOG_SAMPLE_RATE := 0.01
 # Substring patterns for messages classified as Sentry noise. These all
 # originate in Godot internals, GPU drivers, or third-party crates
 # (livekit-rust); we can't act on them and they fire in tight loops,
-# dominating our quota. 
+# dominating our quota.
 const NOISE_PATTERNS := [
 	"VK_SUCCESS",
 	"vkWaitForFences",

--- a/godot/src/project_main_loop.gd
+++ b/godot/src/project_main_loop.gd
@@ -6,6 +6,34 @@ extends SceneTree
 # the Sentry attachment quota.
 const ATTACH_LOG_SAMPLE_RATE := 0.01
 
+# Substring patterns for messages classified as Sentry noise. These all
+# originate in Godot internals, GPU drivers, or third-party crates
+# (livekit-rust); we can't act on them and they fire in tight loops,
+# dominating our quota. The loop with early-exit benchmarks ~1.7x faster
+# than a single compiled RegEx alternation in GDScript (~0.47 vs 0.79 us/call
+# at 200k iterations) — Godot's native String.find is well-optimized and the
+# regex setup cost dominates for short patterns. See tools/bench_noise_filter.gd.
+const NOISE_PATTERNS := [
+	"VK_SUCCESS",
+	"vkWaitForFences",
+	"QueuePresentKHR",
+	"Uniforms supplied",
+	"p_mipmap",
+	"det == 0",
+	"!is_inside_tree",
+	"err != OK",
+	"Bones array",
+	"Skin bind",
+	"must be a normalized",
+	"Mouse is not supported",
+	"utf16 surrogate",
+	"ClientMessagesHandler",
+	'Condition "active"',
+]
+# Keep this fraction of noise events as a canary — if the shape or volume of
+# engine/driver errors shifts we want to notice, but 100% is wasted quota.
+const NOISE_KEEP_RATE := 0.05
+
 # Environment detection based on version string suffix
 var is_dev_version = false
 var is_staging_version = false
@@ -72,6 +100,13 @@ func _before_send(event: SentryEvent) -> SentryEvent:
 	# Discard events for dev builds - only prod and staging report to Sentry
 	if self.is_dev_version:
 		return null
+
+	if randf() >= NOISE_KEEP_RATE:
+		var msg: String = event.message
+		if not msg.is_empty():
+			for pattern in NOISE_PATTERNS:
+				if pattern in msg:
+					return null
 
 	# if event.message.contains("Bruno"):
 	#	# Scrub sensitive information from the event.

--- a/godot/src/project_main_loop.gd
+++ b/godot/src/project_main_loop.gd
@@ -1,12 +1,9 @@
 class_name ProjectMainLoop
 extends SceneTree
 
-# godot.log is normally attached on every event. We disable that globally via
-# project setting `sentry/options/attach_log=false` and re-add the log only
-# for ~1% of sessions, sampled here. We can't toggle attach_log from the init
-# callback in this SDK version (1.0.0): _get_global_attachments() runs before
-# the callback, so the runtime override never takes effect. add_attachment()
-# at scope level works and is honored for every event in the session.
+# Sample which sessions upload godot.log. Without this, every event re-uploads
+# the entire log file (default attach_log=true) and tight error loops blow up
+# the Sentry attachment quota.
 const ATTACH_LOG_SAMPLE_RATE := 0.01
 
 # Environment detection based on version string suffix
@@ -31,6 +28,7 @@ func _initialize() -> void:
 		func(options: SentryOptions) -> void:
 			options.release = release_string
 			options.before_send = _before_send
+			options.attach_log = self.attach_log_sampled
 
 			# Set environment based on build type
 			# production: report to production env
@@ -51,13 +49,6 @@ func _initialize() -> void:
 
 	# Tag every event so we can filter sampled-vs-unsampled in the Sentry UI.
 	SentrySDK.set_tag("attach_log_sampled", str(self.attach_log_sampled))
-
-	if self.attach_log_sampled:
-		var log_path: String = ProjectSettings.get_setting(
-			"debug/file_logging/log_path", "user://logs/godot.log"
-		)
-		if FileAccess.file_exists(log_path):
-			SentrySDK.add_attachment(SentryAttachment.create_with_path(log_path))
 
 	# Add Sentry tags for staging and development builds (for filtering)
 	if self.is_staging_version or self.is_dev_version:

--- a/godot/src/project_main_loop.gd
+++ b/godot/src/project_main_loop.gd
@@ -9,10 +9,7 @@ const ATTACH_LOG_SAMPLE_RATE := 0.01
 # Substring patterns for messages classified as Sentry noise. These all
 # originate in Godot internals, GPU drivers, or third-party crates
 # (livekit-rust); we can't act on them and they fire in tight loops,
-# dominating our quota. The loop with early-exit benchmarks ~1.7x faster
-# than a single compiled RegEx alternation in GDScript (~0.47 vs 0.79 us/call
-# at 200k iterations) — Godot's native String.find is well-optimized and the
-# regex setup cost dominates for short patterns. See tools/bench_noise_filter.gd.
+# dominating our quota. 
 const NOISE_PATTERNS := [
 	"VK_SUCCESS",
 	"vkWaitForFences",

--- a/godot/src/ui/components/auth/login.gd
+++ b/godot/src/ui/components/auth/login.gd
@@ -23,10 +23,8 @@ var _wc_polling_start_time: int = 0
 @onready var button_apple: Button = %Button_Apple
 @onready var button_wallet_connect: Button = %Button_WalletConnect
 @onready var button_metamask: Button = %Button_MetaMask
-@onready var texture_rect_wallet_icon: TextureRect = %TextureRect_WalletIcon
 
 @onready var texture_rect_google: TextureRect = $Button_Google/TextureRect_Google
-@onready var texture_rect_apple: TextureRect = $HBoxContainer_More/Button_Apple/TextureRect_Apple
 
 
 func _ready():

--- a/godot/src/ui/components/chat/chat.gd
+++ b/godot/src/ui/components/chat/chat.gd
@@ -29,7 +29,6 @@ var _autocomplete_queued: bool = false
 @onready var h_box_container_line_edit = %HBoxContainer_LineEdit
 @onready var line_edit_command = %LineEdit_Command
 @onready var margin_container_chat: MarginContainer = %MarginContainer_Chat
-@onready var texture_rect_logo: TextureRect = %TextureRect_Logo
 @onready var v_box_container_chat: VBoxContainer = %VBoxContainerChat
 @onready var scroll_container_chats_list: ScrollContainer = %ScrollContainer_ChatsList
 @onready var panel_container_navbar: PanelContainer = %PanelContainer_Navbar

--- a/godot/src/ui/components/events/button_reminder.gd
+++ b/godot/src/ui/components/events/button_reminder.gd
@@ -14,7 +14,7 @@ var event_name: String = ""
 var event_coordinates: Vector2i = Vector2i(0, 0)
 var event_cover_image_url: String = ""
 var bell_texture = load("res://assets/ui/bell.svg")
-var check_texture = load("res://assets/ui/check.svg")
+var check_texture = load("res://assets/ui/checked.svg")
 var _debounced: DebouncedAction
 
 @onready var texture_rect_icon: TextureRect = %TextureRect_Icon

--- a/godot/src/ui/components/friends/friends_panel.gd
+++ b/godot/src/ui/components/friends/friends_panel.gd
@@ -177,7 +177,7 @@ func _async_subscribe_to_friends_updates() -> void:
 
 	if promise.is_rejected():
 		var error = promise.get_data()
-		push_error(
+		push_warning(
 			"[FriendsPanel] Failed to subscribe to friendship updates: " + str(error.get_error())
 		)
 		streaming_failed = true
@@ -188,7 +188,7 @@ func _async_subscribe_to_friends_updates() -> void:
 
 	if connectivity_promise.is_rejected():
 		var error = connectivity_promise.get_data()
-		push_error(
+		push_warning(
 			"[FriendsPanel] Failed to subscribe to connectivity updates: " + str(error.get_error())
 		)
 		# Connectivity failure alone doesn't mark streaming as failed

--- a/lib/build.rs
+++ b/lib/build.rs
@@ -504,6 +504,15 @@ fn check_safe_repo() -> Result<(), String> {
 }
 
 fn set_godot_explorer_version() {
+    // Re-run when the git HEAD/branch ref/index changes so the embedded commit
+    // hash stays in sync with the current checkout.
+    println!("cargo:rerun-if-changed=../.git/HEAD");
+    println!("cargo:rerun-if-changed=../.git/refs/heads");
+    println!("cargo:rerun-if-changed=../.git/index");
+    println!("cargo:rerun-if-env-changed=BRANCH_NAME");
+    println!("cargo:rerun-if-env-changed=DECENTRALAND_PROD_BUILD");
+    println!("cargo:rerun-if-env-changed=DECENTRALAND_STAGING_BUILD");
+
     // Always use git to get the actual checked-out commit (what GitHub checkout uses)
     let commit_hash = match check_safe_repo() {
         Ok(_) => {

--- a/lib/src/analytics/metrics.rs
+++ b/lib/src/analytics/metrics.rs
@@ -585,7 +585,7 @@ impl Metrics {
             None,
         );
         if let Err(err) = http_requester.request(request, 0).await {
-            tracing::error!("Failed to send segment batch: {:?}", err);
+            tracing::warn!("Failed to send segment batch: {:?}", err);
         } else {
             tracing::debug!("Segment batch sent successfully");
         }

--- a/lib/src/dcl/js/engine.rs
+++ b/lib/src/dcl/js/engine.rs
@@ -180,7 +180,7 @@ async fn op_crdt_recv_from_renderer(
                         component_id,
                         &mut data_writter,
                     ) {
-                        tracing::error!("error writing crdt message: {err}");
+                        tracing::debug!("error writing crdt message: {err}");
                     }
                 }
             }
@@ -207,7 +207,7 @@ async fn op_crdt_recv_from_renderer(
                         element_count,
                         &mut data_writter,
                     ) {
-                        tracing::error!("error writing crdt message: {err}");
+                        tracing::debug!("error writing crdt message: {err}");
                     }
                 }
             }

--- a/lib/src/godot_classes/dcl_social_service.rs
+++ b/lib/src/godot_classes/dcl_social_service.rs
@@ -1050,7 +1050,7 @@ impl DclSocialService {
                 promise.bind_mut().resolve_with_data(array.to_variant());
             }
             Err(e) => {
-                tracing::error!("get_friends failed: {}", e);
+                tracing::warn!("get_friends failed: {}", e);
                 promise.bind_mut().reject(e.as_str().into())
             }
         }

--- a/lib/src/realm/scene_entity_coordinator.rs
+++ b/lib/src/realm/scene_entity_coordinator.rs
@@ -572,7 +572,7 @@ impl SceneEntityCoordinator {
     /// - If no fixed entities: Requests scene at current coordinate (fallback for genesis city teleports)
     pub fn update_position(&mut self, x: i16, z: i16) {
         if self.entities_active_url.is_empty() {
-            tracing::error!("entities_active_url is empty, cannot update position");
+            tracing::warn!("entities_active_url is empty, cannot update position");
             return;
         }
 

--- a/lib/src/scene_runner/pool_manager.rs
+++ b/lib/src/scene_runner/pool_manager.rs
@@ -158,7 +158,7 @@ impl PoolManager {
         let suspicious = current.find_leaks();
         if !suspicious.is_empty() {
             for stats in &suspicious {
-                tracing::error!(
+                tracing::warn!(
                     "[PoolManager] INVALID STATE in '{}': created={}, in_use={}, pooled={} (in_use + pooled != created)",
                     stats.name, stats.created, stats.in_use, stats.pooled
                 );
@@ -174,7 +174,7 @@ impl PoolManager {
                 .in_use
                 .saturating_sub(prev.physics_areas.in_use);
             if areas_growth > self.leak_threshold && current.physics_areas.pooled == 0 {
-                tracing::error!(
+                tracing::warn!(
                     "[PoolManager] POTENTIAL LEAK in 'physics_areas': in_use grew by {} ({} -> {}) with pooled=0",
                     areas_growth, prev.physics_areas.in_use, current.physics_areas.in_use
                 );
@@ -187,7 +187,7 @@ impl PoolManager {
                 .in_use
                 .saturating_sub(prev.physics_box_shapes.in_use);
             if box_growth > self.leak_threshold && current.physics_box_shapes.pooled == 0 {
-                tracing::error!(
+                tracing::warn!(
                     "[PoolManager] POTENTIAL LEAK in 'physics_box_shapes': in_use grew by {} ({} -> {}) with pooled=0",
                     box_growth, prev.physics_box_shapes.in_use, current.physics_box_shapes.in_use
                 );
@@ -200,7 +200,7 @@ impl PoolManager {
                 .in_use
                 .saturating_sub(prev.physics_sphere_shapes.in_use);
             if sphere_growth > self.leak_threshold && current.physics_sphere_shapes.pooled == 0 {
-                tracing::error!(
+                tracing::warn!(
                     "[PoolManager] POTENTIAL LEAK in 'physics_sphere_shapes': in_use grew by {} ({} -> {}) with pooled=0",
                     sphere_growth, prev.physics_sphere_shapes.in_use, current.physics_sphere_shapes.in_use
                 );

--- a/lib/src/scene_runner/scene_manager.rs
+++ b/lib/src/scene_runner/scene_manager.rs
@@ -876,6 +876,11 @@ impl SceneManager {
             self.player_position = player_parcel_position;
         }
 
+        // Drop scene ids removed in a previous tick — sorted list can lag the
+        // scenes map and the unwrap() below would panic on a stale id.
+        let scenes = &self.scenes;
+        self.sorted_scene_ids.retain(|id| scenes.contains_key(id));
+
         // TODO: review to define a better behavior
         self.sorted_scene_ids.sort_by_key(|&scene_id| {
             let scene = self.scenes.get_mut(&scene_id).unwrap();
@@ -993,7 +998,7 @@ impl SceneManager {
                         .main_sender_to_thread
                         .try_send(RendererResponse::Kill)
                     {
-                        tracing::error!("error sending kill signal to thread");
+                        tracing::warn!("error sending kill signal to thread");
                     } else {
                         scene.state = SceneState::KillSignal(current_time_us);
                     }
@@ -1406,6 +1411,13 @@ impl SceneManager {
     }
 
     fn on_current_parcel_scene_changed(&mut self) {
+        // base_ui can be dangling between Explorer teardown and recreate_base_ui()
+        // (see comment on recreate_base_ui). Touching it would panic in
+        // godot-rust's check_rtti — bail out, the next tick after the new
+        // base_ui is attached will reconcile the scene tree.
+        if !self.base_ui.is_instance_valid() {
+            return;
+        }
         // Reset input modifiers and skybox time when changing scenes
         // The new scene's components (if any) will be applied on the next update tick
         if let Some(mut global) = DclGlobal::try_singleton() {
@@ -1781,9 +1793,13 @@ impl INode for SceneManager {
         // Handle avatar detection
         match &current_raycast {
             Some(RaycastResult::Avatar(avatar)) => {
-                // Update selected avatar if changed
+                // Update selected avatar if changed.
+                // last_avatar_under_crosshair can hold a Gd<T> whose underlying
+                // object was freed; calling instance_id() then panics in
+                // godot-rust's check_rtti. Treat that as a change.
                 let avatar_changed = match &self.last_avatar_under_crosshair {
                     None => true,
+                    Some(last) if !last.is_instance_valid() => true,
                     Some(last) => last.instance_id() != avatar.instance_id(),
                 };
 

--- a/lib/src/social/social_service_manager.rs
+++ b/lib/src/social/social_service_manager.rs
@@ -300,7 +300,7 @@ impl SocialServiceManager {
         u64,
     ) {
         if let Err(e) = self.ensure_connected().await {
-            tracing::error!("call_get_friends: connection failed: {:?}", e);
+            tracing::warn!("call_get_friends: connection failed: {:?}", e);
             return (
                 Err(ClientResultError::Client(ClientError::TransportError)),
                 0,
@@ -313,7 +313,7 @@ impl SocialServiceManager {
         let service = match state.connection.as_ref() {
             Some(conn) => &conn.service,
             None => {
-                tracing::error!("call_get_friends: no connection after ensure_connected");
+                tracing::warn!("call_get_friends: no connection after ensure_connected");
                 return (
                     Err(ClientResultError::Client(ClientError::TransportError)),
                     generation,
@@ -330,7 +330,7 @@ impl SocialServiceManager {
         match result {
             Ok(rpc_result) => (rpc_result, generation),
             Err(_) => {
-                tracing::error!("call_get_friends: RPC timeout after {}s", RPC_TIMEOUT_SECS);
+                tracing::warn!("call_get_friends: RPC timeout after {}s", RPC_TIMEOUT_SECS);
                 (
                     Err(ClientResultError::Client(ClientError::TransportError)),
                     generation,

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -4,7 +4,7 @@ pub const BIN_FOLDER: &str = "./.bin/";
 pub const RUST_LIB_PROJECT_FOLDER: &str = "./lib/";
 pub const EXPORTS_FOLDER: &str = "./exports/";
 
-pub const SENTRY_ADDON_URL: &str = "https://github.com/getsentry/sentry-godot/releases/download/1.0.0/sentry-godot-gdextension-1.0.0+f672aa4.zip";
+pub const SENTRY_ADDON_URL: &str = "https://github.com/getsentry/sentry-godot/releases/download/1.6.0/sentry-godot-1.6.0+4e3e3e5.zip";
 
 pub const PROTOC_BASE_URL: &str =
     "https://github.com/protocolbuffers/protobuf/releases/download/v23.2/protoc-23.2-";

--- a/src/install_dependency.rs
+++ b/src/install_dependency.rs
@@ -569,7 +569,7 @@ pub fn install(
         download_and_extract_zip(
             SENTRY_ADDON_URL,
             uncompressed_folder.to_str().unwrap(),
-            cache_key("sentry.zip".into()),
+            cache_key("sentry-1.6.0.zip".into()),
         )?;
 
         fs::rename(


### PR DESCRIPTION
Cuts ~85% of Sentry event volume from the top 40 production issues (423k events / 14d). Most of it is Godot/driver/3rd-party noise we can't act on, plus operational warnings we mis-tagged as errors. Three real panic fixes fell out of the analysis.

- Noise filter in `_before_send`: 15 substring patterns, keep 5% as canary
- 8 operational `tracing::error!` → `warn!`/`debug!` (crdt, pool, realm, kill, social, analytics)
- Friends panel: `push_error` → `push_warning` for network errors
- `SceneManager::scene_runner_update`: fix stale-scene-id unwrap; guard freed `base_ui`; guard freed avatar `Gd<T>`
- Drop dead `%TextureRect_Logo` ref + fix `check.svg` → `checked.svg`

Behavior unchanged — just stops emitting/panicking. Loop-vs-RegEx benchmark in `tools/bench_noise_filter.gd` (loop wins 1.7×, hence no regex).
