### PR TITLE
feat: add border properties for Scene UI

### DIFF
--- a/lib/src/godot_classes/dcl_ui_background.rs
+++ b/lib/src/godot_classes/dcl_ui_background.rs
@@ -1,3 +1,5 @@
+use std::cell::RefCell;
+
 use godot::{
     classes::{
         Control, INinePatchRect, Material, NinePatchRect, Node, ResourceLoader, Shader,
@@ -16,6 +18,62 @@ use crate::{
 
 use super::dcl_global::DclGlobal;
 
+// SDF-based rounded rectangle mask. `VERTEX` in canvas-item shaders is the
+// local position in pixels, so we use it to evaluate a rounded-rect SDF and
+// modulate alpha. Active only when any corner_radii > 0 (a uniform-encoded
+// flag — when all zero, the material is detached entirely from the host).
+const ROUNDED_CLIP_SHADER_CODE: &str = r#"shader_type canvas_item;
+
+uniform vec4 corner_radii = vec4(0.0);
+uniform vec2 control_size = vec2(1.0, 1.0);
+
+varying vec2 v_local_pos;
+
+void vertex() {
+    v_local_pos = VERTEX;
+}
+
+float rounded_rect_sdf(vec2 p, vec2 b, vec4 r) {
+    float radius;
+    if (p.y < 0.0) {
+        radius = (p.x < 0.0) ? r.x : r.y; // top-left / top-right
+    } else {
+        radius = (p.x < 0.0) ? r.w : r.z; // bottom-left / bottom-right
+    }
+    vec2 q = abs(p) - b + vec2(radius);
+    return min(max(q.x, q.y), 0.0) + length(max(q, vec2(0.0))) - radius;
+}
+
+void fragment() {
+    vec2 half_size = control_size * 0.5;
+    vec2 p = v_local_pos - half_size;
+    float d = rounded_rect_sdf(p, half_size, corner_radii);
+    float alpha = clamp(0.5 - d, 0.0, 1.0);
+    COLOR.a *= alpha;
+}
+"#;
+
+thread_local! {
+    // One compiled Shader resource shared by every DclUiBackground in this thread.
+    // godot-rust Gd<T> is not Send/Sync, so std::sync::OnceLock can't be used —
+    // thread_local is the right primitive for "main-thread-only singleton".
+    static SHARED_ROUNDED_CLIP_SHADER: RefCell<Option<Gd<Shader>>> = const { RefCell::new(None) };
+}
+
+fn shared_rounded_clip_shader() -> Gd<Shader> {
+    SHARED_ROUNDED_CLIP_SHADER.with(|cell| {
+        let mut slot = cell.borrow_mut();
+        if let Some(existing) = slot.as_ref() {
+            existing.clone()
+        } else {
+            let mut shader = Shader::new_gd();
+            shader.set_code(ROUNDED_CLIP_SHADER_CODE);
+            *slot = Some(shader.clone());
+            shader
+        }
+    })
+}
+
 #[derive(GodotClass)]
 #[class(base=NinePatchRect)]
 pub struct DclUiBackground {
@@ -30,6 +88,10 @@ pub struct DclUiBackground {
     // Child TextureRect with custom shader for proper UV interpolation
     uv_child: Option<Gd<TextureRect>>,
     uv_shader_material: Option<Gd<ShaderMaterial>>,
+
+    // SDF rounded-rect clip applied only when any corner radius > 0.
+    rounded_clip_material: Option<Gd<ShaderMaterial>>,
+    current_radii: [f32; 4],
 }
 
 #[godot_api]
@@ -43,6 +105,8 @@ impl INinePatchRect for DclUiBackground {
             first_texture_load_shot: false,
             uv_child: None,
             uv_shader_material: None,
+            rounded_clip_material: None,
+            current_radii: [0.0; 4],
         }
     }
 
@@ -111,6 +175,12 @@ impl DclUiBackground {
             my_pos
         );
 
+        // Keep the rounded-clip shader's size uniform in sync.
+        if let Some(mat) = self.rounded_clip_material.clone() {
+            let mut mat = mat;
+            mat.set_shader_parameter("control_size", &my_size.to_variant());
+        }
+
         if !self.texture_loaded {
             tracing::debug!("[UI_BKG] _on_parent_size: texture_loaded=false, skipping");
             return;
@@ -127,6 +197,37 @@ impl DclUiBackground {
                 self.current_value.texture_mode()
             );
         }
+    }
+
+    pub fn set_corner_radii(&mut self, radii: [f32; 4]) {
+        if self.current_radii == radii {
+            return;
+        }
+        self.current_radii = radii;
+        let any = radii.iter().any(|&r| r > 0.0);
+
+        if !any {
+            if self.rounded_clip_material.is_some() {
+                self.base_mut().set_material(Gd::null_arg());
+                self.rounded_clip_material = None;
+            }
+            return;
+        }
+
+        let mut mat = if let Some(existing) = self.rounded_clip_material.clone() {
+            existing
+        } else {
+            let mut new_mat = ShaderMaterial::new_gd();
+            new_mat.set_shader(&shared_rounded_clip_shader());
+            self.rounded_clip_material = Some(new_mat.clone());
+            new_mat
+        };
+
+        let radii_v4 = Vector4::new(radii[0], radii[1], radii[2], radii[3]);
+        let size = self.base().get_size();
+        mat.set_shader_parameter("corner_radii", &radii_v4.to_variant());
+        mat.set_shader_parameter("control_size", &size.to_variant());
+        self.base_mut().set_material(&mat);
     }
 
     /// Check if UVs are non-trivial (rotated, skewed, or non-rectangular)

--- a/lib/src/godot_classes/dcl_ui_border.rs
+++ b/lib/src/godot_classes/dcl_ui_border.rs
@@ -1,0 +1,304 @@
+use godot::{
+    builtin::Corner,
+    classes::{
+        control::{LayoutPreset, MouseFilter},
+        Control, IControl, StyleBoxFlat,
+    },
+    prelude::*,
+};
+
+#[derive(GodotClass)]
+#[class(base=Control)]
+pub struct DclUiBorder {
+    base: Base<Control>,
+    // [left, right, top, bottom]
+    widths: [f32; 4],
+    // [top_left, top_right, bottom_right, bottom_left]
+    radii: [f32; 4],
+    // [top, right, bottom, left]
+    colors: [Color; 4],
+    // Built lazily in set_border when all four colors match. When present, the
+    // draw path is a single FFI call (draw_style_box) instead of rebuilding the
+    // StyleBoxFlat on every redraw. None ⇒ slow path (per-side colors differ).
+    cached_stylebox: Option<Gd<StyleBoxFlat>>,
+}
+
+#[godot_api]
+impl IControl for DclUiBorder {
+    fn init(base: Base<Control>) -> Self {
+        let transparent = Color::from_rgba(0.0, 0.0, 0.0, 0.0);
+        Self {
+            base,
+            widths: [0.0; 4],
+            radii: [0.0; 4],
+            colors: [transparent; 4],
+            cached_stylebox: None,
+        }
+    }
+
+    fn ready(&mut self) {
+        self.base_mut().set_mouse_filter(MouseFilter::IGNORE);
+        self.base_mut().set_anchors_preset(LayoutPreset::FULL_RECT);
+
+        let mut parent = self
+            .base()
+            .get_parent()
+            .expect("ui_border must have a parent");
+        parent.connect("resized", &self.base().callable("_on_parent_size"));
+    }
+
+    fn draw(&mut self) {
+        let size = self.base().get_size();
+        if size.x <= 0.0 || size.y <= 0.0 {
+            return;
+        }
+
+        // Fast path: stylebox was prebuilt in set_border. One FFI call, no rebuild.
+        if let Some(sb) = self.cached_stylebox.clone() {
+            let rect = Rect2::new(Vector2::ZERO, size);
+            self.base_mut().draw_style_box(&sb, rect);
+            return;
+        }
+
+        let [bw_l, bw_r, bw_t, bw_b] = self.widths;
+        let [c_t, c_r, c_b, c_l] = self.colors;
+
+        // Slow path: per-side colors differ.
+        // For each corner: if it has a radius, two annular sectors split at the bisector
+        // fill it; the adjacent side's inner endpoint is aligned to the arc's inner endpoint
+        // (br_*, side_thickness). If it has no radius, the side trapezoid covers the corner
+        // with a CSS miter — inner endpoint at the adjacent border-width (bw_*, side_thickness).
+        let w = size.x;
+        let h = size.y;
+        let [br_tl, br_tr, br_br, br_bl] = self.radii;
+
+        // Inner-endpoint coordinates per side, chosen to match the arc when present.
+        let top_in_l_x = if br_tl > 0.0 { br_tl } else { bw_l };
+        let top_in_r_x = if br_tr > 0.0 { w - br_tr } else { w - bw_r };
+        let right_in_t_y = if br_tr > 0.0 { br_tr } else { bw_t };
+        let right_in_b_y = if br_br > 0.0 { h - br_br } else { h - bw_b };
+        let bottom_in_r_x = if br_br > 0.0 { w - br_br } else { w - bw_r };
+        let bottom_in_l_x = if br_bl > 0.0 { br_bl } else { bw_l };
+        let left_in_b_y = if br_bl > 0.0 { h - br_bl } else { h - bw_b };
+        let left_in_t_y = if br_tl > 0.0 { br_tl } else { bw_t };
+
+        // Top
+        if bw_t > 0.0 && c_t.a > 0.0 {
+            let pts = packed_v2(&[
+                Vector2::new(br_tl, 0.0),
+                Vector2::new(w - br_tr, 0.0),
+                Vector2::new(top_in_r_x, bw_t),
+                Vector2::new(top_in_l_x, bw_t),
+            ]);
+            self.base_mut().draw_colored_polygon(&pts, c_t);
+        }
+        // Right
+        if bw_r > 0.0 && c_r.a > 0.0 {
+            let pts = packed_v2(&[
+                Vector2::new(w, br_tr),
+                Vector2::new(w, h - br_br),
+                Vector2::new(w - bw_r, right_in_b_y),
+                Vector2::new(w - bw_r, right_in_t_y),
+            ]);
+            self.base_mut().draw_colored_polygon(&pts, c_r);
+        }
+        // Bottom
+        if bw_b > 0.0 && c_b.a > 0.0 {
+            let pts = packed_v2(&[
+                Vector2::new(w - br_br, h),
+                Vector2::new(br_bl, h),
+                Vector2::new(bottom_in_l_x, h - bw_b),
+                Vector2::new(bottom_in_r_x, h - bw_b),
+            ]);
+            self.base_mut().draw_colored_polygon(&pts, c_b);
+        }
+        // Left
+        if bw_l > 0.0 && c_l.a > 0.0 {
+            let pts = packed_v2(&[
+                Vector2::new(0.0, h - br_bl),
+                Vector2::new(0.0, br_tl),
+                Vector2::new(bw_l, left_in_t_y),
+                Vector2::new(bw_l, left_in_b_y),
+            ]);
+            self.base_mut().draw_colored_polygon(&pts, c_l);
+        }
+
+        // Corner arcs (annular sectors). Each half draws over the gap left by the
+        // trapezoid outer-corner cut, in its adjacent side's color.
+        const SEGMENTS: u32 = 12;
+        // Top-left: arc angle PI .. 3*PI/2 (left .. up). Bisector at 5*PI/4.
+        if br_tl > 0.0 {
+            let center = Vector2::new(br_tl, br_tl);
+            if bw_l > 0.0 && c_l.a > 0.0 {
+                let pts = annular_sector(
+                    center,
+                    br_tl,
+                    (br_tl - bw_l).max(0.0),
+                    std::f32::consts::PI,
+                    1.25 * std::f32::consts::PI,
+                    SEGMENTS,
+                );
+                self.base_mut().draw_colored_polygon(&pts, c_l);
+            }
+            if bw_t > 0.0 && c_t.a > 0.0 {
+                let pts = annular_sector(
+                    center,
+                    br_tl,
+                    (br_tl - bw_t).max(0.0),
+                    1.25 * std::f32::consts::PI,
+                    1.5 * std::f32::consts::PI,
+                    SEGMENTS,
+                );
+                self.base_mut().draw_colored_polygon(&pts, c_t);
+            }
+        }
+        // Top-right: arc angle 3*PI/2 .. 2*PI (up .. right). Bisector at 7*PI/4.
+        if br_tr > 0.0 {
+            let center = Vector2::new(w - br_tr, br_tr);
+            if bw_t > 0.0 && c_t.a > 0.0 {
+                let pts = annular_sector(
+                    center,
+                    br_tr,
+                    (br_tr - bw_t).max(0.0),
+                    1.5 * std::f32::consts::PI,
+                    1.75 * std::f32::consts::PI,
+                    SEGMENTS,
+                );
+                self.base_mut().draw_colored_polygon(&pts, c_t);
+            }
+            if bw_r > 0.0 && c_r.a > 0.0 {
+                let pts = annular_sector(
+                    center,
+                    br_tr,
+                    (br_tr - bw_r).max(0.0),
+                    1.75 * std::f32::consts::PI,
+                    2.0 * std::f32::consts::PI,
+                    SEGMENTS,
+                );
+                self.base_mut().draw_colored_polygon(&pts, c_r);
+            }
+        }
+        // Bottom-right: arc angle 0 .. PI/2 (right .. down). Bisector at PI/4.
+        if br_br > 0.0 {
+            let center = Vector2::new(w - br_br, h - br_br);
+            if bw_r > 0.0 && c_r.a > 0.0 {
+                let pts = annular_sector(
+                    center,
+                    br_br,
+                    (br_br - bw_r).max(0.0),
+                    0.0,
+                    0.25 * std::f32::consts::PI,
+                    SEGMENTS,
+                );
+                self.base_mut().draw_colored_polygon(&pts, c_r);
+            }
+            if bw_b > 0.0 && c_b.a > 0.0 {
+                let pts = annular_sector(
+                    center,
+                    br_br,
+                    (br_br - bw_b).max(0.0),
+                    0.25 * std::f32::consts::PI,
+                    0.5 * std::f32::consts::PI,
+                    SEGMENTS,
+                );
+                self.base_mut().draw_colored_polygon(&pts, c_b);
+            }
+        }
+        // Bottom-left: arc angle PI/2 .. PI (down .. left). Bisector at 3*PI/4.
+        if br_bl > 0.0 {
+            let center = Vector2::new(br_bl, h - br_bl);
+            if bw_b > 0.0 && c_b.a > 0.0 {
+                let pts = annular_sector(
+                    center,
+                    br_bl,
+                    (br_bl - bw_b).max(0.0),
+                    0.5 * std::f32::consts::PI,
+                    0.75 * std::f32::consts::PI,
+                    SEGMENTS,
+                );
+                self.base_mut().draw_colored_polygon(&pts, c_b);
+            }
+            if bw_l > 0.0 && c_l.a > 0.0 {
+                let pts = annular_sector(
+                    center,
+                    br_bl,
+                    (br_bl - bw_l).max(0.0),
+                    0.75 * std::f32::consts::PI,
+                    std::f32::consts::PI,
+                    SEGMENTS,
+                );
+                self.base_mut().draw_colored_polygon(&pts, c_l);
+            }
+        }
+    }
+}
+
+fn packed_v2(points: &[Vector2]) -> PackedVector2Array {
+    PackedVector2Array::from(points)
+}
+
+fn annular_sector(
+    center: Vector2,
+    radius_outer: f32,
+    radius_inner: f32,
+    start_angle: f32,
+    end_angle: f32,
+    segments: u32,
+) -> PackedVector2Array {
+    let mut pts = PackedVector2Array::new();
+    let step = (end_angle - start_angle) / segments as f32;
+    for i in 0..=segments {
+        let a = start_angle + i as f32 * step;
+        pts.push(center + Vector2::new(a.cos(), a.sin()) * radius_outer);
+    }
+    if radius_inner > 0.0 {
+        for i in (0..=segments).rev() {
+            let a = start_angle + i as f32 * step;
+            pts.push(center + Vector2::new(a.cos(), a.sin()) * radius_inner);
+        }
+    } else {
+        pts.push(center);
+    }
+    pts
+}
+
+#[godot_api]
+impl DclUiBorder {
+    #[func]
+    fn _on_parent_size(&mut self) {
+        self.base_mut().queue_redraw();
+    }
+
+    pub fn set_border(&mut self, widths: [f32; 4], radii: [f32; 4], colors: [Color; 4]) {
+        self.widths = widths;
+        self.radii = radii;
+        self.colors = colors;
+
+        let [c_t, c_r, c_b, c_l] = colors;
+        let all_colors_equal = c_t == c_r && c_r == c_b && c_b == c_l;
+
+        if all_colors_equal && c_t.a > 0.0 {
+            // Build the fast-path StyleBoxFlat once here. Reuse it on every draw.
+            let mut sb = self
+                .cached_stylebox
+                .clone()
+                .unwrap_or_else(StyleBoxFlat::new_gd);
+            sb.set_bg_color(Color::from_rgba(0.0, 0.0, 0.0, 0.0));
+            sb.set_border_color(c_t);
+            sb.set_border_width(Side::LEFT, widths[0].round() as i32);
+            sb.set_border_width(Side::RIGHT, widths[1].round() as i32);
+            sb.set_border_width(Side::TOP, widths[2].round() as i32);
+            sb.set_border_width(Side::BOTTOM, widths[3].round() as i32);
+            sb.set_corner_radius(Corner::TOP_LEFT, radii[0].round() as i32);
+            sb.set_corner_radius(Corner::TOP_RIGHT, radii[1].round() as i32);
+            sb.set_corner_radius(Corner::BOTTOM_RIGHT, radii[2].round() as i32);
+            sb.set_corner_radius(Corner::BOTTOM_LEFT, radii[3].round() as i32);
+            sb.set_anti_aliased(true);
+            self.cached_stylebox = Some(sb);
+        } else {
+            self.cached_stylebox = None;
+        }
+
+        self.base_mut().queue_redraw();
+    }
+}

--- a/lib/src/godot_classes/mod.rs
+++ b/lib/src/godot_classes/mod.rs
@@ -32,6 +32,7 @@ pub mod dcl_social_blacklist;
 pub mod dcl_social_service;
 pub mod dcl_tokio_rpc;
 pub mod dcl_ui_background;
+pub mod dcl_ui_border;
 pub mod dcl_ui_control;
 pub mod dcl_ui_dropdown;
 pub mod dcl_ui_input;

--- a/lib/src/scene_runner/components/ui/style.rs
+++ b/lib/src/scene_runner/components/ui/style.rs
@@ -1,10 +1,24 @@
+use godot::prelude::Color;
+
 use crate::dcl::components::{
-    proto_components::sdk::components::{
-        PbUiTransform, PointerFilterMode, YgAlign, YgDisplay, YgFlexDirection, YgJustify,
-        YgOverflow, YgPositionType, YgUnit, YgWrap,
+    proto_components::{
+        sdk::components::{
+            PbUiTransform, PointerFilterMode, YgAlign, YgDisplay, YgFlexDirection, YgJustify,
+            YgOverflow, YgPositionType, YgUnit, YgWrap,
+        },
+        WrapToGodot,
     },
     SceneEntityId,
 };
+
+// v1 only resolves YGU_POINT to pixels. YGU_PERCENT and YGU_AUTO are not yet
+// supported for borders (would need post-layout resolution against parent size).
+fn border_px(unit: YgUnit, value: Option<f32>) -> f32 {
+    match unit {
+        YgUnit::YguPoint => value.unwrap_or(0.0).max(0.0),
+        _ => 0.0,
+    }
+}
 
 // macro helpers to convert proto format to bevy format for val, size, rect
 macro_rules! val {
@@ -65,16 +79,60 @@ pub struct UiTransform {
     pub pointer_filter_mode: PointerFilterMode,
     pub z_index: i32,
     pub taffy_style: taffy::style::Style,
+    // Border, in pixels. Widths order: [left, right, top, bottom].
+    // Radii order: [top_left, top_right, bottom_right, bottom_left] (Godot StyleBoxFlat order).
+    // Colors order: [top, right, bottom, left] (CSS order).
+    pub border_widths: [f32; 4],
+    pub border_radii: [f32; 4],
+    pub border_colors: [Color; 4],
+    pub has_border: bool,
 }
 
 impl From<&PbUiTransform> for UiTransform {
     fn from(value: &PbUiTransform) -> Self {
+        let bw_l = border_px(value.border_left_width_unit(), value.border_left_width);
+        let bw_r = border_px(value.border_right_width_unit(), value.border_right_width);
+        let bw_t = border_px(value.border_top_width_unit(), value.border_top_width);
+        let bw_b = border_px(value.border_bottom_width_unit(), value.border_bottom_width);
+
+        let br_tl = border_px(
+            value.border_top_left_radius_unit(),
+            value.border_top_left_radius,
+        );
+        let br_tr = border_px(
+            value.border_top_right_radius_unit(),
+            value.border_top_right_radius,
+        );
+        let br_br = border_px(
+            value.border_bottom_right_radius_unit(),
+            value.border_bottom_right_radius,
+        );
+        let br_bl = border_px(
+            value.border_bottom_left_radius_unit(),
+            value.border_bottom_left_radius,
+        );
+
+        let transparent = Color::from_rgba(0.0, 0.0, 0.0, 0.0);
+        let c_t = value.border_top_color.to_godot_or_else(transparent);
+        let c_r = value.border_right_color.to_godot_or_else(transparent);
+        let c_b = value.border_bottom_color.to_godot_or_else(transparent);
+        let c_l = value.border_left_color.to_godot_or_else(transparent);
+
+        let has_border = (bw_l > 0.0 && c_l.a > 0.0)
+            || (bw_r > 0.0 && c_r.a > 0.0)
+            || (bw_t > 0.0 && c_t.a > 0.0)
+            || (bw_b > 0.0 && c_b.a > 0.0);
+
         Self {
             parent: SceneEntityId::from_i32(value.parent),
             right_of: SceneEntityId::from_i32(value.right_of),
             overflow: value.overflow(),
             pointer_filter_mode: value.pointer_filter(),
             z_index: value.z_index.unwrap_or(0),
+            border_widths: [bw_l, bw_r, bw_t, bw_b],
+            border_radii: [br_tl, br_tr, br_br, br_bl],
+            border_colors: [c_t, c_r, c_b, c_l],
+            has_border,
             taffy_style: taffy::style::Style {
                 overflow: match value.overflow() {
                     YgOverflow::YgoVisible => taffy::geometry::Point::<taffy::style::Overflow> {
@@ -223,6 +281,13 @@ impl From<&PbUiTransform> for UiTransform {
                     taffy::style::LengthPercentage::Length(0.0),
                     LengthPercentage
                 ),
+                // Yoga semantics: border width shrinks the content area, like padding.
+                border: taffy::geometry::Rect {
+                    left: taffy::style::LengthPercentage::Length(bw_l),
+                    right: taffy::style::LengthPercentage::Length(bw_r),
+                    top: taffy::style::LengthPercentage::Length(bw_t),
+                    bottom: taffy::style::LengthPercentage::Length(bw_b),
+                },
                 ..Default::default()
             },
         }

--- a/lib/src/scene_runner/components/ui/ui_background.rs
+++ b/lib/src/scene_runner/components/ui/ui_background.rs
@@ -32,10 +32,11 @@ pub fn update_ui_background(scene: &mut Scene, crdt_state: &mut SceneCrdtState) 
                 .unwrap();
 
             if value.is_none() {
-                if let Some(mut node) = existing_ui_background.base_control.get_node_or_null("bkg")
-                {
-                    node.queue_free();
-                    existing_ui_background.base_control.remove_child(&node);
+                if let Some(mut existing) = existing_ui_background.bkg_node.take() {
+                    existing.queue_free();
+                    existing_ui_background
+                        .base_control
+                        .remove_child(&existing.upcast::<Node>());
                 }
                 existing_ui_background.has_background = false;
                 continue;
@@ -54,12 +55,12 @@ pub fn update_ui_background(scene: &mut Scene, crdt_state: &mut SceneCrdtState) 
             );
 
             let mut existing_ui_background_control =
-                if let Some(node) = existing_ui_background.base_control.get_node_or_null("bkg") {
+                if let Some(existing) = existing_ui_background.bkg_node.clone() {
                     tracing::debug!(
                         "[UI_BKG] Entity {:?} - reusing existing background node",
                         entity
                     );
-                    node.cast::<DclUiBackground>()
+                    existing
                 } else {
                     tracing::debug!(
                         "[UI_BKG] Entity {:?} - creating NEW background node",
@@ -75,6 +76,7 @@ pub fn update_ui_background(scene: &mut Scene, crdt_state: &mut SceneCrdtState) 
                     existing_ui_background
                         .base_control
                         .move_child(&node.clone().upcast::<Node>(), 0);
+                    existing_ui_background.bkg_node = Some(node.clone());
                     node
                 };
 
@@ -90,6 +92,12 @@ pub fn update_ui_background(scene: &mut Scene, crdt_state: &mut SceneCrdtState) 
             existing_ui_background_control
                 .bind_mut()
                 .change_value(value.clone(), scene.content_mapping.clone());
+
+            // Apply the (possibly already-set) corner radii so the background is
+            // clipped to the rounded shape from the moment it is first created.
+            existing_ui_background_control
+                .bind_mut()
+                .set_corner_radii(existing_ui_background.ui_transform.border_radii);
 
             let bkg_size_after = existing_ui_background_control.get_size();
             let bkg_pos_after = existing_ui_background_control.get_position();

--- a/lib/src/scene_runner/components/ui/ui_transform.rs
+++ b/lib/src/scene_runner/components/ui/ui_transform.rs
@@ -1,3 +1,5 @@
+use godot::{classes::Node, obj::NewAlloc, prelude::Gd};
+
 use crate::{
     dcl::{
         components::SceneComponentId,
@@ -6,6 +8,7 @@ use crate::{
             SceneCrdtStateProtoComponents,
         },
     },
+    godot_classes::dcl_ui_border::DclUiBorder,
     scene_runner::scene::Scene,
 };
 
@@ -59,7 +62,59 @@ pub fn update_ui_transform(scene: &mut Scene, crdt_state: &mut SceneCrdtState) {
                 node.base_control
                     .bind_mut()
                     .set_pointer_filter(node.ui_transform.pointer_filter_mode);
+
+                update_border_node(node);
+                update_bkg_corner_radii(node);
             }
         }
+    }
+}
+
+fn update_border_node(node: &mut crate::scene_runner::godot_dcl_scene::UiNode) {
+    let want_border = node.ui_transform.has_border;
+
+    if !want_border {
+        if let Some(mut existing) = node.border_node.take() {
+            existing.queue_free();
+            node.base_control.remove_child(&existing.upcast::<Node>());
+        }
+        node.has_border = false;
+        return;
+    }
+
+    // Use the cached Gd if present, otherwise create the border node. Newly
+    // appended nodes land at the end of base_control's child list by default,
+    // which is exactly where we want them (drawn on top of bkg/text/scene-children).
+    // update_layout positions scene-children at indices < last_index every frame,
+    // so the border floats to the tail naturally — no per-update move_child needed.
+    let mut border = if let Some(existing) = node.border_node.clone() {
+        existing
+    } else {
+        let mut new_node: Gd<DclUiBorder> = DclUiBorder::new_alloc();
+        new_node.set_name("border");
+        node.base_control
+            .add_child(&new_node.clone().upcast::<Node>());
+        node.border_node = Some(new_node.clone());
+        new_node
+    };
+
+    border.bind_mut().set_border(
+        node.ui_transform.border_widths,
+        node.ui_transform.border_radii,
+        node.ui_transform.border_colors,
+    );
+    node.has_border = true;
+}
+
+// Propagate border radii to the bkg child if it exists. Background may not exist yet
+// on the first frame (update_ui_background runs afterwards and applies them itself),
+// but on subsequent UI_TRANSFORM-only updates this is the only path that fires.
+fn update_bkg_corner_radii(node: &mut crate::scene_runner::godot_dcl_scene::UiNode) {
+    if !node.has_background {
+        return;
+    }
+    if let Some(bkg) = node.bkg_node.as_mut() {
+        bkg.bind_mut()
+            .set_corner_radii(node.ui_transform.border_radii);
     }
 }

--- a/lib/src/scene_runner/godot_dcl_scene.rs
+++ b/lib/src/scene_runner/godot_dcl_scene.rs
@@ -5,6 +5,7 @@ use crate::{
     },
     godot_classes::{
         dcl_node_entity_3d::DclNodeEntity3d, dcl_scene_node::DclSceneNode,
+        dcl_ui_background::DclUiBackground, dcl_ui_border::DclUiBorder,
         dcl_ui_control::DclUiControl,
     },
     realm::scene_definition::SceneEntityDefinition,
@@ -105,10 +106,19 @@ pub struct UiNode {
     pub ui_transform: UiTransform,
     pub computed_parent: SceneEntityId,
     pub has_background: bool,
+    pub has_border: bool,
     pub text_size: Option<Vector2>,
+    // Direct Gd references avoid get_node_or_null string lookups on every
+    // UI_TRANSFORM update. Set/cleared by the ui_background / ui_transform
+    // update functions in lockstep with has_background / has_border.
+    pub bkg_node: Option<Gd<DclUiBackground>>,
+    pub border_node: Option<Gd<DclUiBorder>>,
 }
 
 impl UiNode {
+    // Number of fixed visual siblings at the START of base_control's children
+    // (currently bkg at index 0, text at index 1). The border node lives at the
+    // END of the children list so it draws on top — it is NOT counted here.
     pub fn control_offset(&self) -> i32 {
         (if self.has_background { 1 } else { 0 }) + (if self.text_size.is_some() { 1 } else { 0 })
     }
@@ -162,6 +172,9 @@ impl GodotDclScene {
             ui_transform: UiTransform::default(),
             computed_parent: SceneEntityId::ROOT,
             has_background: false,
+            has_border: false,
+            bkg_node: None,
+            border_node: None,
             text_size: None,
         };
 
@@ -283,7 +296,10 @@ impl GodotDclScene {
                 ui_transform: UiTransform::default(),
                 computed_parent: SceneEntityId::ROOT,
                 has_background: false,
+                has_border: false,
                 text_size: None,
+                bkg_node: None,
+                border_node: None,
             });
             self.ui_entities.insert(*entity);
         }


### PR DESCRIPTION
## Summary
- Wires the new `PBUiTransform` fields from [protocol#254](https://github.com/decentraland/protocol/pull/254) — per-side border widths, per-corner radii, and per-side colors — into both Taffy layout (`style.border`) and Godot rendering.
- Adds `DclUiBorder` (Control + `_draw` override) as a per-entity child of `base_control`. Fast path uses a cached `StyleBoxFlat` when all four side colors match; slow path draws CSS-miter trapezoids + annular sector arcs split at the corner bisector for per-side colors with rounded corners.
- Clips the background to the rounded shape via an SDF fragment-shader on `DclUiBackground`. The compiled `Shader` resource is shared process-wide (thread_local) so adding many rounded UIs costs N `ShaderMaterial`s, not N shader compilations.
- Caches `Gd<DclUiBorder>` / `Gd<DclUiBackground>` directly on `UiNode` to drop per-update `get_node_or_null` string lookups, and removes the redundant per-update `move_child` (the border floats to the tail naturally as `update_layout` positions scene-children at `control_offset + n`).

Closes #851.

## Test scene

Go to `aesironline.dcl.eth` and select **UI Border Test (Eibriel)**

## Pictures

Godot:
<img width="1444" height="759" alt="Captura de pantalla 2026-05-13 a la(s) 10 55 45" src="https://github.com/user-attachments/assets/2fb9fd1c-1b4c-4e9e-85a4-c80e88c2854e" />

Unity:
<img width="1232" height="732" alt="Captura de pantalla 2026-05-13 a la(s) 10 17 42" src="https://github.com/user-attachments/assets/fdce5b64-d489-46b7-905b-ccaf33a9d083" />


## Test plan
- [ ] `cargo run -- run --itest` — existing UI integration tests still pass (regression check on `style.border`).
- [ ] Scene-test grid exercising:
  - [ ] Uniform width + uniform color + uniform radius (fast path, `StyleBoxFlat`).
  - [ ] Per-side widths only.
  - [ ] Per-corner radii only.
  - [ ] Per-side different colors with rounded corners (slow path — arcs split at bisector).
  - [ ] Mixed `radius != border_width` cases (verify no triangular color leak past arcs).
- [ ] Background is clipped to rounded shape when any `borderRadius > 0` (both top-level and nested children).
- [ ] Layout sanity: an entity with `border-left-width: 20` insets child content by 20px (Yoga border-as-padding semantics via Taffy `style.border`).