### PR TITLE
fix: show player hash in tagging autocomplete suggestions

### DIFF
--- a/godot/src/ui/components/chat/mention_item.gd
+++ b/godot/src/ui/components/chat/mention_item.gd
@@ -6,6 +6,7 @@ var _avatar_name: String
 
 @onready var profile_picture: ProfilePicture = %ProfilePicture
 @onready var label_nickname: Label = %Nickname
+@onready var label_hash: Label = %Hash
 @onready var texture_rect_checkmark: TextureRect = %TextureRect_Checkmark
 
 
@@ -20,11 +21,15 @@ func setup(avatar: Avatar) -> void:
 	if _avatar_name.is_empty():
 		return
 
-	var display_name := _avatar_name
-	var has_claimed := !_avatar_name.contains("#")
-	var tag_pos := display_name.find("#")
+	var display_name = _avatar_name
+	var has_claimed = !_avatar_name.contains("#")
+	var tag_pos = display_name.find("#")
 	if tag_pos != -1:
+		label_hash.text = display_name.substr(tag_pos)
+		label_hash.visible = true
 		display_name = display_name.left(tag_pos)
+	else:
+		label_hash.visible = false
 	label_nickname.text = display_name
 
 	var color := DclAvatar.get_nickname_color(_avatar_name)

--- a/godot/src/ui/components/chat/mention_item.tscn
+++ b/godot/src/ui/components/chat/mention_item.tscn
@@ -9,6 +9,11 @@
 font = ExtResource("4_tpv4r")
 font_size = 22
 
+[sub_resource type="LabelSettings" id="LabelSettings_hash"]
+font = ExtResource("4_tpv4r")
+font_size = 22
+font_color = Color(0.545, 0.545, 0.545, 1)
+
 [node name="MentionItem" type="Control" unique_id=1469431168]
 custom_minimum_size = Vector2(200, 56)
 layout_mode = 3
@@ -46,6 +51,12 @@ unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
 label_settings = SubResource("LabelSettings_8iu80")
+
+[node name="Hash" type="Label" parent="MarginContainer/HBoxContainer" unique_id=1901030001]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 0
+label_settings = SubResource("LabelSettings_hash")
 
 [node name="TextureRect_Checkmark" type="TextureRect" parent="MarginContainer/HBoxContainer" unique_id=190021123]
 unique_name_in_owner = true


### PR DESCRIPTION
## Summary
- Adds a `Hash` label to the mention item UI to display the player hash separately in grey
- Extracts the hash portion from the avatar name and shows it next to the nickname in autocomplete suggestions

Closes #1903

## Test plan
- [ ] Type `@` in chat to open the autocomplete dropdown
- [ ] Verify player hashes now appear next to names in suggestions
- [ ] Verify claimed names (without hash) still display correctly
- [ ] Verify selecting a suggestion still inserts the full name with hash into the chat input