### PR TITLE
fix: clamp inner rect size to avoid negative Rect2 in avatar-preview

### DIFF
--- a/godot/src/ui/components/backpack/avatar_preview.gd
+++ b/godot/src/ui/components/backpack/avatar_preview.gd
@@ -583,10 +583,12 @@ func _inner_rect() -> Rect2:
 	var r: Rect2 = get_global_rect()
 	var mt: float = _effective_margin_top()
 	var mb: float = _effective_margin_bottom()
-	return Rect2(
-		r.position + Vector2(float(preview_margin_left), mt),
+	var size: Vector2 = (
 		r.size - Vector2(float(preview_margin_left + preview_margin_right), mt + mb)
 	)
+	size.x = maxf(size.x, 0.0)
+	size.y = maxf(size.y, 0.0)
+	return Rect2(r.position + Vector2(float(preview_margin_left), mt), size)
 
 
 func _effective_margin_top() -> float:

--- a/godot/src/ui/components/backpack/avatar_preview.gd
+++ b/godot/src/ui/components/backpack/avatar_preview.gd
@@ -583,9 +583,7 @@ func _inner_rect() -> Rect2:
 	var r: Rect2 = get_global_rect()
 	var mt: float = _effective_margin_top()
 	var mb: float = _effective_margin_bottom()
-	var size: Vector2 = (
-		r.size - Vector2(float(preview_margin_left + preview_margin_right), mt + mb)
-	)
+	var size: Vector2 = r.size - Vector2(float(preview_margin_left + preview_margin_right), mt + mb)
 	size.x = maxf(size.x, 0.0)
 	size.y = maxf(size.y, 0.0)
 	return Rect2(r.position + Vector2(float(preview_margin_left), mt), size)


### PR DESCRIPTION
## Summary
  - Clamp the size returned by `_inner_rect()` in `avatar_preview.gd` to non-negative values so `has_point()` no longer errors when configured margins exceed the control's current global rect.

  ## Test plan
  - [ ] Open the backpack / avatar preview and interact with it (click, drag, scroll) without seeing `Rect2 size is negative` errors in the output.
  - [ ] Verify input outside the inner rect is still ignored when margins are valid.