### PR TITLE
refactor(content): quality-parameterized texture fetch API + AsyncImage fallback detection

### DIFF
--- a/godot/src/ui/components/async_image/async_image.gd
+++ b/godot/src/ui/components/async_image/async_image.gd
@@ -124,7 +124,9 @@ func _async_download(url: String) -> void:
 	var url_hash := _get_hash_from_url(url)
 	var content_mapping
 	if quality == Quality.ORIGINAL:
-		content_mapping = Global.content_provider.fetch_texture_by_url_original(url_hash, url)
+		content_mapping = Global.content_provider.fetch_texture_by_url_with_quality(
+			url_hash, url, DclConfig.TEXTURE_QUALITY_HIGH
+		)
 	else:
 		content_mapping = Global.content_provider.fetch_texture_by_url(url_hash, url)
 	var result = await PromiseUtils.async_awaiter(content_mapping)
@@ -133,5 +135,8 @@ func _async_download(url: String) -> void:
 		_finish_with_error()
 		return
 	if not is_instance_valid(self):
+		return
+	if result.failed:
+		_finish_with_error()
 		return
 	set_texture(result.texture)

--- a/godot/src/ui/components/async_image/async_image.gd
+++ b/godot/src/ui/components/async_image/async_image.gd
@@ -6,11 +6,13 @@ extends Control
 
 signal image_loaded
 
-## ORIGINAL fetches at full resolution (bypasses global texture quality).
-## DEFAULT uses the global texture quality setting (typically Medium = 512px max).
-enum Quality { ORIGINAL, DEFAULT }
+## Optional per-instance texture quality override.
+## NONE → uses the global texture quality setting (DclConfig).
+## LOW/MEDIUM/HIGH/SOURCE values mirror DclConfig.TEXTURE_QUALITY_* — keep in sync with
+## TextureQuality in lib/src/godot_classes/dcl_config.rs.
+enum ForcedQuality { NONE = -1, LOW = 0, MEDIUM = 1, HIGH = 2, SOURCE = 3 }
 
-@export var quality: Quality = Quality.ORIGINAL
+@export var forced_quality: ForcedQuality = ForcedQuality.NONE
 @export var border_radius: int = 12
 @export var border_color: Color = Color("E8B9FF")
 @export var background_color: Color = Color(0.20784314, 0.03137255, 0.32941177, 0.5)
@@ -123,12 +125,12 @@ static func _get_hash_from_url(url: String) -> String:
 func _async_download(url: String) -> void:
 	var url_hash := _get_hash_from_url(url)
 	var content_mapping
-	if quality == Quality.ORIGINAL:
-		content_mapping = Global.content_provider.fetch_texture_by_url_with_quality(
-			url_hash, url, DclConfig.TEXTURE_QUALITY_HIGH
-		)
-	else:
+	if forced_quality == ForcedQuality.NONE:
 		content_mapping = Global.content_provider.fetch_texture_by_url(url_hash, url)
+	else:
+		content_mapping = Global.content_provider.fetch_texture_by_url_with_quality(
+			url_hash, url, forced_quality
+		)
 	var result = await PromiseUtils.async_awaiter(content_mapping)
 	if result is PromiseError:
 		printerr("AsyncImage: download error: ", result.get_error())

--- a/lib/src/content/content_provider.rs
+++ b/lib/src/content/content_provider.rs
@@ -1320,6 +1320,7 @@ impl ContentProvider {
                     original_size,
                     image,
                     texture,
+                    failed: false,
                 });
 
                 then_promise(get_promise, Ok(Some(texture_entry.to_variant())));
@@ -1360,25 +1361,26 @@ impl ContentProvider {
         promise
     }
 
