### PR TITLE
revert: HIDE_AVATARS should not disable passport (cherry-pick #2096)

### DIFF
--- a/godot/src/decentraland_components/avatar/avatar.gd
+++ b/godot/src/decentraland_components/avatar/avatar.gd
@@ -264,7 +264,6 @@ func _on_set_avatar_modifier_area(area: DclAvatarModifierArea3D):
 			hide()
 			_hide_impostor_render()
 			_set_click_area_enabled(false)
-			passport_disabled = true
 		elif modifier == 1:  # disable passport
 			passport_disabled = true
 


### PR DESCRIPTION
Cherry-pick of #2096 onto `release`.

## Summary
#2044 disabled the click-area collider on `HIDE_AVATARS` (correct) but also set `passport_disabled = true` in the same branch, conflating it with the separate `DISABLE_PASSPORT` modifier. The click-area disable already blocks profile-opening on hidden avatars, so the flag was redundant and semantically wrong.

This cherry-pick keeps the click-area fix from #2044 and removes only the incorrect `passport_disabled = true` line.

## Test plan
- [ ] `HIDE_AVATARS` area: avatars invisible, clicks don't open passport.
- [ ] Leaving the area: avatars reappear and become clickable.
- [ ] `DISABLE_PASSPORT` only: avatars visible, clicks don't open passport.
- [ ] Blocked/muted avatars (via `set_hidden(true)`) remain non-clickable.