### PR TITLE
fix: replace dead test fixture URL in resource_provider test

### DIFF
--- a/lib/src/content/resource_provider.rs
+++ b/lib/src/content/resource_provider.rs
@@ -688,15 +688,15 @@ mod tests {
 
         let files_to_download = vec![
             (
-                "https://freetestdata.com/wp-content/uploads/2021/09/500kb.png",
+                "https://httpbin.org/image/png",
                 "bafkreibmrvrdgqthfrvehyell552sk7ivuas2ozzjdmlojbzttqlcrxiya",
             ),
             (
-                "https://freetestdata.com/wp-content/uploads/2021/09/500kb.png",
+                "https://httpbin.org/image/png",
                 "bafkreic4osvzsjzyqutwjxt2xmyd4hjrwukrxzclvixke3putyrihggmam",
             ),
             (
-                "https://freetestdata.com/wp-content/uploads/2021/09/500kb.png",
+                "https://httpbin.org/image/png",
                 "bafkreibhjuitdcu3jwu7khjcg2fo6xf2h3hilnfv4liy4p5h2olxj6tcce",
             ),
         ];


### PR DESCRIPTION
Closes #2062

## Summary
- `test_fetch_resource_or_wait` was downloading from `https://freetestdata.com/wp-content/uploads/2021/09/500kb.png`, which now returns HTTP 404, breaking CI on `main` ([failing run](https://github.com/decentraland/godot-explorer/actions/runs/25324682045)).
- Swap the URL to `https://httpbin.org/image/png` (stable, returns a small PNG). The `file_hash` arg is used as a cache key, not a content hash, so the underlying URL can change freely.

## Caveat
This keeps the test network-dependent — same fragility class as before, just a more reliable host. A proper fix would mock the HTTP layer with `mockito`/`wiremock`. Filing this as the cheap unblock so `main` goes green; happy to follow up with the mocked version.

## Test plan
- [ ] Linux CI test step passes (was the failing job)
- [ ] No other test regressions