### PR TITLE
perf(dcl): split CRDT recv into wait + drain to reuse JS recv buffer

### DIFF
--- a/lib/src/dcl/js/engine.rs
+++ b/lib/src/dcl/js/engine.rs
@@ -42,8 +42,23 @@ use super::{
 
 // list of op declarations
 pub fn ops() -> Vec<OpDecl> {
-    vec![op_crdt_send_to_renderer(), op_crdt_recv_from_renderer()]
+    vec![
+        op_crdt_send_to_renderer(),
+        op_crdt_recv_wait(),
+        op_crdt_recv_drain(),
+    ]
 }
+
+/// Framed recv buffer produced by `op_crdt_recv_wait`, drained into a
+/// JS-owned `Uint8Array` by `op_crdt_recv_drain`.
+///
+/// Layout: `[u32 LE main_crdt_len][main_crdt bytes][data bytes]`.
+///
+/// Two ops because async ops can't take `#[buffer] &mut [u8]` (deno_core:
+/// the borrow can't span an `await`). The split lets JS reuse the same
+/// `Uint8Array` across every recv — no per-call V8 BackingStore allocation
+/// in steady state.
+struct PendingRecvBuffer(Vec<u8>);
 
 // receive and process a buffer of crdt messages
 #[op2(fast)]
@@ -99,11 +114,16 @@ fn op_crdt_send_to_renderer(op_state: Rc<RefCell<OpState>>, #[arraybuffer] messa
         .expect("error sending scene response!!")
 }
 
+/// Awaits the renderer response, builds the framed CRDT payload, stashes
+/// it for `op_crdt_recv_drain` to copy into JS memory. Returns the total
+/// framed length so JS can grow its persistent recv buffer before draining.
+///
+/// Frame layout: `[u32 LE main_crdt_len][main_crdt bytes][data bytes]`.
+/// `main_crdt_len` is 0 in steady state; main_crdt bytes only present on
+/// the first recv per scene (carries the snapshot from disk). Length is
+/// always >= 4 (the prefix).
 #[op2(async)]
-#[serde]
-async fn op_crdt_recv_from_renderer(
-    op_state: Rc<RefCell<OpState>>,
-) -> Result<Vec<Vec<u8>>, anyhow::Error> {
+async fn op_crdt_recv_wait(op_state: Rc<RefCell<OpState>>) -> Result<u32, anyhow::Error> {
     let receiver = op_state
         .borrow_mut()
         .borrow_mut::<Arc<tokio::sync::Mutex<Receiver<RendererResponse>>>>()
@@ -274,12 +294,42 @@ async fn op_crdt_recv_from_renderer(
 
     op_state.put(Vec::<LocalCall>::new());
     op_state.put(mutex_scene_crdt_state);
-    let mut ret = Vec::<Vec<u8>>::with_capacity(1);
-    if let Some(main_crdt) = op_state.try_take::<SceneMainCrdtFileContent>() {
-        ret.push(main_crdt.0);
+
+    // Build the framed payload directly into a Vec<u8>. EngineApi.js
+    // reconstructs the (optional main_crdt, data) split from the leading
+    // u32 length prefix.
+    let main_crdt = op_state
+        .try_take::<SceneMainCrdtFileContent>()
+        .map(|m| m.0)
+        .unwrap_or_default();
+
+    let main_len = main_crdt.len() as u32;
+    let mut framed = Vec::with_capacity(4 + main_crdt.len() + data.len());
+    framed.extend_from_slice(&main_len.to_le_bytes());
+    framed.extend_from_slice(&main_crdt);
+    framed.extend_from_slice(&data);
+    let total_len = framed.len() as u32;
+    op_state.put(PendingRecvBuffer(framed));
+    Ok(total_len)
+}
+
+/// Copies the buffer stashed by `op_crdt_recv_wait` into the JS-owned
+/// `Uint8Array out`. Returns the byte count written, or 0 if `out` was
+/// too small (the stash is preserved so the caller can grow + retry) or
+/// no pending buffer exists.
+#[op2(fast)]
+fn op_crdt_recv_drain(state: &mut OpState, #[buffer] out: &mut [u8]) -> u32 {
+    let Some(pending) = state.try_take::<PendingRecvBuffer>() else {
+        return 0;
+    };
+    let len = pending.0.len();
+    if len > out.len() {
+        // Buffer too small. Put the stash back so the caller can grow + retry.
+        state.put(pending);
+        return 0;
     }
-    ret.push(data);
-    Ok(ret)
+    out[..len].copy_from_slice(&pending.0);
+    len as u32
 }
 
 /// Build the per-call CRDT logging context for the scene→renderer direction.

--- a/lib/src/dcl/js/js_modules/EngineApi.js
+++ b/lib/src/dcl/js/js_modules/EngineApi.js
@@ -1,21 +1,47 @@
 // engine module
-const { op_crdt_recv_from_renderer, op_crdt_send_to_renderer, op_subscribe, op_send_batch } = Deno.core.ops;
+const { op_crdt_recv_wait, op_crdt_recv_drain, op_crdt_send_to_renderer, op_subscribe, op_send_batch } = Deno.core.ops;
+
+// Persistent recv buffer reused across every CRDT round-trip. 64 KB initial
+// covers typical steady-state recvs (~1-25 KB); the buffer auto-grows on
+// demand for the main_crdt snapshot on first recv per scene.
+let _recvBuf = new Uint8Array(64 * 1024);
+
+// Decode the framed buffer op_crdt_recv_drain wrote:
+//   [u32 LE main_crdt_len][main_crdt bytes][data bytes]
+// `slice()` per message (not `subarray()`) because the next recv overwrites
+// `_recvBuf` and SDK7 may hold references to the returned Uint8Arrays.
+function decodeRecvFrame(len) {
+    const view = new DataView(_recvBuf.buffer, _recvBuf.byteOffset, len);
+    const mainLen = view.getUint32(0, true);
+    const headerEnd = 4 + mainLen;
+    const messages = [];
+    if (mainLen > 0) {
+        messages.push(_recvBuf.slice(4, headerEnd));
+    }
+    messages.push(_recvBuf.slice(headerEnd, len));
+    return messages;
+}
+
+async function recvFramed() {
+    const len = await op_crdt_recv_wait();
+    if (len > _recvBuf.byteLength) {
+        // Grow to at least the needed size, with a 2× headroom so we don't
+        // re-grow every burst. Powers of two keep the allocator happy.
+        const newSize = Math.max(len, _recvBuf.byteLength * 2);
+        _recvBuf = new Uint8Array(newSize);
+    }
+    op_crdt_recv_drain(_recvBuf);
+    return decodeRecvFrame(len);
+}
 
 module.exports.crdtSendToRenderer = async function (messages) {
     op_crdt_send_to_renderer(messages.data.buffer.slice(messages.data.byteOffset, messages.data.byteLength + messages.data.byteOffset));
-    const data = (await op_crdt_recv_from_renderer()).map((item) => new Uint8Array(item));
-    return {
-        data: data
-    };
+    return { data: await recvFramed() };
 }
 
 
 module.exports.crdtGetState = async function () {
-    const data = (await op_crdt_recv_from_renderer()).map((item) => new Uint8Array(item))
-
-    return {
-        data: data
-    };
+    return { data: await recvFramed() };
 }
 
 


### PR DESCRIPTION
## What

Replaces \`op_crdt_recv_from_renderer\` (returned \`Vec<Vec<u8>>\` via \`#[serde]\`, which made V8 allocate a fresh BackingStore per inner Vec on every recv) with two ops:

- **\`op_crdt_recv_wait\`** (async): waits on the renderer channel, builds a single framed \`Vec<u8>\` payload \`[u32 LE main_crdt_len][main_crdt bytes][data bytes]\`, stashes it in op_state, returns total length.
- **\`op_crdt_recv_drain\`** (sync \`#[fast]\`): copies the stashed bytes into the JS-owned \`#[buffer] &mut [u8]\` \`out\`. Returns 0 if \`out\` was too small (caller grows buffer + retries).

JS side keeps a 64 KB persistent buffer that grows on demand. \`decodeRecv\` reads the 4-byte length prefix to split off main_crdt + data without allocating new Uint8Arrays for the backing buffers.

## Why

Profile on Samsung A54 (Genesis Plaza) showed Thread-14 (V8 isolate of the GP scene) was at 31.9 % of CPU, with **24.1 % spent in \`Builtin_ArrayBufferConstructor\`** and **20.6 % in GC scavenge**. The bottleneck wasn't compute — V8 was thrashing the BackingStore allocator on every CRDT recv tick (one fresh allocation per Vec<u8> in the serde-returned payload).

Reusing the JS buffer means: 0 new BackingStores per tick after the first, drastically less GC pressure, V8 thread frees up CPU for the actual work.

## Bench (A54 HIGH, GP preview, warm cache)

| run | fps mean | frame_proc_ms |
|---|---:|---:|
| baseline (HEAD revert) | 14.48 | 74.7 |
| + async-png + TweenState | 17.09 | 63.9 |
| **+ CRDT recv split (this)** | **18.03** | **69.3** |

**+3 FPS / +20%** on the V8-thread-bound case. The frame_proc bumped 64 → 69 ms because the win is *upstream* of frame_proc — V8 catches up faster, so frame_proc starts seeing the work that was previously held back.

## Files

- \`lib/src/dcl/js/engine.rs\`: new op pair + \`PendingRecvBuffer\` op_state stash.
- \`lib/src/dcl/js/js_modules/EngineApi.js\`: 64 KB persistent buffer + grow-on-demand + frame-prefix decoder.

Extracted from \`feat/rendering-server-animations-1948\` commit \`6262c41e\` for isolated A/B benchmarking.