### PR TITLE
revert: HIDE_AVATARS should not disable passport (hotfix for #2044)

### DIFF
--- a/godot/src/decentraland_components/avatar/avatar.gd
+++ b/godot/src/decentraland_components/avatar/avatar.gd
@@ -264,7 +264,6 @@ func _on_set_avatar_modifier_area(area: DclAvatarModifierArea3D):
 			hide()
 			_hide_impostor_render()
 			_set_click_area_enabled(false)
-			passport_disabled = true
 		elif modifier == 1:  # disable passport
 			passport_disabled = true
 


### PR DESCRIPTION
## Summary
Hotfix for #2044. That PR correctly disabled the click-area collider when `HIDE_AVATARS` modifier is active (so users can't click invisible avatars and open their profile), but it also set `passport_disabled = true` in the same branch. That was wrong: `passport_disabled` is the state for the separate `DISABLE_PASSPORT` modifier (modifier == 1) and conflating the two changes the semantics of `HIDE_AVATARS`.

The click-area disable already prevents profile-opening on hidden avatars, so the extra flag was both redundant and semantically incorrect.

## What changed
- Remove `passport_disabled = true` from the `HIDE_AVATARS` (modifier == 0) branch in `_on_set_avatar_modifier_area`.
- Keep the `_set_click_area_enabled(false)` line from #2044 — that's the real fix.

## Test plan
- [ ] Enter an area with `HIDE_AVATARS`: avatars are invisible and clicking where they stand does not open a passport (still works via click-area being disabled).
- [ ] Leave the area: avatars reappear and become clickable again.
- [ ] Enter an area with `DISABLE_PASSPORT` only: avatars are still visible, but clicking them does not open the passport.
- [ ] Blocked/muted avatars (via `set_hidden(true)`) remain non-clickable regardless of modifier areas.