### PR TITLE
perf(rendering): port visibility-grid hot path to Rust + enable by default

### DIFF
--- a/godot/src/decentraland_components/visibility_culling.gd
+++ b/godot/src/decentraland_components/visibility_culling.gd
@@ -1,0 +1,40 @@
+## Visibility-grid culling driver.
+##
+## Rebuilds the cell grid + PVS on every scene-set load (the same boundary
+## the floating-islands feature uses — N parcels load/unload as a batch via
+## `Global.scene_runner.loading_complete`). Per-frame update delegates to
+## the Rust hot path (DclVisibilityGridRust) to keep CPU < 1ms/frame on GP.
+##
+## Off when `Global.cli.visibility_grid_enabled == false` (--no-visibility-grid).
+class_name VisibilityCulling
+extends Node
+
+const GRID_SCRIPT := preload("res://src/tools/visibility_grid.gd")
+
+var _grid: Node = null
+
+
+func _ready() -> void:
+	if not Global.cli.visibility_grid_enabled:
+		set_process(false)
+		return
+	Global.scene_runner.loading_complete.connect(_on_loading_complete)
+
+
+func _on_loading_complete(_session_id: int) -> void:
+	if _grid != null:
+		_grid = null
+	var scene_root: Node = Global.scene_runner
+	if scene_root == null:
+		return
+	_grid = GRID_SCRIPT.new()
+	_grid.build_from_scene_tree(scene_root)
+
+
+func _process(_delta: float) -> void:
+	if _grid == null:
+		return
+	var camera: Camera3D = Global.player_camera_node
+	if camera == null:
+		return
+	_grid.update_visibility(camera)

--- a/godot/src/global.gd
+++ b/godot/src/global.gd
@@ -343,6 +343,11 @@ func _ready():
 	get_tree().root.add_child.call_deferred(self.modal_manager)
 	get_tree().root.add_child.call_deferred(self.content_provider)
 	get_tree().root.add_child.call_deferred(self.scene_runner)
+	var visibility_culling = (
+		preload("res://src/decentraland_components/visibility_culling.gd").new()
+	)
+	visibility_culling.name = "VisibilityCulling"
+	get_tree().root.add_child.call_deferred(visibility_culling)
 	get_tree().root.add_child.call_deferred(self.realm)
 	get_tree().root.add_child.call_deferred(self.dcl_tokio_rpc)
 	get_tree().root.add_child.call_deferred(self.player_identity)

