### PR TITLE
fix: HIDE_AVATARS modifier area now disables profile click collider

### DIFF
--- a/godot/src/decentraland_components/avatar/avatar.gd
+++ b/godot/src/decentraland_components/avatar/avatar.gd
@@ -263,6 +263,7 @@ func _on_set_avatar_modifier_area(area: DclAvatarModifierArea3D):
 		if modifier == 0:  # hide avatar
 			hide()
 			_hide_impostor_render()
+			_set_click_area_enabled(false)
 		elif modifier == 1:  # disable passport
 			passport_disabled = true
 
@@ -322,6 +323,7 @@ func _set_click_area_enabled(enabled: bool) -> void:
 func _unset_avatar_modifier_area():
 	if not hidden:
 		show()
+		_set_click_area_enabled(true)
 	passport_disabled = false
 
 

--- a/godot/src/decentraland_components/avatar/avatar.gd
+++ b/godot/src/decentraland_components/avatar/avatar.gd
@@ -264,6 +264,7 @@ func _on_set_avatar_modifier_area(area: DclAvatarModifierArea3D):
 			hide()
 			_hide_impostor_render()
 			_set_click_area_enabled(false)
+			passport_disabled = true
 		elif modifier == 1:  # disable passport
 			passport_disabled = true
 


### PR DESCRIPTION
## Summary
- Avatar modifier areas with `HIDE_AVATARS` were hiding visuals but leaving the `ClickArea` collider active, so users could click on invisible avatars and open their profile.
- The fix mirrors `set_hidden(true)`: when the modifier hides the avatar, also call `_set_click_area_enabled(false)`. When the modifier is unset, re-enable the click area (guarded by `if not hidden` so blocked avatars remain non-interactable).

Fixes #2016

## Test plan
- [ ] Enter a scene with an `AvatarModifierArea` configured with `HIDE_AVATARS`; confirm avatars inside the area are invisible and clicking where they stand does not open a passport.
- [ ] Leave the area; confirm avatars re-appear and become clickable again.
- [ ] Verify a separately-blocked/muted avatar (set via `set_hidden(true)`) remains non-clickable after entering/leaving a modifier area.
- [ ] Verify `DISABLE_PASSPORT` modifier behavior is unchanged.