### PR TITLE
fix: restore broken DirectionalLight animation + base floor multimesh

### DIFF
--- a/godot/assets/environment/sky_lights.tscn
+++ b/godot/assets/environment/sky_lights.tscn
@@ -20,4 +20,6 @@ directional_shadow_split_1 = 0.3
 directional_shadow_max_distance = 30.0
 
 [node name="AnimationPlayer" type="AnimationPlayer" parent="." unique_id=1628949876]
-libraries/ = SubResource("AnimationLibrary_local")
+libraries = {
+"": SubResource("AnimationLibrary_local")
+}

--- a/godot/src/logic/base_floor_manager.gd
+++ b/godot/src/logic/base_floor_manager.gd
@@ -20,9 +20,6 @@ func _initialize_base_floor_multimesh():
 	base_floor_multimesh.name = "BaseFloorMultimesh"
 	add_child(base_floor_multimesh)
 
-	var quad_mesh = QuadMesh.new()
-	quad_mesh.size = Vector2(FLOOR_SIZE, FLOOR_SIZE)
-	quad_mesh.material = BASE_FLOOR_MATERIAL
 	var array_mesh = ArrayMesh.new()
 	var arrays = []
 	arrays.resize(Mesh.ARRAY_MAX)
@@ -36,9 +33,7 @@ func _initialize_base_floor_multimesh():
 	)
 
 	var uvs = PackedVector2Array([Vector2(0, 0), Vector2(1, 0), Vector2(1, 1), Vector2(0, 1)])
-
 	var normals = PackedVector3Array([Vector3.UP, Vector3.UP, Vector3.UP, Vector3.UP])
-
 	var indices = PackedInt32Array([0, 1, 2, 0, 2, 3])
 
 	arrays[Mesh.ARRAY_VERTEX] = vertices
@@ -62,25 +57,8 @@ func add_scene_floors(scene_id: String, parcels: Array):
 	if scene_id in loaded_parcels_floors:
 		return
 
-	var multimesh = base_floor_multimesh.multimesh
-	var current_count = multimesh.instance_count
-	var new_floors = []
-	multimesh.instance_count = current_count + parcels.size()
-	for i in range(parcels.size()):
-		var parcel = parcels[i]
-		var instance_idx = current_count + i
-
-		var parcel_x = parcel.x * FLOOR_SIZE + FLOOR_SIZE / 2
-		var parcel_z = -parcel.y * FLOOR_SIZE - FLOOR_SIZE / 2
-
-		var transform = Transform3D()
-		transform.origin = Vector3(parcel_x, -0.05, parcel_z)
-		multimesh.set_instance_transform(instance_idx, transform)
-
-		new_floors.append(instance_idx)
-
-	loaded_parcels_floors[scene_id] = new_floors
-	_update_base_floor_visibility()
+	loaded_parcels_floors[scene_id] = parcels.duplicate()
+	_rebuild_multimesh()
 
 
 func remove_scene_floors(scene_id: String):
@@ -90,27 +68,27 @@ func remove_scene_floors(scene_id: String):
 	if not scene_id in loaded_parcels_floors:
 		return
 
+	loaded_parcels_floors.erase(scene_id)
+	_rebuild_multimesh()
+
+
+func _rebuild_multimesh():
 	var multimesh = base_floor_multimesh.multimesh
+	var total := 0
+	for parcels in loaded_parcels_floors.values():
+		total += parcels.size()
 
-	var remaining_transforms = []
-	var remaining_scene_ids = {}
+	multimesh.instance_count = total
 
-	for sid in loaded_parcels_floors:
-		if sid != scene_id:
-			for idx in loaded_parcels_floors[sid]:
-				remaining_transforms.append(multimesh.get_instance_transform(idx))
-	multimesh.instance_count = remaining_transforms.size()
-	var new_idx = 0
-	for sid in loaded_parcels_floors:
-		if sid != scene_id:
-			var new_indices = []
-			for old_idx in loaded_parcels_floors[sid]:
-				multimesh.set_instance_transform(new_idx, remaining_transforms[new_idx])
-				new_indices.append(new_idx)
-				new_idx += 1
-			remaining_scene_ids[sid] = new_indices
+	var idx := 0
+	for parcels in loaded_parcels_floors.values():
+		for parcel in parcels:
+			var parcel_x: float = parcel.x * FLOOR_SIZE + FLOOR_SIZE / 2.0
+			var parcel_z: float = -parcel.y * FLOOR_SIZE - FLOOR_SIZE / 2.0
+			var transform := Transform3D(Basis.IDENTITY, Vector3(parcel_x, -0.05, parcel_z))
+			multimesh.set_instance_transform(idx, transform)
+			idx += 1
 
