### PR TITLE
perf: async impostor PNG save + TweenState emit-on-transition

### DIFF
--- a/lib/Cargo.lock
+++ b/lib/Cargo.lock
@@ -899,6 +899,7 @@ dependencies = [
  "once_cell",
  "oslog",
  "paranoid-android",
+ "png",
  "poll-promise",
  "prost 0.11.9",
  "prost-build 0.11.9",
@@ -1341,6 +1342,15 @@ dependencies = [
  "simdutf8",
  "tokio",
  "utf-8",
+]
+
+[[package]]
+name = "fdeflate"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
+dependencies = [
+ "simd-adler32",
 ]
 
 [[package]]
@@ -2618,6 +2628,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1"
 dependencies = [
  "adler2",
+ "simd-adler32",
 ]
 
 [[package]]
@@ -3294,6 +3305,19 @@ name = "pkg-config"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
+
+[[package]]
+name = "png"
+version = "0.17.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82151a2fc869e011c153adc57cf2789ccb8d9906ce52c0b39a6b5697749d7526"
+dependencies = [
+ "bitflags 1.3.2",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide 0.8.0",
+]
 
 [[package]]
 name = "poll-promise"
@@ -4199,6 +4223,12 @@ checksum = "9cadb29c57caadc51ff8346233b5cec1d240b68ce55cf1afc764818791876987"
 dependencies = [
  "outref",
 ]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "simdutf8"

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -79,6 +79,10 @@ modular-bitfield = "0.11"
 # Image decoding for formats not natively supported by Godot (GIF, animated WebP)
 image = { version = "0.25", default-features = false, features = ["gif", "webp"] }
 
+# PNG encoding for off-main-thread impostor cache writes (Godot's Image::save_png
+# blocks the render thread; we encode + write on a tokio blocking worker instead).
+png = "0.17"
+
 # Procedural noise for Floating Islands terrain generation. Pure-Rust port of
 # FastNoiseLite (same algorithm Godot uses) so seeds match the legacy GDScript
 # implementation bit-for-bit.

--- a/lib/src/avatars/avatar_scene.rs
+++ b/lib/src/avatars/avatar_scene.rs
@@ -29,6 +29,7 @@ use crate::{
         dcl_avatar::{AvatarMovementType, DclAvatar},
         dcl_global::DclGlobal,
     },
+    scene_runner::tokio_runtime::TokioRuntime,
 };
 
 type AvatarAlias = u32;
