### PR TITLE
bump version v66 and iOS short_version to 1.5

### DIFF
--- a/godot/export_presets.cfg
+++ b/godot/export_presets.cfg
@@ -38,7 +38,7 @@ architectures/armeabi-v7a=false
 architectures/arm64-v8a=true
 architectures/x86=false
 architectures/x86_64=true
-version/code=65
+version/code=66
 version/name="1.0"
 package/unique_name="org.decentraland.godotexplorer"
 package/name="Decentraland"
@@ -292,8 +292,8 @@ application/provisioning_profile_specifier_release=""
 application/export_method_release=1
 application/bundle_identifier="org.decentraland.godotexplorer"
 application/signature=""
-application/short_version="1.4"
-application/version="65"
+application/short_version="1.5"
+application/version="66"
 application/additional_plist_content="	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>

--- a/lib/Cargo.lock
+++ b/lib/Cargo.lock
@@ -861,7 +861,7 @@ dependencies = [
 
 [[package]]
 name = "dclgodot"
-version = "0.65.0"
+version = "0.66.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dclgodot"
-version = "0.65.0"
+version = "0.66.0"
 edition = "2021"
 publish = false
 


### PR DESCRIPTION
Replicates what the `🔢 Bump Version` workflow (`.github/workflows/bump_version.yml`) does, plus an additional bump of the iOS marketing version.

## Changes

- `godot/export_presets.cfg`
  - Android `version/code`: `65` → `66`
  - iOS `application/version`: `"65"` → `"66"`
  - iOS `application/short_version`: `"1.4"` → `"1.5"`
- `lib/Cargo.toml`: `dclgodot` `0.65.0` → `0.66.0`
- `lib/Cargo.lock`: `dclgodot` `0.65.0` → `0.66.0`


---
_Generated by [Claude Code](https://claude.ai/code/session_01BKtoACUVum2bi5YSRHBwZH)_