-	loaded_parcels_floors = remaining_scene_ids
 	_update_base_floor_visibility()
 
 
@@ -124,6 +102,6 @@ func _on_player_parcel_changed(_new_parcel: Vector2i):
 
 
 func clear_all_floors():
+	loaded_parcels_floors.clear()
 	if base_floor_multimesh and base_floor_multimesh.multimesh:
 		base_floor_multimesh.multimesh.instance_count = 0
-		loaded_parcels_floors.clear()


### PR DESCRIPTION
## Summary

Two unrelated visual regressions, most visible in Genesis Plaza and other realms with many parcels. Both fixes are config-only / GDScript only — no Rust changes.

### 1. World stuck in shadow — DirectionalLight animation not applying

`sky_lights.tscn` had the `AnimationPlayer.libraries` property serialized as:

\`\`\`gdscript
libraries/ = SubResource(\"AnimationLibrary_local\")
\`\`\`

The trailing-slash form with no library name after it is not a valid indexed-property write in Godot 4's tscn parser, so the library was silently never registered on the AnimationPlayer.

Downstream effects in `sky_base.gd`:
- `anim_player.play(\"light_cycle\")` failed silently (animation not found).
- `anim_player.seek(skybox_time, true)` had nothing to apply.
- `MainLight` stayed in its default identity rotation (`basis.z = (0, 0, 1)`, light pointing horizontally along -Z).
- The elevation-based energy gate

  \`\`\`gdscript
  var elevation = -light_dir.y  # = 0 for horizontal light
  var energy_factor = smoothstep(-0.05, 0.3, elevation)  # → 0.055
  main_light.light_energy = initial_sun_energy * energy_factor  # → ~5%
  \`\`\`

  capped the sun light at ~5% energy regardless of skybox_time.

The whole world looked like permanent dusk/eclipse. Reproducible on every spawn after #1890.

**Fix:** restore the original dictionary form:

\`\`\`gdscript
libraries = {
\"\": SubResource(\"AnimationLibrary_local\")
}
\`\`\`

Regression introduced by #1890 (\"generate unique_id for all scenes\"), which auto-rewrote the libraries property to the broken syntax across multiple tscn files. This PR only touches `sky_lights.tscn`; if other scenes are affected they should be audited separately.

### 2. \"Huge red triangles smeared across the screen\" — BaseFloorMultimesh index drift

`base_floor_manager.gd:remove_scene_floors` compacted the `BaseFloorMultimesh` in place:

1. Capture transforms of every other-scene slot via `get_instance_transform(old_idx)`.
2. Shrink `multimesh.instance_count` to the new total.
3. Write captured transforms back via `set_instance_transform(new_idx, …)`, advancing a parallel `new_idx` counter.

The two iteration passes over `loaded_parcels_floors` (Dictionary) and its nested per-scene index arrays had to stay aligned for the captured-transform-to-new-slot mapping to be correct. Under repeated add/remove churn — easiest to repro by walking from a large scene (raft, ~2500 parcels) back to Genesis Plaza — the indices drifted, leaving multimesh slots with either stale transforms (a previous scene's parcel-local origin) or post-shrink default basis. Those slots rendered the 16×16m floor quad at unintended world positions/orientations.

The floor mesh uses the same grass-shaded material as the terrain. The visible artifact was hundreds of huge bordó-coloured triangles smeared across the screen whenever the player moved between scenes of different sizes.

**Fix:** rewrite `remove_scene_floors` (and `add_scene_floors`) so that `loaded_parcels_floors` stores the source `Array[Vector2i]` parcel list per scene_id (not slot indices). A new `_rebuild_multimesh()` helper sets `multimesh.instance_count` to the live total and writes every transform from scratch from those parcel coordinates. No `get_instance_transform` round-trips, no index re-mapping, no risk of stale slots.

## Test plan

- [x] Cold launch → spawn looks normally lit (sun energy, shadows, etc.). Before this PR the world was in permanent shadow.
- [ ] In a realm with many parcels (Genesis Plaza), walk to a large scene then back. Before this PR, transitioning out of a 50×50-style scene produced hundreds of huge bordó triangles; with this PR the base floor stays clean across transitions.
- [ ] Reload a scene (Esc → reload) and confirm the floor under the player remains in place.
- [ ] Switch realms and confirm `BaseFloorMultimesh` instance_count tracks the loaded scenes (no leaked floors from the previous realm).