### PR TITLE
bump version v67 and iOS short_version to 1.6

### DIFF
--- a/godot/export_presets.cfg
+++ b/godot/export_presets.cfg
@@ -38,7 +38,7 @@ architectures/armeabi-v7a=false
 architectures/arm64-v8a=true
 architectures/x86=false
 architectures/x86_64=true
-version/code=66
+version/code=67
 version/name="1.0"
 package/unique_name="org.decentraland.godotexplorer"
 package/name="Decentraland"
@@ -292,8 +292,8 @@ application/provisioning_profile_specifier_release=""
 application/export_method_release=1
 application/bundle_identifier="org.decentraland.godotexplorer"
 application/signature=""
-application/short_version="1.5"
-application/version="66"
+application/short_version="1.6"
+application/version="67"
 application/additional_plist_content="	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>


### PR DESCRIPTION
## Summary
- Bump Android `version/code` from 66 to 67
- Bump iOS `application/short_version` from 1.5 to 1.6 and `application/version` (build) from 66 to 67

## Test plan
- [ ] Verify Android export produces an APK/AAB with versionCode 67
- [ ] Verify iOS export produces an IPA with CFBundleShortVersionString 1.6 and CFBundleVersion 67