### PR TITLE
feat: add AMT_HIDE_NAMETAGS modifier to AvatarModifierArea

### DIFF
--- a/godot/src/decentraland_components/avatar/avatar.gd
+++ b/godot/src/decentraland_components/avatar/avatar.gd
@@ -38,6 +38,7 @@ var is_local_player: bool = false
 var avatar_id: String = ""
 var hidden: bool = false
 var passport_disabled: bool = false
+var nametag_hidden: bool = false
 var avatar_ready: bool = false
 var has_connected_web3: bool = false  # Whether the user has connected a web3 wallet (not a guest)
 
@@ -267,6 +268,10 @@ func _on_set_avatar_modifier_area(area: DclAvatarModifierArea3D):
 			passport_disabled = true
 		elif modifier == 1:  # disable passport
 			passport_disabled = true
+		elif modifier == 2:  # hide nametag
+			nametag_hidden = true
+
+	_apply_nickname_visibility()
 
 
 func set_hidden(value):
@@ -326,6 +331,8 @@ func _unset_avatar_modifier_area():
 		show()
 		_set_click_area_enabled(true)
 	passport_disabled = false
+	nametag_hidden = false
+	_apply_nickname_visibility()
 
 
 func async_update_avatar_from_profile(profile: DclUserProfile):
@@ -524,7 +531,7 @@ func _apply_nickname_visibility() -> void:
 		is_avatar_shape and (current_name.is_empty() or current_name == "NPC")
 	)
 	var far_lod: bool = _lod_state == LODState.FAR
-	var should_hide := avatar_shape_has_no_name or hide_name or _force_hide_name or far_lod
+	var should_hide := avatar_shape_has_no_name or hide_name or _force_hide_name or far_lod or nametag_hidden
 	if should_hide:
 		nickname_quad.hide()
 		if nickname_viewport != null:

--- a/lib/src/godot_classes/dcl_avatar_modifier_area_3d.rs
+++ b/lib/src/godot_classes/dcl_avatar_modifier_area_3d.rs
@@ -6,12 +6,13 @@ use godot::prelude::*;
 pub enum AvatarModifierType {
     HideAvatar = 0,
     DisablePassports = 1,
+    HideNameTags = 2,
 }
 
 #[derive(GodotClass)]
 #[class(init, base=Area3D)]
 pub struct DclAvatarModifierArea3D {
-    #[export(enum = (HideAvatar, DisablePassports))]
+    #[export(enum = (HideAvatar, DisablePassports, HideNameTags))]
     avatar_modifiers: Array<i32>,
 
     #[export]

--- a/src/install_dependency.rs
+++ b/src/install_dependency.rs
@@ -30,7 +30,7 @@ fn create_directory_all(path: &Path) -> io::Result<()> {
     Ok(())
 }
 
-const PROTOCOL_FIXED_VERSION_URL: Option<&str> = Some("https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-24360051842.commit-5e66d77.tgz");
+const PROTOCOL_FIXED_VERSION_URL: Option<&str> = Some("https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-25678907683.commit-94ee065.tgz");
 
 fn get_protocol_url() -> Result<String, anyhow::Error> {
     match PROTOCOL_FIXED_VERSION_URL {


### PR DESCRIPTION
Add AMT_HIDE_NAMETAGS modifier to AvatarModifierArea

Implements support for the new AMT_HIDE_NAMETAGS modifier (value 2) defined in [protocol PR link].

Changes:

dcl_avatar_modifier_area_3d.rs: add HideNameTags = 2 to the Rust enum and editor export
avatar.gd: handle modifier 2 by setting nametag_hidden = true and hiding the nickname quad; reset on area exit
install_dependency.rs: bump PROTOCOL_FIXED_VERSION_URL to the protocol PR that adds AMT_HIDE_NAMETAGS

protocol:
npm install "https://sdk-team-cdn.decentraland.org/@dcl/protocol/branch//dcl-protocol-1.0.0-25678907683.commit-94ee065.tgz"
js-sdk-toolchain:
npm install "https://sdk-team-cdn.decentraland.org/@dcl/js-sdk-toolchain/branch/feat/add-hide-nametags-modifier/dcl-sdk-7.23.2-25809367759.commit-4ac73c7.tgz"