### PR TITLE
fix: account deletion popup stays in landscape from side panel

### DIFF
--- a/godot/src/ui/components/menu/account_deletion_popup.gd
+++ b/godot/src/ui/components/menu/account_deletion_popup.gd
@@ -15,16 +15,18 @@ func _ready() -> void:
 
 
 func _on_button_cancel_delete_account_pressed() -> void:
-	hide()
-	# If the flow was opened from the explorer's landscape side panel, the menu
-	# was force-opened in portrait. Close it so the explorer flips back to
-	# landscape via _on_menu_close instead of stranding the user in portrait.
-	if Global.get_explorer():
-		Global.close_menu.emit()
+	_close_flow()
 
 
 func _on_button_ok_pressed() -> void:
+	_close_flow()
+
+
+func _close_flow() -> void:
 	hide()
+	if Global.get_explorer():
+		Global.close_navbar.emit()
+		Global.close_menu.emit()
 
 
 func _hide_all() -> void:

--- a/godot/src/ui/components/menu/menu.gd
+++ b/godot/src/ui/components/menu/menu.gd
@@ -359,5 +359,15 @@ func _async_on_deep_link_open_place(place_id: String) -> void:
 
 
 func _on_account_delete() -> void:
-	if account_deletion_pop_up:
-		account_deletion_pop_up.async_start_flow()
+	if not account_deletion_pop_up:
+		return
+	if not is_open:
+		# Kill pending close tweens from a previous close
+		if is_instance_valid(_close_modulate_tween) and _close_modulate_tween.is_running():
+			_close_modulate_tween.kill()
+		if is_instance_valid(_close_hide_tween) and _close_hide_tween.is_running():
+			_close_hide_tween.kill()
+		modulate = Color(1, 1, 1, 1)
+		show()
+		is_open = true
+	account_deletion_pop_up.async_start_flow()

--- a/godot/src/ui/components/settings/settings.gd
+++ b/godot/src/ui/components/settings/settings.gd
@@ -499,11 +499,6 @@ func _on_button_account_pressed() -> void:
 
 
 func _on_button_delete_account_pressed() -> void:
-	# The deletion popup lives inside the fullscreen menu, which is hidden while
-	# the side panel is up. Promote to the menu first so it renders in portrait;
-	# closing the right panel + orientation flip happen via the menu's own hooks.
-	if panel_mode:
-		Global.open_settings.emit()
 	Global.delete_account.emit()
 
 


### PR DESCRIPTION
## Summary
Fixes #1918

When triggering account deletion from the in-game landscape settings (side panel), the flow incorrectly switched to portrait mode and left the user stranded in portrait after completion.

## Root cause
`settings.gd` emitted `Global.open_settings` before `Global.delete_account` when in `panel_mode`, which opened the fullscreen menu and triggered `discover`'s `_on_visibility_changed` → `set_orientation_portrait()`. After the deletion flow completed, the orientation was never restored.

## Changes
- **`settings.gd`**: Removed the `open_settings` emit before `delete_account` — the deletion popup no longer forces a switch to fullscreen menu
- **`menu.gd`**: `_on_account_delete` now opens the menu directly with `show()` + `is_open = true` (without triggering discover or any orientation change). Kills pending close tweens to handle rapid re-opening
- **`account_deletion_popup.gd`**: Unified cancel and OK exit paths into `_close_flow()` which emits both `close_navbar` and `close_menu` to properly restore the game view

## Test plan
- [ ] Open settings from landscape side panel → Delete Account → popup stays in landscape
- [ ] Complete the deletion flow (OK) → returns to game in landscape, navbar collapsed
- [ ] Cancel the deletion flow → returns to game in landscape, navbar collapsed
- [ ] Re-open Delete Account immediately after closing → popup appears correctly
- [ ] Open Delete Account from portrait fullscreen settings → flow works as before