-    /// Fetches a texture by hash, bypassing the optimization pipeline.
-    /// This is useful for UI textures that need the original quality.
-    /// Uses a separate cache key (`{hash}_original`) to avoid conflicts with optimized versions.
-    pub fn fetch_texture_by_hash_original(
+    /// Fetches a texture by hash with an explicit quality, bypassing the optimization
+    /// pipeline. Useful for UI textures that need a specific (usually Source) quality.
+    /// Cache key: `{hash}_q{N}` — shared with `fetch_texture_by_url_with_quality`.
+    pub fn fetch_texture_by_hash_with_quality(
         &mut self,
         file_hash_godot: GString,
         content_mapping: Gd<DclContentMappingAndUrl>,
+        quality: TextureQuality,
     ) -> Gd<Promise> {
         let file_hash = file_hash_godot.to_string();
 
         // Validate file_hash is not empty to prevent "Is a directory" errors
         if file_hash.is_empty() {
             tracing::warn!(
-                "fetch_texture_by_hash_original: empty file_hash, returning rejected promise"
+                "fetch_texture_by_hash_with_quality: empty file_hash, returning rejected promise"
             );
             return Promise::from_rejected("Empty texture hash".to_string());
         }
 
-        let cache_key = format!("{}_original", file_hash);
+        let cache_key = format!("{}_q{}", file_hash, quality.to_i32());
 
         if let Some(promise) = self.get_cached_promise(&cache_key) {
             return promise;
@@ -1386,18 +1388,20 @@ impl ContentProvider {
 
         // Handle URL-based textures
         if file_hash.starts_with("http") {
-            let new_file_hash = format!("hashed_{:x}_original", file_hash_godot.hash_u32());
-            let promise =
-                self.fetch_texture_by_url_original(GString::from(&new_file_hash), file_hash_godot);
+            let new_file_hash = format!("hashed_{:x}", file_hash_godot.hash_u32());
+            let promise = self.fetch_texture_by_url_with_quality(
+                GString::from(&new_file_hash),
+                file_hash_godot,
+                quality,
+            );
             self.cache_promise(cache_key, &promise);
             return promise;
         }
 
         let (promise, get_promise) = Promise::make_to_async();
 
-        // Create context with Source quality to bypass resize optimization
         let mut ctx = self.get_context();
-        ctx.texture_quality = TextureQuality::Source;
+        ctx.texture_quality = quality;
 
         let url = format!(
             "{}{}",
@@ -1411,7 +1415,7 @@ impl ContentProvider {
 
         TokioRuntime::spawn(async move {
             #[cfg(feature = "use_resource_tracking")]
-            report_resource_start(&hash_id, "texture_original");
+            report_resource_start(&hash_id, "texture_with_quality");
 
             loading_resources.fetch_add(1, Ordering::Relaxed);
 
@@ -1434,24 +1438,24 @@ impl ContentProvider {
         promise
     }
 
-    /// Fetches a texture by URL, bypassing the optimization pipeline.
-    /// Uses Source quality to preserve original texture resolution.
+    /// Fetches a texture by URL with an explicit quality, bypassing the global texture
+    /// quality setting. From GDScript, use `DclConfig.TEXTURE_QUALITY_LOW/MEDIUM/HIGH/SOURCE`.
     #[func]
-    pub fn fetch_texture_by_url_original(
+    pub fn fetch_texture_by_url_with_quality(
         &mut self,
         file_hash: GString,
         url: GString,
+        quality: TextureQuality,
     ) -> Gd<Promise> {
-        let file_hash = format!("{}_original", file_hash);
+        let file_hash = format!("{}_q{}", file_hash, quality.to_i32());
         if let Some(promise) = self.get_cached_promise(&file_hash) {
             return promise;
         }
         let url = url.to_string();
         let (promise, get_promise) = Promise::make_to_async();
 
-        // Create context with Source quality to bypass resize optimization
         let mut content_provider_context = self.get_context();
-        content_provider_context.texture_quality = TextureQuality::Source;
+        content_provider_context.texture_quality = quality;
 
         let sent_file_hash = file_hash.clone();
 
@@ -1464,7 +1468,7 @@ impl ContentProvider {
         let url_for_error = url.clone();
         TokioRuntime::spawn(async move {
             #[cfg(feature = "use_resource_tracking")]
-            report_resource_start(&hash_id, "texture_url_original");
+            report_resource_start(&hash_id, "texture_url_with_quality");
 
             loading_resources.fetch_add(1, Ordering::Relaxed);
 
@@ -1487,47 +1491,13 @@ impl ContentProvider {
         promise
     }
 
+    /// Fetches a texture by URL using the global texture-quality setting.
+    /// Thin wrapper over `fetch_texture_by_url_with_quality`, so it shares cache slots
+    /// with explicit-quality fetches at the same quality (cache key: `{hash}_q{N}`).
     #[func]
     pub fn fetch_texture_by_url(&mut self, file_hash: GString, url: GString) -> Gd<Promise> {
-        let file_hash = file_hash.to_string();
-        if let Some(promise) = self.get_cached_promise(&file_hash) {
-            return promise;
-        }
-        let url = url.to_string();
-        let (promise, get_promise) = Promise::make_to_async();
-        let content_provider_context = self.get_context();
-        let sent_file_hash = file_hash.clone();
-
-        let loading_resources = self.loading_resources.clone();
-        let loaded_resources = self.loaded_resources.clone();
-
-        #[cfg(feature = "use_resource_tracking")]
-        let hash_id = file_hash.clone();
-        #[cfg(feature = "use_resource_tracking")]
-        let url_for_error = url.clone();
-        TokioRuntime::spawn(async move {
-            #[cfg(feature = "use_resource_tracking")]
-            report_resource_start(&hash_id, "texture_url");
-
-            loading_resources.fetch_add(1, Ordering::Relaxed);
-
-            let result = load_image_texture(url, sent_file_hash, content_provider_context).await;
-
-            #[cfg(feature = "use_resource_tracking")]
-            if let Err(error) = &result {
-                report_resource_error(&hash_id, &format!("url={} error={}", url_for_error, error));
-            } else {
-                report_resource_loaded(&hash_id);
-            }
-
-            then_promise(get_promise, result);
-
-            loaded_resources.fetch_add(1, Ordering::Relaxed);
-        });
-
-        self.cache_promise(file_hash, &promise);
-
-        promise
+        let quality = DclConfig::static_get_texture_quality();
+        self.fetch_texture_by_url_with_quality(file_hash, url, quality)
     }
 
     #[func]

--- a/lib/src/content/texture.rs
+++ b/lib/src/content/texture.rs
@@ -73,6 +73,7 @@ fn create_fallback_texture_entry() -> Gd<TextureEntry> {
         image,
         texture,
         original_size,
+        failed: true,
     })
 }
 
@@ -85,6 +86,10 @@ pub struct TextureEntry {
     pub texture: Gd<Texture2D>,
     #[var]
     pub original_size: Vector2i,
+    /// True when this entry holds the fallback texture because decoding failed
+    /// or the format is unsupported. Callers should treat the texture as a placeholder.
+    #[var]
+    pub failed: bool,
 }
 
 /// Decodes a GIF and creates an AnimatedTexture with compressed frames.
@@ -286,6 +291,7 @@ pub async fn load_image_texture(
             image,
             texture,
             original_size,
+            failed: false,
         });
 
         return Ok(Some(texture_entry.to_variant()));
@@ -316,6 +322,7 @@ pub async fn load_image_texture(
             image,
             texture,
             original_size,
+            failed: false,
         });
 
         return Ok(Some(texture_entry.to_variant()));
@@ -390,6 +397,7 @@ pub async fn load_image_texture(
         image,
         texture,
         original_size,
+        failed: false,
     });
 
     Ok(Some(texture_entry.to_variant()))

--- a/lib/src/godot_classes/dcl_config.rs
+++ b/lib/src/godot_classes/dcl_config.rs
@@ -75,6 +75,15 @@ impl IRefCounted for DclConfig {
 
 #[godot_api]
 impl DclConfig {
+    #[constant]
+    const TEXTURE_QUALITY_LOW: i32 = 0;
+    #[constant]
+    const TEXTURE_QUALITY_MEDIUM: i32 = 1;
+    #[constant]
+    const TEXTURE_QUALITY_HIGH: i32 = 2;
+    #[constant]
+    const TEXTURE_QUALITY_SOURCE: i32 = 3;
+
     #[func]
     pub fn get_settings_file_path() -> GString {
         "user://settings.cfg".to_godot()

--- a/lib/src/godot_classes/dcl_ui_background.rs
+++ b/lib/src/godot_classes/dcl_ui_background.rs
@@ -12,6 +12,7 @@ use crate::{
         material::{DclSourceTex, DclTexture},
         proto_components::sdk::components::{BackgroundTextureMode, PbUiBackground},
     },
+    godot_classes::dcl_config::TextureQuality,
 };
 
 use super::dcl_global::DclGlobal;
@@ -548,14 +549,18 @@ impl DclUiBackground {
                     DclSourceTex::Texture(texture_hash) => {
                         let global = DclGlobal::singleton();
                         let mut content_provider = global.bind().get_content_provider();
-                        let mut promise =
-                            content_provider.bind_mut().fetch_texture_by_hash_original(
+                        let quality = TextureQuality::Source;
+                        let mut promise = content_provider
+                            .bind_mut()
+                            .fetch_texture_by_hash_with_quality(
                                 texture_hash.to_godot(),
                                 DclContentMappingAndUrl::from_ref(content_mapping),
+                                quality.clone(),
                             );
 
-                        // Use the _original suffix to match the cache key used by fetch_texture_by_hash_original
-                        self.waiting_hash = format!("{}_original", texture_hash).to_godot();
+                        // Match the cache key used by fetch_texture_by_hash_with_quality.
+                        self.waiting_hash =
+                            format!("{}_q{}", texture_hash, quality.to_i32()).to_godot();
 
                         if !promise.bind().is_resolved() {
                             promise.connect(


### PR DESCRIPTION
## Summary
- Adds `TextureEntry.failed: bool` so callers can distinguish a real texture from the `image_not_supported.png` placeholder that `load_image_texture` returns for unsupported formats / decode errors. `AsyncImage` now checks `result.failed` and routes those cases to its no-image state instead of silently displaying the placeholder.
- Replaces `fetch_texture_by_{url,hash}_original` with `fetch_texture_by_{url,hash}_with_quality(file_hash, url|content_mapping, quality)`. `fetch_texture_by_url` becomes a thin wrapper that reads the global default from `DclConfig::static_get_texture_quality()` — cache keys converge on `{hash}_q{N}`, so the same URL fetched at the same quality is no longer downloaded twice.
- Exposes `DclConfig.TEXTURE_QUALITY_LOW/MEDIUM/HIGH/SOURCE` `#[constant]` items so GDScript callers don't pass magic numbers.
- Updates `dcl_ui_background.rs` (the only Rust caller of the former `_original` hash variant) to use `fetch_texture_by_hash_with_quality(..., TextureQuality::Source)` and the matching `{hash}_q3` `waiting_hash`.

## Why
- Reported: `AsyncImage` silently rendered the magenta/placeholder texture when the URL pointed at an unsupported image format. The fallback was hidden inside the content provider behind an `Ok(...)` result, so the GDScript layer had no way to detect failure. (See #2063.)
- The two existing entry points (`fetch_texture_by_url` and `fetch_texture_by_url_original`) used separate cache namespaces (bare hash vs. `_original` suffix), which meant the same texture could be downloaded and decoded twice when one site asked for the global default and another asked for source quality. Unifying on `{hash}_q{N}` keys avoids that.

## Out of scope
- The optimized-asset (`.res`) fast-path inside `fetch_texture_by_hash` is unchanged. It only honors a single baked quality variant; supporting per-quality variants requires asset-pipeline changes tracked in #2076.

Closes #2063

## Test plan
- [ ] Load a snap carousel with valid images — textures appear as before, no regression.
- [ ] Point an `AsyncImage` at a URL serving an unsupported format (e.g. AVIF) — verify the no-image state renders instead of the magenta placeholder.
- [ ] Confirm a UI background using `DclSourceTex::Texture` still loads (covers `fetch_texture_by_hash_with_quality` + `waiting_hash`).
- [ ] `cargo fmt --all`, `cargo clippy`, `cargo run -- check-gdscript` clean.