### PR TITLE
fix: ResourceProvider::clear NotFound on fresh install (#1970)

### DIFF
--- a/godot/src/global.gd
+++ b/godot/src/global.gd
@@ -261,6 +261,11 @@ func _ready():
 	self.portable_experience_controller = PortableExperienceController.new()
 	self.portable_experience_controller.set_name("portable_experience_controller")
 
+	# Ensure the content cache folder exists before clearing — clear runs against
+	# this directory and would log an error if it doesn't exist yet (fresh install).
+	if not DirAccess.dir_exists_absolute("user://content/"):
+		DirAccess.make_dir_absolute("user://content/")
+
 	# Clear cache if needed (startup flag or version changed) - await completion
 	print(
 		"[Startup] global._async_clear_cache start: %dms" % (Time.get_ticks_msec() - _startup_time)
@@ -291,9 +296,6 @@ func _ready():
 		fi_runner.set_name("FIBenchmarkRunner")
 		get_tree().root.add_child.call_deferred(fi_runner)
 		return
-
-	if not DirAccess.dir_exists_absolute("user://content/"):
-		DirAccess.make_dir_absolute("user://content/")
 
 	session_id = DclConfig.generate_uuid_v4()
 	# Initialize metrics with proper user_id and session_id (skip in asset server mode)

--- a/lib/src/content/resource_provider.rs
+++ b/lib/src/content/resource_provider.rs
@@ -60,6 +60,7 @@ impl ResourceProvider {
     // Private asynchronous function to initialize the cache
     async fn initialize(&self) -> Result<(), io::Error> {
         let mut existing_files = self.existing_files.write().await;
+        fs::create_dir_all(&self.cache_folder).await?;
         let dir = std::fs::read_dir(&self.cache_folder)?;
         for entry in dir {
             let entry = entry?;
@@ -615,8 +616,11 @@ impl ResourceProvider {
 
     // Method to clear the cache and delete all files from the file system
     pub async fn clear(&self) {
-        if self.ensure_initialized().await.is_err() {
-            tracing::error!("ResourceLoader failed to load!");
+        if let Err(e) = self.ensure_initialized().await {
+            tracing::error!(
+                "ResourceProvider::clear failed to initialize cache folder: {}",
+                e
+            );
             return;
         }
 


### PR DESCRIPTION
## Summary

Closes #1970.

The Sentry cluster `[Rust:dclgodot::content::resource_provider] ResourceLoader failed to load!` (255 users in 0.65, up from 191 in 0.64) was triggered on every fresh install and every cache-version-bump upgrade, because `ResourceProvider::clear()` called `read_dir()` on a cache folder that hadn't been created yet.

### Root cause

In `godot/src/global.gd`, `await _async_clear_cache_if_needed()` ran *before* `DirAccess.make_dir_absolute(\"user://content/\")`. The reorder plus the `LOCAL_ASSETS_CACHE_VERSION` 3→4 bump introduced together in `01c2908f` (\"feat: asset optimization server with ZIP packing\") forced every upgrading 0.65 user through the clear path against a non-existent directory.

The Rust `clear()` then logged a generic `tracing::error!(\"ResourceLoader failed to load!\")` and discarded the underlying `io::Error`, which is why the Sentry message gave no clue about the cause.

### Fixes

- **`lib/src/content/resource_provider.rs::initialize()`** — `fs::create_dir_all(&self.cache_folder)` before `read_dir`, so the provider self-heals when the cache folder is absent. Removes this entire failure mode regardless of caller ordering.
- **`lib/src/content/resource_provider.rs::clear()`** — log the underlying `io::Error` from `ensure_initialized()` instead of the generic message, so future init failures (permission denied, disk full, etc.) are diagnosable in Sentry.
- **`godot/src/global.gd`** — move `make_dir_absolute(\"user://content/\")` above `await _async_clear_cache_if_needed()` and drop the now-redundant copy that sat after the `test_runner` / `fi_benchmark` early-returns. Restores the pre-0.65 invariant.

## Test plan

- [ ] Wipe `user://content/` on a desktop build and launch — no `ResourceLoader failed to load!` error in Sentry / console.
- [ ] Wipe `user://content/` and bump `LOCAL_ASSETS_CACHE_VERSION` locally to force the clear path — clean startup, cache rebuilds normally.
- [ ] Fresh install on Android (or wipe app data) — clean startup, no Sentry error.
- [ ] Fresh install on iOS — clean startup, no Sentry error.
- [ ] Settings → Clear cache after the above — still works (the clear path remains exercised).
- [ ] Confirm the existing `test_fetch_resource_or_wait` integration test in `resource_provider.rs` still passes (it calls `provider.clear().await` against a freshly-set-up dir).