--- a/godot/src/tools/visibility_grid.gd
+++ b/godot/src/tools/visibility_grid.gd
@@ -1,0 +1,488 @@
+# gdlint: disable=class-definitions-order
+## Cell-based visibility culling for the GP benchmark.
+##
+## Built once after loading_complete. Each static MeshInstance3D is bucketed
+## into every cell its world AABB overlaps (not just the center cell, so a
+## 60m building correctly remains visible as long as ANY of the cells it
+## spans is in the PVS-visible set). Per frame the camera's cell + its 3
+## nearest neighbors (chosen by sub-cell position) contribute their PVS
+## rows via OR — gives hysteresis at cell boundaries so the visible set
+## changes gradually as the camera moves, instead of popping at every 16m
+## boundary crossing.
+class_name DclVisibilityGrid extends Node
+
+const CELL_SIZE_M: float = 16.0
+const MAX_DISTANCE_M: float = 150.0
+## Only MIs whose AABB diagonal exceeds this get bucketed into every cell
+## they overlap (V3 fix for "big building disappears when its center cell
+## is hidden"). Smaller props stay single-cell — bucketing them into
+## multiple cells inflates cells_with_content and neutralizes culling.
+const MULTI_CELL_BUCKET_THRESHOLD_M: float = 5.0
+## Number of frames a cell must consistently fail visibility before its MIs
+## actually get hidden. Prevents popping at cell boundaries when the camera
+## moves: 0 = immediate hide. >0 = temporal hysteresis. New visibility is
+## always immediate (no fade-in delay) so freshly-revealed content shows up
+## right away. 60 frames ≈ 1s at 60fps / 2s at 30fps.
+const HIDE_DELAY_FRAMES: int = 60
+## Cells whose AABB diagonal divided by camera distance is smaller than
+## this threshold are hidden — they'd render as a sub-pixel blob.
+const MIN_SIZE_DISTANCE_RATIO: float = 0.05
+## Blocker selection threshold for the PVS bake.
+const BLOCKER_MIN_DIAGONAL_M: float = 8.0
+## Eye-height the per-cell PVS rays start from.
+const PVS_PLAYER_EYE_HEIGHT: float = 1.5
+
+# ---- Grid topology ----
+var built: bool = false
+var cell_origin_xz: Vector2 = Vector2.ZERO
+var cols: int = 0
+var rows: int = 0
+# Per-cell flat arrays, indexed by cz * cols + cx.
+var _cell_aabb: Array[AABB] = []
+var _cell_has_content: PackedByteArray = PackedByteArray()
+var _cell_last_visible: PackedByteArray = PackedByteArray()
+# Frames the cell has been "should-be-hidden" — used by HIDE_DELAY_FRAMES to
+# delay the actual MI flip and prevent popping during camera movement.
+var _cell_hide_streak: PackedInt32Array = PackedInt32Array()
+# Per-cell list of MI INDICES into _all_mis (PackedInt32Array, fast iter).
+var _cell_mi_indices: Array[PackedInt32Array] = []
+
+# ---- Flat MI storage ----
+# All static, bucketable MeshInstance3Ds. A single MI may appear in multiple
+# cells' _cell_mi_indices when its AABB spans cell borders, but it has ONE
+# entry in these flat arrays.
+var _all_mis: Array[MeshInstance3D] = []
+var _mi_diag_sq: PackedFloat32Array = PackedFloat32Array()
+var _mi_center: PackedVector3Array = PackedVector3Array()
+# Reference count: how many of this MI's cells are currently visible.
+# `mi.visible = (_mi_visible_count[mi_idx] > 0)`.
+var _mi_visible_count: PackedInt32Array = PackedInt32Array()
+
+# ---- PVS ----
+# Bit `cam_cell * (cols*rows) + target_cell` = 1 when cam_cell can see
+# target_cell through the blocker set.
+var _pvs_bits: PackedByteArray = PackedByteArray()
+var _blockers: Array[AABB] = []
+var _pvs_build_ms: int = 0
+
+# ---- Stats ----
+var total_mis: int = 0
+var multi_cell_mis: int = 0  # MIs that span >1 cell
+var cells_with_content: int = 0
+var skipped_avatar: int = 0
+var skipped_hud: int = 0
+var skipped_out_of_grid: int = 0
+var skipped_animated: int = 0
+var skipped_tween: int = 0
+var skipped_modifier: int = 0
+
+# ---- Rust hot-path delegate ----
+## Set during build. When non-null, `update_visibility(camera)` delegates to
+## the Rust per-frame loop (avoids GDScript overhead of ~5-7ms/frame on GP).
+var _rust_grid: DclVisibilityGridRust = null
+
+
+func build_from_scene_tree(scene_root: Node) -> Dictionary:
+	var mis: Array[MeshInstance3D] = []
+	_collect_mis(scene_root, mis)
+
+	# First pass: filter + compute world AABB and bounds.
+	var kept: Array[MeshInstance3D] = []
+	var kept_world_aabb: Array[AABB] = []
+	var min_xz := Vector2(INF, INF)
+	var max_xz := Vector2(-INF, -INF)
+	for mi in mis:
+		var skip_reason := _mi_skip_reason(mi)
+		match skip_reason:
+			"avatar":
+				skipped_avatar += 1
+				continue
+			"hud":
+				skipped_hud += 1
+				continue
+			"animated":
+				skipped_animated += 1
+				continue
+			"tween":
+				skipped_tween += 1
+				continue
+			"modifier":
+				skipped_modifier += 1
+				continue
+		var t := mi.global_transform
+		var world_aabb := _transform_aabb(t, mi.get_aabb())
+		var center := world_aabb.position + world_aabb.size * 0.5
+		min_xz.x = min(min_xz.x, center.x)
+		min_xz.y = min(min_xz.y, center.z)
+		max_xz.x = max(max_xz.x, center.x)
+		max_xz.y = max(max_xz.y, center.z)
+		kept.append(mi)
+		kept_world_aabb.append(world_aabb)
+
+	if kept.is_empty():
+		built = true
+		return _stats_dict()
+
+	cell_origin_xz = Vector2(
+		floor(min_xz.x / CELL_SIZE_M) * CELL_SIZE_M, floor(min_xz.y / CELL_SIZE_M) * CELL_SIZE_M
+	)
+	cols = int(ceil((max_xz.x - cell_origin_xz.x) / CELL_SIZE_M)) + 1
+	rows = int(ceil((max_xz.y - cell_origin_xz.y) / CELL_SIZE_M)) + 1
+	var n_cells := cols * rows
+	_cell_aabb.resize(n_cells)
+	_cell_has_content.resize(n_cells)
+	_cell_last_visible.resize(n_cells)
+	_cell_hide_streak.resize(n_cells)
+	_cell_mi_indices.resize(n_cells)
+	for i in n_cells:
+		_cell_aabb[i] = AABB()
+		_cell_has_content[i] = 0
+		_cell_last_visible[i] = 1
+		_cell_hide_streak[i] = 0
+		_cell_mi_indices[i] = PackedInt32Array()
+
+	# Second pass: store flat MI data + bucket each MI into every cell its
+	# AABB overlaps. This fixes the "big building disappears when its center
+	# cell is hidden" artifact — the MI now lives in all cells it touches.
+	for mi_idx in kept.size():
+		var mi := kept[mi_idx]
+		var world_aabb := kept_world_aabb[mi_idx]
+		var center := world_aabb.position + world_aabb.size * 0.5
+		var diag_sq := (
+			world_aabb.size.x * world_aabb.size.x
+			+ world_aabb.size.y * world_aabb.size.y
+			+ world_aabb.size.z * world_aabb.size.z
+		)
+		_all_mis.append(mi)
+		_mi_diag_sq.append(diag_sq)
+		_mi_center.append(center)
+		# Initial visible_count gets bumped per cell membership below.
+		_mi_visible_count.append(0)
+		var flat_idx := _all_mis.size() - 1
+
+		# Bucket into ONE cell (center) for small MIs, every overlapping cell
+		# for large MIs. This keeps the cell-with-content count tight while
+		# still preventing big-building-disappears artifacts.
+		var diag_xz := sqrt(
+			world_aabb.size.x * world_aabb.size.x + world_aabb.size.z * world_aabb.size.z
+		)
+		var cx_min: int
+		var cz_min: int
+		var cx_max: int
+		var cz_max: int
+		if diag_xz >= MULTI_CELL_BUCKET_THRESHOLD_M:
+			cx_min = int(floor((world_aabb.position.x - cell_origin_xz.x) / CELL_SIZE_M))
+			cz_min = int(floor((world_aabb.position.z - cell_origin_xz.y) / CELL_SIZE_M))
+			cx_max = int(
+				floor((world_aabb.position.x + world_aabb.size.x - cell_origin_xz.x) / CELL_SIZE_M)
+			)
+			cz_max = int(
+				floor((world_aabb.position.z + world_aabb.size.z - cell_origin_xz.y) / CELL_SIZE_M)
+			)
+		else:
+			var center_cx := int(floor((center.x - cell_origin_xz.x) / CELL_SIZE_M))
+			var center_cz := int(floor((center.z - cell_origin_xz.y) / CELL_SIZE_M))
+			cx_min = center_cx
+			cx_max = center_cx
+			cz_min = center_cz
+			cz_max = center_cz
+		cx_min = clampi(cx_min, 0, cols - 1)
+		cz_min = clampi(cz_min, 0, rows - 1)
+		cx_max = clampi(cx_max, 0, cols - 1)
+		cz_max = clampi(cz_max, 0, rows - 1)
+		var cell_count := 0
+		for cz in range(cz_min, cz_max + 1):
+			for cx in range(cx_min, cx_max + 1):
+				var ci := cz * cols + cx
+				if _cell_has_content[ci] == 0:
+					_cell_aabb[ci] = world_aabb
+					_cell_has_content[ci] = 1
+					cells_with_content += 1
+				else:
+					_cell_aabb[ci] = _cell_aabb[ci].merge(world_aabb)
+				_cell_mi_indices[ci].append(flat_idx)
+				_mi_visible_count[flat_idx] += 1
+				cell_count += 1
+		if cell_count > 1:
+			multi_cell_mis += 1
+		total_mis += 1
+
+	_collect_blockers(scene_root)
+	_build_pvs()
+
+	_build_rust_delegate()
+
+	built = true
+	return _stats_dict()
+
+
+func _build_rust_delegate() -> void:
+	# Push our built state into the Rust hot-path delegate. After this runs,
+	# update_visibility(camera) routes through native code, avoiding the
+	# GDScript per-frame overhead (~5-7ms/frame on GP at HIGH).
+	_rust_grid = DclVisibilityGridRust.new()
+	_rust_grid.set_grid_topology(cell_origin_xz.x, cell_origin_xz.y, CELL_SIZE_M, cols, rows)
+	_rust_grid.set_thresholds(MAX_DISTANCE_M, MIN_SIZE_DISTANCE_RATIO, HIDE_DELAY_FRAMES)
+	var n := cols * rows
+	for i in n:
+		_rust_grid.set_cell_aabb(
+			i, _cell_aabb[i].position, _cell_aabb[i].size, _cell_has_content[i] != 0
+		)
+		_rust_grid.set_cell_mi_indices(i, _cell_mi_indices[i])
+	for mi_idx in _all_mis.size():
+		var mi := _all_mis[mi_idx]
+		if is_instance_valid(mi):
+			_rust_grid.add_mi(mi.get_instance(), _mi_visible_count[mi_idx])
+		else:
+			# Fill slot so MI index lines up with cell_mi_indices. Use the same
+			# count so the toggle math stays consistent; the RID is invalid so
+			# RenderingServer calls are no-ops.
+			_rust_grid.add_mi(RID(), _mi_visible_count[mi_idx])
+	_rust_grid.set_pvs_bits(_pvs_bits)
+	_rust_grid.mark_built()
+
+
+func update_visibility(camera: Camera3D) -> Dictionary:
+	if not built or camera == null:
+		return {"toggled_on": 0, "toggled_off": 0, "cells_visible": 0}
+	if _rust_grid != null:
+		return _rust_grid.update_visibility(camera.global_position, camera.get_frustum())
+	var planes := camera.get_frustum()
+	var cam_pos := camera.global_position
+	var cam_xz := Vector2(cam_pos.x, cam_pos.z)
+	var max_dist_sq := MAX_DISTANCE_M * MAX_DISTANCE_M
+	var n := cols * rows
+	# Camera cell + 3 nearest neighbor cells (hysteresis to prevent popping
+	# as camera crosses cell boundaries). Neighbors picked by which side of
+	# the cell the camera is closest to.
+	var cam_cells := _camera_cell_neighborhood(cam_pos)
+	var toggled_on := 0
+	var toggled_off := 0
+	var cells_visible := 0
+	for idx in n:
+		if _cell_has_content[idx] == 0:
+			continue
+		var aabb := _cell_aabb[idx]
+		var cell_center := aabb.position + aabb.size * 0.5
+		var dx := cell_center.x - cam_xz.x
+		var dz := cell_center.z - cam_xz.y
+		var dist_sq := dx * dx + dz * dz
+		var visible := dist_sq <= max_dist_sq
+		if visible and dist_sq > 4.0:
+			var diag_sq := aabb.size.x * aabb.size.x + aabb.size.z * aabb.size.z
+			if diag_sq < dist_sq * MIN_SIZE_DISTANCE_RATIO * MIN_SIZE_DISTANCE_RATIO:
+				visible = false
+		if visible:
+			visible = _aabb_in_frustum(aabb, planes)
+		# PVS: visible from ANY of the camera's neighborhood cells.
+		if visible:
+			var pvs_ok := false
+			for cc in cam_cells:
+				if _pvs_get(cc * n + idx):
+					pvs_ok = true
+					break
+			if not pvs_ok:
+				visible = false
+		if visible:
+			cells_visible += 1
+		# Temporal hysteresis on the OFF transition: a cell that just stopped
+		# being visible this frame doesn't flip its MIs hidden until it's
+		# been not-visible HIDE_DELAY_FRAMES in a row. Hide-counter resets to
+		# zero whenever the cell is visible, so a single visible frame
+		# restarts the streak.
+		var prev := _cell_last_visible[idx] != 0
+		if visible:
+			_cell_hide_streak[idx] = 0
+		else:
+			_cell_hide_streak[idx] += 1
+			if prev and _cell_hide_streak[idx] < HIDE_DELAY_FRAMES:
+				# Treat as still visible for now; skip the flip below.
+				continue
+		if visible != prev:
+			_cell_last_visible[idx] = 1 if visible else 0
+			# Multi-cell-aware toggle: update each MI's visible_count and
+			# only flip the MeshInstance3D when its count crosses 0.
+			var mi_ids := _cell_mi_indices[idx]
+			if visible:
+				for mid in mi_ids:
+					var prev_cnt := _mi_visible_count[mid]
+					_mi_visible_count[mid] = prev_cnt + 1
+					if prev_cnt == 0:
+						var mi := _all_mis[mid]
+						if is_instance_valid(mi):
+							mi.visible = true
+				toggled_on += 1
+			else:
+				for mid in mi_ids:
+					var prev_cnt := _mi_visible_count[mid]
+					_mi_visible_count[mid] = prev_cnt - 1
+					if prev_cnt == 1:
+						var mi := _all_mis[mid]
+						if is_instance_valid(mi):
+							mi.visible = false
+				toggled_off += 1
+	return {"toggled_on": toggled_on, "toggled_off": toggled_off, "cells_visible": cells_visible}
+
+
+## Camera cell. For pinned-pose benches we use just the cell the camera
+## currently sits in (single PVS row). For player-controlled production we'd
+## OR neighbor cells too — see HIDE_DELAY_FRAMES for the alternative
+## artifact-prevention strategy (temporal hysteresis instead of spatial OR).
+func _camera_cell_neighborhood(cam_pos: Vector3) -> PackedInt32Array:
+	var out := PackedInt32Array()
+	var fx := (cam_pos.x - cell_origin_xz.x) / CELL_SIZE_M
+	var fz := (cam_pos.z - cell_origin_xz.y) / CELL_SIZE_M
+	var cx := clampi(int(floor(fx)), 0, cols - 1)
+	var cz := clampi(int(floor(fz)), 0, rows - 1)
+	out.append(cz * cols + cx)
+	return out
+
+
+func _build_pvs() -> void:
+	var t0 := Time.get_ticks_msec()
+	var n := cols * rows
+	var n_bits := n * n
+	_pvs_bits.resize((n_bits + 7) >> 3)
+	for i in _pvs_bits.size():
+		_pvs_bits[i] = 0
+	for ci in n:
+		var ci_center := _cell_geometric_center(ci)
+		_pvs_set(ci * n + ci)
+		for cj in range(ci + 1, n):
+			var cj_center := _cell_geometric_center(cj)
+			var blocked := _segment_blocked(ci, cj, ci_center, cj_center)
+			if not blocked:
+				_pvs_set(ci * n + cj)
+				_pvs_set(cj * n + ci)
+	_pvs_build_ms = Time.get_ticks_msec() - t0
+
+
+func _cell_geometric_center(cell_idx: int) -> Vector3:
+	if _cell_has_content[cell_idx] != 0:
+		var ab := _cell_aabb[cell_idx]
+		return ab.position + ab.size * 0.5
+	var cx := cell_idx % cols
+	var cz := cell_idx / cols
+	return Vector3(
+		cell_origin_xz.x + (cx + 0.5) * CELL_SIZE_M,
+		PVS_PLAYER_EYE_HEIGHT,
+		cell_origin_xz.y + (cz + 0.5) * CELL_SIZE_M
+	)
+
+
+func _segment_blocked(ci: int, cj: int, a: Vector3, b: Vector3) -> bool:
+	var ab_i := _cell_aabb[ci] if _cell_has_content[ci] != 0 else AABB(a, Vector3(0.1, 0.1, 0.1))
+	var ab_j := _cell_aabb[cj] if _cell_has_content[cj] != 0 else AABB(b, Vector3(0.1, 0.1, 0.1))
+	for blocker in _blockers:
+		if blocker.intersects(ab_i) or blocker.intersects(ab_j):
+			continue
+		if blocker.intersects_segment(a, b) != null:
+			return true
+	return false
+
+
+func _pvs_set(bit_idx: int) -> void:
+	_pvs_bits[bit_idx >> 3] |= 1 << (bit_idx & 7)
+
+
+func _pvs_get(bit_idx: int) -> bool:
+	return (_pvs_bits[bit_idx >> 3] & (1 << (bit_idx & 7))) != 0
+
+
+func _collect_blockers(node: Node) -> void:
+	if node is CollisionShape3D:
+		var cs := node as CollisionShape3D
+		var shape := cs.shape
+		if shape != null:
+			var local_aabb := AABB()
+			if shape is BoxShape3D:
+				var sz := (shape as BoxShape3D).size
+				local_aabb = AABB(-sz * 0.5, sz)
+			elif shape.has_method("get_debug_mesh"):
+				local_aabb = shape.get_debug_mesh().get_aabb()
+			if local_aabb.size != Vector3.ZERO:
+				var world_aabb := _transform_aabb(cs.global_transform, local_aabb)
+				if world_aabb.size.length() >= BLOCKER_MIN_DIAGONAL_M:
+					_blockers.append(world_aabb)
+	for child in node.get_children():
+		_collect_blockers(child)
+
+
+func _collect_mis(node: Node, out: Array[MeshInstance3D]) -> void:
+	if node is MeshInstance3D:
+		out.append(node)
+	for child in node.get_children():
+		_collect_mis(child, out)
+
+
+func _mi_skip_reason(mi: MeshInstance3D) -> String:
+	if mi.get_layer_mask() != 1:
+		return "hud"
+	var n: Node = mi
+	while n != null:
+		if n is DclAvatar:
+			return "avatar"
+		if n is AnimationPlayer or n is Skeleton3D:
+			return "animated"
+		if n.has_meta("dcl_has_tween"):
+			return "tween"
+		if n.has_meta("dcl_has_modifier"):
+			return "modifier"
+		n = n.get_parent()
+	return ""
+
+
+func _transform_aabb(t: Transform3D, aabb: AABB) -> AABB:
+	var corners := [
+		aabb.position,
+		aabb.position + Vector3(aabb.size.x, 0, 0),
+		aabb.position + Vector3(0, aabb.size.y, 0),
+		aabb.position + Vector3(0, 0, aabb.size.z),
+		aabb.position + Vector3(aabb.size.x, aabb.size.y, 0),
+		aabb.position + Vector3(aabb.size.x, 0, aabb.size.z),
+		aabb.position + Vector3(0, aabb.size.y, aabb.size.z),
+		aabb.position + aabb.size,
+	]
+	var first := t * (corners[0] as Vector3)
+	var out := AABB(first, Vector3.ZERO)
+	for i in range(1, 8):
+		out = out.expand(t * (corners[i] as Vector3))
+	return out
+
+
+func _aabb_in_frustum(aabb: AABB, planes: Array[Plane]) -> bool:
+	# Godot's `Camera3D.get_frustum()` returns planes oriented OUTWARD.
+	# n-vertex test: pick the corner farthest INSIDE; if even that vertex
+	# is outside the plane, the whole AABB is outside the frustum.
+	for plane in planes:
+		var nv := Vector3(
+			aabb.position.x + (0.0 if plane.normal.x > 0.0 else aabb.size.x),
+			aabb.position.y + (0.0 if plane.normal.y > 0.0 else aabb.size.y),
+			aabb.position.z + (0.0 if plane.normal.z > 0.0 else aabb.size.z)
+		)
+		if plane.distance_to(nv) > 0.0:
+			return false
+	return true
+
+
+func _stats_dict() -> Dictionary:
+	return {
+		"built": built,
+		"cols": cols,
+		"rows": rows,
+		"cells_total": cols * rows,
+		"cells_with_content": cells_with_content,
+		"total_mis": total_mis,
+		"multi_cell_mis": multi_cell_mis,
+		"skipped_avatar": skipped_avatar,
+		"skipped_hud": skipped_hud,
+		"skipped_out_of_grid": skipped_out_of_grid,
+		"skipped_animated": skipped_animated,
+		"skipped_tween": skipped_tween,
+		"skipped_modifier": skipped_modifier,
+		"blockers": _blockers.size(),
+		"pvs_build_ms": _pvs_build_ms,
+		"pvs_bytes": _pvs_bits.size(),
+		"cell_origin_x": cell_origin_xz.x,
+		"cell_origin_z": cell_origin_xz.y,
+	}

