### PR TITLE
fix: avatar_attach duplicate parent + dup tree_changed connect; social_item dead method call

### DIFF
--- a/godot/src/ui/components/social/social_item/social_item.gd
+++ b/godot/src/ui/components/social/social_item/social_item.gd
@@ -261,7 +261,7 @@ func _notify_other_components_of_change() -> void:
 
 func _sync_blacklist_ui(changed_avatar_id: String) -> void:
 	if social_data and social_data.address == changed_avatar_id:
-		call_deferred("_update_buttons")
+		call_deferred("_update_blocked_visibility_for_type")
 
 
 func _update_elements_visibility() -> void:

--- a/lib/src/scene_runner/components/avatar_attach.rs
+++ b/lib/src/scene_runner/components/avatar_attach.rs
@@ -35,14 +35,15 @@ pub fn update_avatar_attach(scene: &mut Scene, crdt_state: &mut SceneCrdtState) 
                     // TODO: resolve the current transform
                 }
             } else if let Some(new_value) = new_value {
-                let mut avatar_attach_node = if let Some(avatar_attach_node) = existing {
-                    avatar_attach_node
+                let (mut avatar_attach_node, is_new) = if let Some(avatar_attach_node) = existing {
+                    (avatar_attach_node, false)
                 } else {
-                    godot::tools::load::<PackedScene>(
+                    let node = godot::tools::load::<PackedScene>(
                         "res://src/decentraland_components/avatar_attach.tscn",
                     )
                     .instantiate()
-                    .unwrap()
+                    .unwrap();
+                    (node, true)
                 };
 
                 avatar_attach_node.set(
@@ -52,10 +53,11 @@ pub fn update_avatar_attach(scene: &mut Scene, crdt_state: &mut SceneCrdtState) 
 
                 avatar_attach_node.set("attach_point", &Variant::from(new_value.anchor_point_id));
 
-                avatar_attach_node.set_name("AvatarAttach");
-
-                node_3d.add_child(&avatar_attach_node.clone());
-                avatar_attach_node.call("init", &[]);
+                if is_new {
+                    avatar_attach_node.set_name("AvatarAttach");
+                    node_3d.add_child(&avatar_attach_node.clone());
+                    avatar_attach_node.call("init", &[]);
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary

Two real fixes to engine errors surfaced by Sentry triage in v0.64/v0.65. Both target root causes — no error muting.

| Sentry | Issue | File | Fix |
|---|---|---|---|
| 1YZ | #1961 | `lib/src/scene_runner/components/avatar_attach.rs` | When the AvatarAttach node already exists for an entity, only update its properties — don't re-`add_child` (was creating "duplicate parent") and don't re-`init()` (was creating a duplicate `tree_changed` connection). |
| 1SX | #1986 | `godot/src/ui/components/social/social_item/social_item.gd` | `_sync_blacklist_ui` was `call_deferred`-ing the nonexistent `_update_buttons`; route to the existing `_update_blocked_visibility_for_type` instead, matching the `_on_blacklist_changed` pathway. |

Closes #1961, #1986.

## Why the Rust fix (not a GDScript guard)

In `update_avatar_attach`, the code reuses the existing `AvatarAttach` Godot node when the component changes (e.g. anchor_point flips). It then unconditionally re-adds it as a child and re-calls `init()` — which itself connects `scene.tree_changed` and walks the collider tree. That's the underlying cause of:

- "Signal already connected" warnings on `scene.tree_changed`
- Duplicate parents (the same node appearing twice in `node_3d`'s children)
- Per-frame collider-tree work being doubled (or worse) per attach update

A GDScript `is_connected()` guard in `player_collider_filter.gd` would silence the signal warning but leave the duplicate parenting + duplicate work in place. The Rust change fixes the source.

## Out of scope

- **#1984 (gamepad `ia_any`)** — closed-out as misdiagnosed during triage. The actual `ia_any` lookup happens in `tooltip_label.gd`, which already special-cases it correctly. The `player_gamepad_input.gd` actions all exist in `project.godot` so no guard is warranted there. Leaving #1984 open with the corrected note for separate investigation.
- **#1964 (places category SVGs)** — separate; needs the missing assets added (`featured.svg`, `favorites.svg`, `shop.svg`) rather than a load() guard.
- Other Sentry items from the triage need design decisions, span Rust+GDScript, or were already addressed on `main`.

## Test plan

- [ ] Spawn an SDK scene with a `AvatarAttach` component that flips `anchor_point` (e.g. left hand → right hand) → no "Signal already connected" warnings, no duplicate `AvatarAttach` children under the entity node, the attach still updates its transform correctly.
- [ ] Open Nearby Players panel, block/unblock another user → row hides/shows correctly, no "Cannot find method `_update_buttons`" engine error in the console.
- [ ] `gdformat` / `gdlint` clean (verified locally), `cargo fmt` clean, `cargo check` clean.