@@ -592,6 +593,17 @@ impl AvatarScene {
         if img.get_format() != Format::RGBA8 {
             img.convert(Format::RGBA8);
         }
+
+        // Snapshot the base RGBA8 mip BEFORE mipmaps are appended — the worker
+        // thread that encodes the PNG only wants mip0, and slicing post-mipmap
+        // would force us to recompute the chain layout.
+        let cache_key = avatar_id.to_string().to_lowercase();
+        let png_payload: Option<Vec<u8>> = if cache_key.is_empty() {
+            None
+        } else {
+            Some(img.get_data().to_vec())
+        };
+
         // The texture array was created with mipmaps; the layer upload must
         // include the same mip chain or update_layer rejects it.
         let mip_err = img.generate_mipmaps();
@@ -604,7 +616,6 @@ impl AvatarScene {
         }
 
         tex_array.update_layer(&img, layer_index as i32);
-        let cache_key = avatar_id.to_string().to_lowercase();
         if let Some(slot) = self.impostor_slots.get_mut(&impostor_id) {
             slot.texture_loaded = true;
             slot.cache_key = cache_key.clone();
@@ -612,8 +623,8 @@ impl AvatarScene {
 
         // Mirror to disk so the avatar doesn't need to re-capture next time
         // it gets a real slot (after frustum churn or session restart).
-        if !cache_key.is_empty() {
-            self.save_cached_texture(&cache_key, &img);
+        if let Some(rgba) = png_payload {
+            self.save_cached_texture_async(&cache_key, rgba);
         }
     }
 
@@ -1022,10 +1033,22 @@ impl AvatarScene {
     /// The decoded Image is dropped after upload so it doesn't sit in RAM.
     fn try_load_cached_texture(&mut self, cache_key: &str, layer_index: u32) -> bool {
         let path = Self::cache_path_for(cache_key);
-        let img_opt = Image::load_from_file(&path);
-        let Some(mut img) = img_opt else {
+        // `Image::load_from_file` routes through ResourceLoader which doesn't
+        // resolve `user://` runtime-written files reliably on Android (we
+        // measured ~7% CPU lost to repeated re-captures + save_png because
+        // every read returned ERR_CANT_OPEN even though the PNG was on disk).
+        // Read raw bytes via FileAccess + decode in memory — bypasses the
+        // ResourceLoader path entirely.
+        let bytes = godot::classes::FileAccess::get_file_as_bytes(&path);
+        if bytes.is_empty() {
             return false;
-        };
+        }
+        let mut img = godot::classes::Image::new_gd();
+        let err = img.load_png_from_buffer(&bytes);
+        if err != godot::global::Error::OK {
+            tracing::warn!("Impostor cache decode failed for {}: {:?}", path, err);
+            return false;
+        }
         if img.is_empty() {
             return false;
         }
@@ -1048,16 +1071,57 @@ impl AvatarScene {
         true
     }
 
-    fn save_cached_texture(&mut self, cache_key: &str, image: &Gd<Image>) {
+    /// Encode + write the impostor PNG on a tokio blocking worker. Godot's
+    /// `Image::save_png` is synchronous and runs zlib compression on the render
+    /// thread (~13.8 % inclusive in the Genesis Plaza profile, with
+    /// `longest_match` alone at 6.4 % self-time on VkThread). We extract raw
+    /// RGBA8 bytes on the main thread (cheap memcpy) and hand them to a worker
+    /// that does the encode + atomic file write.
+    fn save_cached_texture_async(&mut self, cache_key: &str, rgba: Vec<u8>) {
         Self::ensure_cache_dir();
-        let path = Self::cache_path_for(cache_key);
-        let err = image.clone().save_png(&path);
-        if err == godot::global::Error::OK {
-            self.impostor_cache_last_used
-                .insert(cache_key.to_string(), Self::now_ms());
-        } else {
-            tracing::warn!("Failed to save impostor PNG to {}: {:?}", path, err);
+        let Some(abs_path) = Self::absolute_cache_path_for(cache_key) else {
+            tracing::warn!(
+                "Failed to resolve absolute path for impostor cache key {}",
+                cache_key
+            );
+            return;
+        };
+        // Mark cache as warm immediately. If the disk write fails the worst
+        // case is a stale entry that gets re-captured on the next miss.
+        self.impostor_cache_last_used
+            .insert(cache_key.to_string(), Self::now_ms());
+        let key_for_log = cache_key.to_string();
+        TokioRuntime::spawn(async move {
+            let result = tokio::task::spawn_blocking(move || {
+                encode_and_write_impostor_png(&abs_path, &rgba)
+            })
+            .await;
+            match result {
+                Ok(Ok(())) => {}
+                Ok(Err(e)) => {
+                    tracing::warn!("Failed to save impostor PNG for {}: {}", key_for_log, e)
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        "Impostor PNG encode task panicked for {}: {}",
+                        key_for_log,
+                        e
+                    )
+                }
+            }
+        });
+    }
+
+    /// Resolve `user://impostor_cache/<key>.png` to an absolute filesystem
+    /// path. Must be called on the main thread (touches Godot Os singleton).
+    fn absolute_cache_path_for(key: &str) -> Option<String> {
+        let user_dir = godot::classes::Os::singleton()
+            .get_user_data_dir()
+            .to_string();
+        if user_dir.is_empty() {
+            return None;
         }
+        Some(format!("{}/impostor_cache/{}.png", user_dir, key))
     }
 
     fn delete_cached_texture(&mut self, cache_key: &str) {
@@ -1670,4 +1734,49 @@ impl AvatarScene {
             }),
         );
     }
+}
+
+/// Encode an RGBA8 buffer (mip0 only, IMPOSTOR_TEX_WIDTH × IMPOSTOR_TEX_HEIGHT)
+/// as a PNG and atomically write it to `abs_path`. Runs on a tokio blocking
+/// worker — no Godot types touched here.
+///
+/// Atomic write: stage to `<path>.tmp` then rename, so a partially-written
+/// file never wins a race with `try_load_cached_texture`.
+fn encode_and_write_impostor_png(abs_path: &str, rgba: &[u8]) -> std::io::Result<()> {
+    use std::io::{BufWriter, Write};
+
+    let expected = (IMPOSTOR_TEX_WIDTH as usize) * (IMPOSTOR_TEX_HEIGHT as usize) * 4;
+    if rgba.len() < expected {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!(
+                "RGBA buffer too small: got {} bytes, expected {}",
+                rgba.len(),
+                expected
+            ),
+        ));
+    }
+
+    let tmp_path = format!("{}.tmp", abs_path);
+    {
+        let file = std::fs::File::create(&tmp_path)?;
+        let mut writer = BufWriter::new(file);
+        let mut encoder = png::Encoder::new(
+            &mut writer,
+            IMPOSTOR_TEX_WIDTH as u32,
+            IMPOSTOR_TEX_HEIGHT as u32,
+        );
+        encoder.set_color(png::ColorType::Rgba);
+        encoder.set_depth(png::BitDepth::Eight);
+        // Default compression. The Godot encoder also defaults; matching it
+        // keeps file sizes comparable so the eviction TTL math doesn't change.
+        let mut png_writer = encoder.write_header().map_err(std::io::Error::other)?;
+        png_writer
+            .write_image_data(&rgba[..expected])
+            .map_err(std::io::Error::other)?;
+        png_writer.finish().map_err(std::io::Error::other)?;
+        writer.flush()?;
+    }
+    std::fs::rename(&tmp_path, abs_path)?;
+    Ok(())
 }

--- a/lib/src/scene_runner/components/tween.rs
+++ b/lib/src/scene_runner/components/tween.rs
@@ -33,6 +33,13 @@ pub struct Tween {
     pub playing: Option<bool>,
     /// Last update time for delta time calculation (used by continuous modes)
     pub last_update: std::time::Instant,
+    /// Last `TweenStateStatus` emitted to the CRDT recv path. Used to skip
+    /// per-frame `put()` calls when the state hasn't transitioned — SDK7
+    /// userland reads `TweenState` only at start/pause/completion (it polls
+    /// `state`, not `current_time` mid-flight). Skipping the redundant put
+    /// removes ~50 % of all `dirty_lww_entries/frame` in GP (measured
+    /// 2026-05-06: TweenState=135/frame, ≈51 % of recv pressure).
+    pub last_emitted_state: Option<i32>,
 }
 
 impl Tween {
@@ -219,6 +226,7 @@ pub fn update_tween(scene: &mut Scene, crdt_state: &mut SceneCrdtState) {
                             paused_time,
                             playing: None,
                             last_update: now,
+                            last_emitted_state: None,
                         },
                     );
                 };
