### PR TITLE
feat(graphics): per-profile mesh_lod_threshold

### DIFF
--- a/godot/src/config/graphic_settings.gd
+++ b/godot/src/config/graphic_settings.gd
@@ -1,7 +1,15 @@
 class_name GraphicSettings extends RefCounted
 
 ## Profile definitions as data - easier to tune without code changes
-## Keys: aa, shadow, bloom, skybox, texture, fps, scale
+## Keys: aa, shadow, bloom, skybox, texture, fps, scale, mesh_lod_threshold
+##
+## mesh_lod_threshold (pixels of screen-space error before swapping to a
+## lower-detail LOD). Default Godot=1.0 — very conservative. Genesis Plaza
+## scenes ship a full LOD chain via the Rust GLTF import pipeline (sibling
+## PR perf/lod-chain-pregen); raising this threshold makes that chain do
+## real work by swapping farther/smaller MeshInstances to LOD1/2/3 sooner.
+## Tuned per profile so HIGH stays visually crisp while lower profiles
+## trade detail for fragment cost.
 const PROFILE_DEFINITIONS: Array[Dictionary] = [
 	# Very Low (0) - Maximum battery savings
 	{
@@ -11,7 +19,8 @@ const PROFILE_DEFINITIONS: Array[Dictionary] = [
 		"skybox": 0,
 		"texture": 0,
 		"fps": ConfigData.FpsLimitMode.FPS_18,
-		"scale": 0.5
+		"scale": 0.5,
+		"mesh_lod_threshold": 8.0,
 	},
 	# Low (1) - Battery savings with better visuals
 	{
@@ -21,7 +30,8 @@ const PROFILE_DEFINITIONS: Array[Dictionary] = [
 		"skybox": 0,
 		"texture": 0,
 		"fps": ConfigData.FpsLimitMode.FPS_30,
-		"scale": 0.75
+		"scale": 0.75,
+		"mesh_lod_threshold": 6.0,
 	},
 	# Medium (2) - Balanced performance and quality
 	{
@@ -31,7 +41,8 @@ const PROFILE_DEFINITIONS: Array[Dictionary] = [
 		"skybox": 1,
 		"texture": 1,
 		"fps": ConfigData.FpsLimitMode.FPS_30,
-		"scale": 1.0
+		"scale": 1.0,
+		"mesh_lod_threshold": 3.0,
 	},
 	# High (3) - Best quality
 	{
@@ -41,7 +52,8 @@ const PROFILE_DEFINITIONS: Array[Dictionary] = [
 		"skybox": 2,
 		"texture": 2,
 		"fps": ConfigData.FpsLimitMode.FPS_60,
-		"scale": 1.0
+		"scale": 1.0,
+		"mesh_lod_threshold": 2.0,
 	},
 ]
 
@@ -207,3 +219,8 @@ static func apply_graphic_profile(profile_index: int) -> void:
 	var viewport := Global.get_tree().root.get_viewport()
 	if viewport:
 		viewport.scaling_3d_scale = config.resolution_3d_scale
+		# Higher value = swap to lower-detail LOD sooner. The LOD chain itself
+		# is baked at GLTF import time; this is the only knob that decides how
+		# aggressively the renderer picks LOD1/2/3 at distance.
+		var lod_thr: float = profile.get("mesh_lod_threshold", 1.0)
+		viewport.mesh_lod_threshold = lod_thr

--- a/godot/src/config/graphic_settings.gd
+++ b/godot/src/config/graphic_settings.gd
@@ -191,18 +191,24 @@ static func apply_full_processor_mode() -> void:
 	Global.get_window().get_viewport().disable_3d = false
 
 
-## Apply a graphic profile by index
-## 0: Very Low, 1: Low, 2: Medium, 3: High, 4: Custom
-## Sets ALL graphics parameters including FPS limit, bloom, and 3D resolution scale
+## Apply a graphic profile by index (0=Very Low, 1=Low, 2=Medium, 3=High, 4=Custom).
+##
+## Mirrors PROFILE_DEFINITIONS[index] into DclConfig, then pushes the
+## viewport-side knobs (scaling_3d_scale, mesh_lod_threshold) and the FPS
+## limit. Index 4 (Custom) and out-of-range values are ignored — the
+## caller keeps whatever is already in DclConfig.
+##
+## HardwareBenchmark writes its picked profile to DclConfig once at
+## first launch; this function reads from PROFILE_DEFINITIONS by index
+## and is agnostic to who set graphic_profile (HW-bench, settings UI,
+## or the force-graphic-profile deeplink override).
 static func apply_graphic_profile(profile_index: int) -> void:
-	# Custom or invalid index - do nothing
 	if profile_index < 0 or profile_index >= PROFILE_DEFINITIONS.size():
 		return
 
 	var config: DclConfig = Global.get_config()
 	var profile: Dictionary = PROFILE_DEFINITIONS[profile_index]
 
-	# Apply all settings from profile definition
 	config.anti_aliasing = profile.aa
 	config.shadow_quality = profile.shadow
 	config.bloom_quality = profile.bloom
@@ -212,10 +218,8 @@ static func apply_graphic_profile(profile_index: int) -> void:
 	config.resolution_3d_scale = profile.scale
 	config.graphic_profile = profile_index
 
-	# Apply FPS limit immediately
 	apply_fps_limit()
 
-	# Apply 3D resolution scale to viewport
 	var viewport := Global.get_tree().root.get_viewport()
 	if viewport:
 		viewport.scaling_3d_scale = config.resolution_3d_scale

--- a/godot/src/test/graphics/test_mesh_lod_threshold.gd
+++ b/godot/src/test/graphics/test_mesh_lod_threshold.gd
@@ -1,0 +1,82 @@
+extends Node
+
+## Per-profile mesh_lod_threshold fixtures.
+##
+## Default Godot viewport.mesh_lod_threshold is 1.0 (very conservative). These
+## tests pin the per-profile values so a future tweak to the LOD chain or to
+## profile balancing surfaces in CI rather than as a silent regression on
+## low-end hardware (where higher thresholds buy real fps by skipping
+## sub-pixel mesh detail).
+
+const _TEST_METHODS: Array[String] = [
+	"test_profile_definitions_include_mesh_lod_threshold",
+	"test_apply_very_low_profile_sets_viewport_threshold_to_8",
+	"test_apply_low_profile_sets_viewport_threshold_to_6",
+	"test_apply_medium_profile_sets_viewport_threshold_to_3",
+	"test_apply_high_profile_sets_viewport_threshold_to_2",
+]
+
+var suite_name: String = "test_mesh_lod_threshold"
+var method_name: String = ""
+var errors: Array[String] = []
+var execution_time_seconds: float = 0.0
+
+
+func run() -> bool:
+	errors.clear()
+	var start_usec: int = Time.get_ticks_usec()
+	if method_name.is_empty():
+		for m in _TEST_METHODS:
+			call(m)
+	else:
+		call(method_name)
+	execution_time_seconds = float(Time.get_ticks_usec() - start_usec) / 1_000_000.0
+	return errors.is_empty()
+
+
+func _viewport() -> Viewport:
+	return Global.get_tree().root.get_viewport()
+
+
+func _fail(msg: String) -> void:
+	errors.append("[%s] %s" % [method_name, msg])
+
+
+func test_profile_definitions_include_mesh_lod_threshold() -> void:
+	method_name = "test_profile_definitions_include_mesh_lod_threshold"
+	for i in range(GraphicSettings.PROFILE_DEFINITIONS.size()):
+		var entry: Dictionary = GraphicSettings.PROFILE_DEFINITIONS[i]
+		if not entry.has("mesh_lod_threshold"):
+			_fail("PROFILE_DEFINITIONS[%d] missing mesh_lod_threshold key" % i)
+
+
+func test_apply_very_low_profile_sets_viewport_threshold_to_8() -> void:
+	method_name = "test_apply_very_low_profile_sets_viewport_threshold_to_8"
+	GraphicSettings.apply_graphic_profile(0)
+	var got: float = _viewport().mesh_lod_threshold
+	if not is_equal_approx(got, 8.0):
+		_fail("expected viewport.mesh_lod_threshold == 8.0, got %f" % got)
+
+
+func test_apply_low_profile_sets_viewport_threshold_to_6() -> void:
+	method_name = "test_apply_low_profile_sets_viewport_threshold_to_6"
+	GraphicSettings.apply_graphic_profile(1)
+	var got: float = _viewport().mesh_lod_threshold
+	if not is_equal_approx(got, 6.0):
+		_fail("expected viewport.mesh_lod_threshold == 6.0, got %f" % got)
+
+
+func test_apply_medium_profile_sets_viewport_threshold_to_3() -> void:
+	method_name = "test_apply_medium_profile_sets_viewport_threshold_to_3"
+	GraphicSettings.apply_graphic_profile(2)
+	var got: float = _viewport().mesh_lod_threshold
+	if not is_equal_approx(got, 3.0):
+		_fail("expected viewport.mesh_lod_threshold == 3.0, got %f" % got)
+
+
+func test_apply_high_profile_sets_viewport_threshold_to_2() -> void:
+	method_name = "test_apply_high_profile_sets_viewport_threshold_to_2"
+	GraphicSettings.apply_graphic_profile(3)
+	var got: float = _viewport().mesh_lod_threshold
+	if not is_equal_approx(got, 2.0):
+		_fail("expected viewport.mesh_lod_threshold == 2.0, got %f" % got)


### PR DESCRIPTION
## What

Add `mesh_lod_threshold` (viewport pixel-error budget for swapping to a lower-detail LOD) to `GraphicSettings.PROFILE_DEFINITIONS`, applied to the main viewport inside `apply_graphic_profile`:

| profile | mesh_lod_threshold |
|---|---:|
| Very Low (0) | 8.0 |
| Low (1) | 6.0 |
| Medium (2) | 3.0 |
| High (3) | 2.0 |

Default Godot value is `1.0` (very conservative); higher value = swap to lower-detail LOD sooner.

## Why

The LOD chain (sibling PR #2033) bakes LOD1/2/3 at GLTF import. `viewport.mesh_lod_threshold` is the knob that decides when the renderer picks them. Without per-profile tuning all profiles use 1.0 and the LOD chain barely engages.

## Bench (A54 HIGH, GP preview, warm cache)

| metric | baseline | after | Δ |
|---|---:|---:|---:|
| fps.mean | 7.14 | **8.68** | **+21.5%** |
| render_gpu_ms.mean | 95.33 | 57.01 | **−40.2%** |
| render_cpu_ms.mean | 7.35 | 7.20 | −2.1% |
| video_mem_mb | 778.67 | 755.80 | −2.9% |
| load_seconds | 26.28 | 24.92 | −5.2% |

Note: original PR description hypothesized HIGH would be within noise. Actual measurement shows the largest individual fps gain of the 5 split PRs — most far MIs at HIGH camera distance hit the 2.0 px threshold and swap to LOD2/3, dropping primitives substantially.

### Visual diff

| baseline | this PR |
|---|---|
| ![baseline](https://raw.githubusercontent.com/decentraland/godot-explorer/bench-screenshots/baseline-high.png) | ![after](https://raw.githubusercontent.com/decentraland/godot-explorer/bench-screenshots/mesh-lod-thr-warm.png) |

## Tests

`godot/src/test/graphics/test_mesh_lod_threshold.gd`:
- `test_profile_definitions_include_mesh_lod_threshold`
- `test_apply_very_low_profile_sets_viewport_threshold_to_8`
- `test_apply_low_profile_sets_viewport_threshold_to_6`
- `test_apply_medium_profile_sets_viewport_threshold_to_3`
- `test_apply_high_profile_sets_viewport_threshold_to_2`

`git log --reverse` shows red → green → refactor.

## Optimization opportunities spotted but NOT addressed here

- `viewport.scaling_3d_scale` is `1.0` for both Medium and High — Medium could go `0.85` or `0.9` for a free fragment-cost reduction.
- HIGH's `aa = 1` (MSAA on) costs ~8 ms on Mali-G68; consider dropping for HIGH and adding a \"Very High\" tier.
- Thresholds 8/6/3/2 were tuned on A54 GP HIGH. Re-tuning on iPhone / Snapdragon would likely move LOW/Medium up further.