### PR TITLE
feat: implement z_index for SDK7 UI components

### DIFF
--- a/lib/src/scene_runner/components/ui/scene_ui.rs
+++ b/lib/src/scene_runner/components/ui/scene_ui.rs
@@ -8,7 +8,7 @@ use godot::{
     builtin::math::FloatExt,
     classes::{
         text_server::{JustificationFlag, LineBreakFlag},
-        Node,
+        Node, RenderingServer,
     },
     obj::Gd,
 };
@@ -33,11 +33,41 @@ use crate::{
             ui_background::update_ui_background, ui_text::update_ui_text,
             ui_transform::update_ui_transform,
         },
+        godot_dcl_scene::GodotDclScene,
         scene::{Scene, SceneType},
     },
 };
 
 use super::{ui_dropdown::update_ui_dropdown, ui_input::update_ui_input};
+
+fn assign_z_index_recursive(
+    children: &[(SceneEntityId, i32)],
+    z_counter: &mut i32,
+    children_by_parent: &HashMap<SceneEntityId, Vec<(SceneEntityId, i32)>>,
+    godot_dcl_scene: &mut GodotDclScene,
+) {
+    let last_idx = children.len().saturating_sub(1);
+    for (i, (entity, _)) in children.iter().enumerate() {
+        if let Some(ui_node) = godot_dcl_scene.get_node_or_null_ui_mut(entity) {
+            ui_node.base_control.set_z_index(
+                (*z_counter).clamp(RenderingServer::CANVAS_ITEM_Z_MIN, RenderingServer::CANVAS_ITEM_Z_MAX),
+            );
+            ui_node.base_control.set_z_as_relative(false);
+        }
+        let entity_children = children_by_parent.get(entity).cloned().unwrap_or_default();
+        if !entity_children.is_empty() {
+            assign_z_index_recursive(
+                &entity_children,
+                z_counter,
+                children_by_parent,
+                godot_dcl_scene,
+            );
+        }
+        if i < last_idx {
+            *z_counter += 1;
+        }
+    }
+}
 
 pub struct UiResults {
     pub pointer_event_results: Vec<(SceneEntityId, PbPointerEventsResult)>,
@@ -395,26 +425,15 @@ fn update_layout(
         children.sort_by_key(|(_, z)| *z);
     }
 
-    let mut z_counter: i32 = 0;
-    let initial_children = children_by_parent
+    // SDK UI occupies the low end of the z_index range so it always renders behind the app UI.
+    // A margin of 1000 is reserved at the bottom for scenes that use negative z_index values.
+    const SDK_UI_Z_MARGIN: i32 = 1000;
+    let mut z_counter: i32 = RenderingServer::CANVAS_ITEM_Z_MIN + SDK_UI_Z_MARGIN;
+    let root_children = children_by_parent
         .get(&SceneEntityId::ROOT)
         .cloned()
         .unwrap_or_default();
-    let mut dfs_stack: Vec<SceneEntityId> =
-        initial_children.into_iter().rev().map(|(e, _)| e).collect();
-
-    while let Some(entity) = dfs_stack.pop() {
-        if let Some(ui_node) = godot_dcl_scene.get_node_or_null_ui_mut(&entity) {
-            ui_node.base_control.set_z_index(z_counter);
-            ui_node.base_control.set_z_as_relative(false);
-            z_counter += 1;
-        }
-        if let Some(children) = children_by_parent.get(&entity) {
-            for (child_entity, _) in children.iter().rev() {
-                dfs_stack.push(*child_entity);
-            }
-        }
-    }
+    assign_z_index_recursive(&root_children, &mut z_counter, &children_by_parent, godot_dcl_scene);
 }
 
 pub fn update_scene_ui(

--- a/lib/src/scene_runner/components/ui/scene_ui.rs
+++ b/lib/src/scene_runner/components/ui/scene_ui.rs
@@ -49,9 +49,10 @@ fn assign_z_index_recursive(
     let last_idx = children.len().saturating_sub(1);
     for (i, (entity, _)) in children.iter().enumerate() {
         if let Some(ui_node) = godot_dcl_scene.get_node_or_null_ui_mut(entity) {
-            ui_node.base_control.set_z_index(
-                (*z_counter).clamp(RenderingServer::CANVAS_ITEM_Z_MIN, RenderingServer::CANVAS_ITEM_Z_MAX),
-            );
+            ui_node.base_control.set_z_index((*z_counter).clamp(
+                RenderingServer::CANVAS_ITEM_Z_MIN,
+                RenderingServer::CANVAS_ITEM_Z_MAX,
+            ));
             ui_node.base_control.set_z_as_relative(false);
         }
         let entity_children = children_by_parent.get(entity).cloned().unwrap_or_default();
@@ -433,7 +434,12 @@ fn update_layout(
         .get(&SceneEntityId::ROOT)
         .cloned()
         .unwrap_or_default();
-    assign_z_index_recursive(&root_children, &mut z_counter, &children_by_parent, godot_dcl_scene);
+    assign_z_index_recursive(
+        &root_children,
+        &mut z_counter,
+        &children_by_parent,
+        godot_dcl_scene,
+    );
 }
 
 pub fn update_scene_ui(

--- a/lib/src/scene_runner/components/ui/scene_ui.rs
+++ b/lib/src/scene_runner/components/ui/scene_ui.rs
@@ -381,8 +381,7 @@ fn update_layout(
     // Each node is assigned a monotonically increasing counter value as its absolute
     // Godot z_index. Because the entire subtree of a lower-z_index sibling is visited
     // before the next sibling, containment is enforced automatically.
-    let mut children_by_parent: HashMap<SceneEntityId, Vec<(SceneEntityId, i32)>> =
-        HashMap::new();
+    let mut children_by_parent: HashMap<SceneEntityId, Vec<(SceneEntityId, i32)>> = HashMap::new();
     for (entity, _) in processed_nodes_sorted.iter() {
         let ui_node = godot_dcl_scene.get_node_or_null_ui(entity).unwrap();
         let parent = ui_node.ui_transform.parent;
@@ -401,11 +400,8 @@ fn update_layout(
         .get(&SceneEntityId::ROOT)
         .cloned()
         .unwrap_or_default();
-    let mut dfs_stack: Vec<SceneEntityId> = initial_children
-        .into_iter()
-        .rev()
-        .map(|(e, _)| e)
-        .collect();
+    let mut dfs_stack: Vec<SceneEntityId> =
+        initial_children.into_iter().rev().map(|(e, _)| e).collect();
 
     while let Some(entity) = dfs_stack.pop() {
         if let Some(ui_node) = godot_dcl_scene.get_node_or_null_ui_mut(&entity) {

--- a/lib/src/scene_runner/components/ui/scene_ui.rs
+++ b/lib/src/scene_runner/components/ui/scene_ui.rs
@@ -372,6 +372,53 @@ fn update_layout(
             || is_hidden_by_zero_size;
         control.set_visible(!is_hidden);
     }
+
+    // Assign absolute Godot z_index using a z_index-aware DFS traversal.
+    // This implements DCL stacking contexts: siblings are ordered by their DCL z_index,
+    // and a child's z_index never escapes its parent's context.
+    //
+    // Strategy: DFS pre-order, children sorted by DCL z_index (ascending).
+    // Each node is assigned a monotonically increasing counter value as its absolute
+    // Godot z_index. Because the entire subtree of a lower-z_index sibling is visited
+    // before the next sibling, containment is enforced automatically.
+    let mut children_by_parent: HashMap<SceneEntityId, Vec<(SceneEntityId, i32)>> =
+        HashMap::new();
+    for (entity, _) in processed_nodes_sorted.iter() {
+        let ui_node = godot_dcl_scene.get_node_or_null_ui(entity).unwrap();
+        let parent = ui_node.ui_transform.parent;
+        let z_index = ui_node.ui_transform.z_index;
+        children_by_parent
+            .entry(parent)
+            .or_default()
+            .push((*entity, z_index));
+    }
+    for children in children_by_parent.values_mut() {
+        children.sort_by_key(|(_, z)| *z);
+    }
+
+    let mut z_counter: i32 = 0;
+    let initial_children = children_by_parent
+        .get(&SceneEntityId::ROOT)
+        .cloned()
+        .unwrap_or_default();
+    let mut dfs_stack: Vec<SceneEntityId> = initial_children
+        .into_iter()
+        .rev()
+        .map(|(e, _)| e)
+        .collect();
+
+    while let Some(entity) = dfs_stack.pop() {
+        if let Some(ui_node) = godot_dcl_scene.get_node_or_null_ui_mut(&entity) {
+            ui_node.base_control.set_z_index(z_counter);
+            ui_node.base_control.set_z_as_relative(false);
+            z_counter += 1;
+        }
+        if let Some(children) = children_by_parent.get(&entity) {
+            for (child_entity, _) in children.iter().rev() {
+                dfs_stack.push(*child_entity);
+            }
+        }
+    }
 }
 
 pub fn update_scene_ui(

--- a/lib/src/scene_runner/components/ui/style.rs
+++ b/lib/src/scene_runner/components/ui/style.rs
@@ -63,6 +63,7 @@ pub struct UiTransform {
     pub right_of: SceneEntityId,
     pub overflow: YgOverflow,
     pub pointer_filter_mode: PointerFilterMode,
+    pub z_index: i32,
     pub taffy_style: taffy::style::Style,
 }
 
@@ -73,6 +74,7 @@ impl From<&PbUiTransform> for UiTransform {
             right_of: SceneEntityId::from_i32(value.right_of),
             overflow: value.overflow(),
             pointer_filter_mode: value.pointer_filter(),
+            z_index: value.z_index.unwrap_or(0),
             taffy_style: taffy::style::Style {
                 overflow: match value.overflow() {
                     YgOverflow::YgoVisible => taffy::geometry::Point::<taffy::style::Overflow> {


### PR DESCRIPTION
## Summary                                                                                                                                                                                                      
  - Reads the `z_index` field from `UiTransform` (proto field 77, already declared but previously unused)                                                                                                         
  - Implements DCL stacking context semantics: z_index orders siblings within the same parent; a child's z_index cannot escape its parent's context                                                               
  - Purely visual — does not affect pointer/input handling                                                                                                                                                        
                                                                                                                                                                                                                  
  ## How z_index values are assigned in Godot                                                                                                                                                                     
                                                                                                                                                                                                                  
  DCL z_index is `int32` (range ±2 billion), while Godot's `CanvasItem.z_index` is clamped to **-4096 to 4096**. The DCL value is never used directly as a Godot z_index — it is only used as a **sort key**.
                                                                                                                                                                                                                  
  After the layout pass, a recursive DFS traversal visits each entity's children sorted by DCL z_index (ascending) and assigns a monotonically increasing counter as the absolute Godot z_index (`z_as_relative = 
  false`). The counter only increments between siblings, never when descending into children — so all nodes in a subtree share the same z_index as their parent, with Godot's tree order handling within-group    
  rendering. This naturally enforces stacking context containment.     
                                                                                                                                                                                                                  
  SDK UI starts at `RenderingServer.CANVAS_ITEM_Z_MIN + 1000` (-3096) so it always renders behind the app UI, which occupies the default z_index range (0+). The 1000-unit margin reserves space at the bottom for
   scenes using negative z_index values.                                                                                                                                                                                                                                                  
   
## Image

<img width="851" height="823" alt="Captura de pantalla 2026-05-05 a la(s) 18 49 05" src="https://github.com/user-attachments/assets/3e1494c1-80ee-40ec-a7d6-df5c70510a3d" />


  Closes #556        