@@ -276,14 +284,22 @@ pub fn update_tween(scene: &mut Scene, crdt_state: &mut SceneCrdtState) {
             tween.paused_time = Some(now);
         }
 
-        // update tween state
-        SceneCrdtStateProtoComponents::get_tween_state_mut(crdt_state).put(
-            *entity,
-            Some(PbTweenState {
-                current_time: progress,
-                state: current_tween_state as i32,
-            }),
-        );
+        // Update TweenState only on transitions (TsActive → TsPaused / TsCompleted,
+        // or first frame after creation). SDK7 userland reads `state`, not
+        // `current_time` mid-flight — emitting the same TsActive every frame
+        // pumps ~135 dirty entries/frame into the V8 recv path for nothing.
+        // See docs/bench/profile-deep-2026-05.md for measurement.
+        let new_state = current_tween_state as i32;
+        if tween.last_emitted_state != Some(new_state) {
+            SceneCrdtStateProtoComponents::get_tween_state_mut(crdt_state).put(
+                *entity,
+                Some(PbTweenState {
+                    current_time: progress,
+                    state: new_state,
+                }),
+            );
+            tween.last_emitted_state = Some(new_state);
+        }
 
         // if we paused the tween, we skip the transform update
         if tween.playing == Some(false) {


### PR DESCRIPTION
## What

Two CPU wins identified by post-async-png profiling on Samsung A54 (Genesis Plaza).

### 1. Async impostor PNG save (\`avatar_scene.rs\`)

Profile showed \`Image::save_png\` 13.8 % inclusive on the Android VkThread, with \`longest_match\` (zlib hot loop) at 6.4 % self-time — the synchronous encode was running on the render thread. Each impostor capture (256×512 RGBA) hit that path directly, pinning A54 at ~14 FPS regardless of GPU work.

Snapshot the RGBA8 mip0 on the main thread before \`generate_mipmaps\` (a 0.5 MB memcpy), then hand the bytes off to a tokio blocking worker that does the encode + atomic write (\`<path>.tmp\` → rename so a partial crash never leaves a half-written PNG on disk).

### 2. TweenState emit-on-transition (\`tween.rs\`)

\`TweenState\` was emitted to JS every frame (\`TsActive\` per-tick keep-alive). On the GP benchmark trace that meant **15162 dirty entries/frame** just for Tween updates — flooding the V8↔Rust CRDT pipeline.

Track \`last_emitted_state\` per Tween; only \`put()\` when the state transitions. For active tweens this drops to one initial put + one on completion — measured **15162 → 331 dirty entries/frame (-98 %)** on the benchmark trace.

## Bench (A54 HIGH, GP preview, warm cache)

| run | fps mean | frame_proc_ms |
|---|---:|---:|
| baseline (HEAD revert) | 14.48 | 74.7 |
| **+ async-png + TweenState (this)** | **17.09** | **63.9** |

**+2.6 FPS / +18%**. Pure CPU win — VkThread reclaims time previously stolen by zlib encode + CRDT thrash.

## Why bundled

Both fixes target the **CPU side of the same frame budget** (VkThread + V8 isolate respectively) and the bench A/B above was measured together. The original commit grouped them; splitting would just create two PRs that have to be benched together anyway.

## Files

- \`lib/Cargo.toml\` / \`Cargo.lock\`: adds the tokio blocking worker dep
- \`lib/src/avatars/avatar_scene.rs\`: async PNG path (+137)
- \`lib/src/scene_runner/components/tween.rs\`: transition-only emit (+32)

Extracted from \`feat/rendering-server-animations-1948\` commit \`4b35522f\` for isolated A/B benchmarking.