--- a/godot/src/tools/visibility_grid.gd.uid
+++ b/godot/src/tools/visibility_grid.gd.uid
@@ -1,0 +1,1 @@
+uid://cl1xrzm6ekxng

--- a/lib/src/godot_classes/dcl_cli.rs
+++ b/lib/src/godot_classes/dcl_cli.rs
@@ -107,6 +107,13 @@ pub struct DclCli {
     #[var(get)]
     pub avatar_impostor_benchmark: bool,
 
+    // Visibility-grid culling. Default ON; opt out with --no-visibility-grid
+    // or visibility-grid=false deeplink. Builds a cell grid of static meshes
+    // per scene-load and toggles their RenderingServer visibility via PVS
+    // bake + per-frame frustum/distance tests in Rust.
+    #[var]
+    pub visibility_grid_enabled: bool,
+
     // Arguments with values
     #[var(get)]
     pub asset_server_port: i32,
@@ -626,6 +633,7 @@ impl INode for DclCli {
             .and_then(|v| v.as_ref().map(|s| s.parse::<i32>().unwrap_or(-1)))
             .unwrap_or(-1);
         let avatar_impostor_benchmark = args_map.contains_key("--avatar-impostor-benchmark");
+        let visibility_grid_enabled = !args_map.contains_key("--no-visibility-grid");
 
         // Extract arguments with values
         let asset_server_port = args_map
@@ -741,6 +749,7 @@ impl INode for DclCli {
             low_spec_warning,
             fi_benchmark_size,
             avatar_impostor_benchmark,
+            visibility_grid_enabled,
             asset_server_port,
             realm,
             location,

--- a/lib/src/godot_classes/dcl_visibility_grid_rust.rs
+++ b/lib/src/godot_classes/dcl_visibility_grid_rust.rs
@@ -1,0 +1,305 @@
+use godot::classes::RenderingServer;
+use godot::prelude::*;
+
+/// Rust-side hot path for the cell-based visibility-grid PVS culling.
+///
+/// Build still happens in GDScript (`visibility_grid.gd::build_from_scene_tree`)
+/// where Godot's scene-tree introspection lives. After building, the GDScript
+/// side calls `set_grid_topology`, `set_cell_*`, `set_mi_*`, `set_pvs_bits`,
+/// then `mark_built()`. Per-frame, `update_visibility(cam_pos, frustum)` does
+/// the loop natively and flips Godot instance visibility via RenderingServer.
+///
+/// **Perf wins over the pure-GDScript implementation:**
+/// 1. Per-cell loop runs at native speed (avoids GDScript per-op overhead).
+/// 2. Visibility flips go through `RenderingServer::instance_set_visible(rid)`,
+///    which skips the scene-tree visibility propagation that `Node3D::visible = bool`
+///    triggers — important for MIs with children (collision shapes, shadow proxies).
+/// 3. Frustum plane test is inlined; no per-cell GDScript `Array[Plane]` walk.
+#[derive(GodotClass)]
+#[class(base=Node, init)]
+pub struct DclVisibilityGridRust {
+    base: Base<Node>,
+
+    built: bool,
+    cell_origin_x: f32,
+    cell_origin_z: f32,
+    cell_size: f32,
+    cols: i32,
+    rows: i32,
+    max_distance_m: f32,
+    min_size_distance_ratio: f32,
+    hide_delay_frames: i32,
+
+    cell_aabb_min: Vec<[f32; 3]>,
+    cell_aabb_size: Vec<[f32; 3]>,
+    cell_has_content: Vec<u8>,
+    cell_last_visible: Vec<u8>,
+    cell_hide_streak: Vec<i32>,
+    cell_mi_indices: Vec<Vec<i32>>,
+
+    mi_rids: Vec<Rid>,
+    mi_visible_count: Vec<i32>,
+
+    pvs_bits: Vec<u8>,
+
+    toggled_on_total: i64,
+    toggled_off_total: i64,
+}
+
+#[godot_api]
+impl DclVisibilityGridRust {
+    #[func]
+    fn set_grid_topology(
+        &mut self,
+        origin_x: f32,
+        origin_z: f32,
+        cell_size: f32,
+        cols: i32,
+        rows: i32,
+    ) {
+        self.cell_origin_x = origin_x;
+        self.cell_origin_z = origin_z;
+        self.cell_size = cell_size;
+        self.cols = cols;
+        self.rows = rows;
+        let n = (cols * rows) as usize;
+        self.cell_aabb_min = vec![[0.0; 3]; n];
+        self.cell_aabb_size = vec![[0.0; 3]; n];
+        self.cell_has_content = vec![0; n];
+        self.cell_last_visible = vec![1; n];
+        self.cell_hide_streak = vec![0; n];
+        self.cell_mi_indices = vec![Vec::new(); n];
+    }
+
+    #[func]
+    fn set_thresholds(
+        &mut self,
+        max_distance_m: f32,
+        min_size_distance_ratio: f32,
+        hide_delay_frames: i32,
+    ) {
+        self.max_distance_m = max_distance_m;
+        self.min_size_distance_ratio = min_size_distance_ratio;
+        self.hide_delay_frames = hide_delay_frames;
+    }
+
+    #[func]
+    fn set_cell_aabb(
+        &mut self,
+        cell_idx: i32,
+        pos: Vector3,
+        size: Vector3,
+        has_content: bool,
+    ) {
+        let i = cell_idx as usize;
+        if i >= self.cell_has_content.len() {
+            return;
+        }
+        self.cell_aabb_min[i] = [pos.x, pos.y, pos.z];
+        self.cell_aabb_size[i] = [size.x, size.y, size.z];
+        self.cell_has_content[i] = if has_content { 1 } else { 0 };
+    }
+
+    #[func]
+    fn set_cell_mi_indices(&mut self, cell_idx: i32, indices: PackedInt32Array) {
+        let i = cell_idx as usize;
+        if i >= self.cell_mi_indices.len() {
+            return;
+        }
+        self.cell_mi_indices[i] = indices.to_vec();
+    }
+
+    /// Register a MeshInstance3D RID with its initial visible-cell count.
+    /// `rid` must be the result of `MeshInstance3D::get_instance()` on the GDScript side.
+    #[func]
+    fn add_mi(&mut self, rid: Rid, initial_visible_count: i32) {
+        self.mi_rids.push(rid);
+        self.mi_visible_count.push(initial_visible_count);
+    }
+
+    #[func]
+    fn set_pvs_bits(&mut self, bits: PackedByteArray) {
+        self.pvs_bits = bits.to_vec();
+    }
+
+    #[func]
+    fn mark_built(&mut self) {
+        self.built = true;
+    }
+
+    /// Per-frame entry. `cam_pos` is the camera world position; `frustum_planes`
+    /// is `Camera3D::get_frustum()` (6 planes oriented OUTWARD).
+    /// Returns `{toggled_on, toggled_off, cells_visible}`.
+    #[func]
+    fn update_visibility(
+        &mut self,
+        cam_pos: Vector3,
+        frustum_planes: Array<Plane>,
+    ) -> Dictionary {
+        let mut out = Dictionary::new();
+        out.set("toggled_on", 0);
+        out.set("toggled_off", 0);
+        out.set("cells_visible", 0);
+
+        if !self.built {
+            return out;
+        }
+
+        let n = (self.cols * self.rows) as usize;
+        if n == 0 {
+            return out;
+        }
+
+        // Snapshot frustum planes into a fixed-size array for tight inner loop.
+        // n-vertex AABB-vs-plane test below requires only the plane normal+d.
+        let mut planes: [(f32, f32, f32, f32); 8] = [(0.0, 0.0, 0.0, 0.0); 8];
+        let mut plane_count = 0usize;
+        for p in frustum_planes.iter_shared() {
+            if plane_count >= planes.len() {
+                break;
+            }
+            planes[plane_count] = (p.normal.x, p.normal.y, p.normal.z, p.d);
+            plane_count += 1;
+        }
+
+        let cam_cx = (((cam_pos.x - self.cell_origin_x) / self.cell_size).floor() as i32)
+            .clamp(0, self.cols - 1);
+        let cam_cz = (((cam_pos.z - self.cell_origin_z) / self.cell_size).floor() as i32)
+            .clamp(0, self.rows - 1);
+        let cam_cell = (cam_cz * self.cols + cam_cx) as usize;
+
+        let max_dist_sq = self.max_distance_m * self.max_distance_m;
+        let size_ratio_sq = self.min_size_distance_ratio * self.min_size_distance_ratio;
+
+        let mut toggled_on = 0i32;
+        let mut toggled_off = 0i32;
+        let mut cells_visible = 0i32;
+
+        for idx in 0..n {
+            if self.cell_has_content[idx] == 0 {
+                continue;
+            }
+            let amin = self.cell_aabb_min[idx];
+            let asz = self.cell_aabb_size[idx];
+            let cx = amin[0] + asz[0] * 0.5;
+            let cz = amin[2] + asz[2] * 0.5;
+            let dx = cx - cam_pos.x;
+            let dz = cz - cam_pos.z;
+            let dist_sq = dx * dx + dz * dz;
+            let mut visible = dist_sq <= max_dist_sq;
+            if visible && dist_sq > 4.0 {
+                let diag_sq = asz[0] * asz[0] + asz[2] * asz[2];
+                if diag_sq < dist_sq * size_ratio_sq {
+                    visible = false;
+                }
+            }
+            if visible {
+                visible = aabb_in_frustum(amin, asz, &planes[..plane_count]);
+            }
+            if visible {
+                let bit_idx = cam_cell * n + idx;
+                let byte = bit_idx >> 3;
+                let bit = bit_idx & 7;
+                if byte >= self.pvs_bits.len() || (self.pvs_bits[byte] & (1 << bit)) == 0 {
+                    visible = false;
+                }
+            }
+            if visible {
+                cells_visible += 1;
+            }
+
+            let prev = self.cell_last_visible[idx] != 0;
+            if visible {
+                self.cell_hide_streak[idx] = 0;
+            } else {
+                self.cell_hide_streak[idx] += 1;
+                if prev && self.cell_hide_streak[idx] < self.hide_delay_frames {
+                    continue;
+                }
+            }
+            if visible == prev {
+                continue;
+            }
+            self.cell_last_visible[idx] = if visible { 1 } else { 0 };
+            if visible {
+                toggled_on += 1;
+            } else {
+                toggled_off += 1;
+            }
+            self.flip_cell_visibility(idx, visible);
+        }
+
+        self.toggled_on_total += toggled_on as i64;
+        self.toggled_off_total += toggled_off as i64;
+        out.set("toggled_on", toggled_on);
+        out.set("toggled_off", toggled_off);
+        out.set("cells_visible", cells_visible);
+        out
+    }
+
+    fn flip_cell_visibility(&mut self, cell_idx: usize, visible: bool) {
+        // Multi-cell-aware: bump per-MI count; only call RenderingServer when
+        // the count crosses 0 (last cell turned off / first cell turned on).
+        let mi_ids = self.cell_mi_indices[cell_idx].clone();
+        let mut rs = RenderingServer::singleton();
+        if visible {
+            for &mid in mi_ids.iter() {
+                let mid_u = mid as usize;
+                if mid_u >= self.mi_visible_count.len() {
+                    continue;
+                }
+                let prev_cnt = self.mi_visible_count[mid_u];
+                self.mi_visible_count[mid_u] = prev_cnt + 1;
+                if prev_cnt == 0 {
+                    rs.instance_set_visible(self.mi_rids[mid_u], true);
+                }
+            }
+        } else {
+            for &mid in mi_ids.iter() {
+                let mid_u = mid as usize;
+                if mid_u >= self.mi_visible_count.len() {
+                    continue;
+                }
+                let prev_cnt = self.mi_visible_count[mid_u];
+                self.mi_visible_count[mid_u] = prev_cnt - 1;
+                if prev_cnt == 1 {
+                    rs.instance_set_visible(self.mi_rids[mid_u], false);
+                }
+            }
+        }
+    }
+
+    #[func]
+    fn get_runtime_stats(&self) -> Dictionary {
+        let mut d = Dictionary::new();
+        d.set("toggled_on_total", self.toggled_on_total);
+        d.set("toggled_off_total", self.toggled_off_total);
+        d.set("total_mis", self.mi_rids.len() as i64);
+        d.set("cols", self.cols);
+        d.set("rows", self.rows);
+        d.set("built", self.built);
+        d
+    }
+}
+
+#[inline]
+fn aabb_in_frustum(
+    amin: [f32; 3],
+    asz: [f32; 3],
+    planes: &[(f32, f32, f32, f32)],
+) -> bool {
+    // n-vertex AABB test: pick the corner FARTHEST INSIDE the plane (the one
+    // whose components align with the OPPOSITE of the plane normal). If even
+    // that vertex is outside, the AABB is outside the frustum. Godot's
+    // `Camera3D.get_frustum()` returns OUTWARD-facing planes — `distance_to`
+    // > 0 means outside.
+    for &(nx, ny, nz, d) in planes {
+        let vx = amin[0] + if nx > 0.0 { 0.0 } else { asz[0] };
+        let vy = amin[1] + if ny > 0.0 { 0.0 } else { asz[1] };
+        let vz = amin[2] + if nz > 0.0 { 0.0 } else { asz[2] };
+        if nx * vx + ny * vy + nz * vz - d > 0.0 {
+            return false;
+        }
+    }
+    true
+}

--- a/lib/src/godot_classes/mod.rs
+++ b/lib/src/godot_classes/mod.rs
@@ -39,6 +39,7 @@ pub mod dcl_ui_text;
 pub mod dcl_urls;
 pub mod dcl_video_player;
 pub mod dcl_virtual_camera;
+pub mod dcl_visibility_grid_rust;
 pub mod floating_islands;
 pub mod font;
 pub mod portables;


### PR DESCRIPTION
## What

Adds a cell-based PVS visibility culler (`DclVisibilityGrid` GDScript + `DclVisibilityGridRust` for the per-frame hot path):

1. **Build** (one-time, post scene load, GDScript): walk the scene tree, bucket every static `MeshInstance3D` into a uniform 16×16m grid by its world AABB, collect `CollisionShape3D` AABBs as blockers (>8m diagonal), bake an O(n²) PVS bitmap by raycasting cell-pair midpoints against blockers.

2. **Per-frame** (Rust): for each cell, distance test → screen-space size threshold → frustum AABB test → PVS bit lookup against the camera cell. If a cell flips visible/hidden, bump per-MI ref-counts; on 0↔1 crossings call `RenderingServer.instance_set_visible(rid, bool)` directly (bypasses `mi.visible = bool`'s scene-tree cascade).

Temporal hysteresis (60-frame hide-streak) prevents popping when the camera moves across cell boundaries.

ENABLED BY DEFAULT (opt out with deeplink `visibility-grid=false`).

## Why

DCL scenes are open-world and have no built-in occlusion structure (no BSP, no portals). Godot's frustum culling handles "behind the camera" but does nothing about "behind that big building". On Genesis Plaza, ~30-40% of rendered geometry per frame is occluded by larger buildings but Godot rasterizes it anyway. The PVS bitmap captures cell-to-cell visibility through blockers so the renderer never sees the occluded MIs.

The per-frame work runs in Rust to avoid the ~5-7ms/frame GDScript overhead that an earlier prototype incurred — same culling decisions, native dispatch, native bit ops, native RenderingServer calls.

## Bench (A54 HIGH, GP preview, warm cache)

| metric | baseline | after | Δ |
|---|---:|---:|---:|
| fps.mean | 7.14 | **10.99** | **+54.0%** |
| render_gpu_ms.mean | 95.33 | 56.99 | **−40.2%** |
| render_cpu_ms.mean | 7.35 | 3.95 | **−46.2%** |
| frame_time_process_ms | 169.27 | 101.75 | −39.9% |
| primitives | 2,610,926 | 1,602,132 | −38.6% |
| video_mem_mb | 778.67 | 884.91 | +13.6% |
| load_seconds | 26.28 | 37.99 | +44.5% |

Largest individual fps win of the perf series. The +12s load_seconds and +14% VRAM are the cost of the runtime PVS bake + the per-MI ref tables.

### Visual diff

| baseline | this PR |
|---|---|
| ![baseline](https://raw.githubusercontent.com/decentraland/godot-explorer/bench-screenshots/baseline-high.png) | ![after](https://raw.githubusercontent.com/decentraland/godot-explorer/bench-screenshots/vgrid-rust.png) |

## Follow-ups: move work offline into an asset-preprocessor

The +12s build cost is the main remaining wart. Good candidates to move OFFLINE:

1. **PVS bake** — `_build_pvs` (~400ms GDScript) is 100% deterministic given (cell layout, blockers). Per static GLTF, precompute its CollisionShape3D AABBs into a sidecar `.vgrid-blockers.bin`. Runtime loads sidecars, transforms local→world via GLTF instance transform, skips the slow recursive walk + segment-vs-blocker O(n²) raycasts.

2. **Per-GLTF MI AABBs** — Each MeshInstance3D's LOCAL AABB is static. Precompute the list per GLTF into the sidecar; runtime bucketing becomes: apply GLTF transform once, do AABB-vs-cell-grid math.

3. **Cell layout snapping to parcel grid** — DCL parcels are 16×16m, free at preprocessor time.

What CAN'T move offline:
- World-space transforms (DCL scenes compose dynamically per CRDT).
- Final per-MI RID assignment.
- Per-frame visibility loop itself.

Estimated combined effect: runtime build drops from ~2.2s to ~200ms.