### PR TITLE
feat: jump in on FTUE card tap

### DIFF
--- a/godot/src/ui/components/snap_carousel/ftue_screen.gd
+++ b/godot/src/ui/components/snap_carousel/ftue_screen.gd
@@ -19,6 +19,7 @@ var _places: Array[Dictionary] = []
 
 func _ready() -> void:
 	carousel.card_changed.connect(_on_card_changed)
+	carousel.card_tapped.connect(_on_card_tapped)
 	carousel.all_cards_loaded.connect(_on_all_cards_loaded)
 	carousel.items_loaded.connect(_on_items_loaded)
 	button_jump_in.pressed.connect(_on_button_jump_in_pressed)
@@ -59,6 +60,10 @@ func _on_card_changed(index: int) -> void:
 	if creator.is_empty():
 		creator = place.get("owner", "")
 	label_creator.text = creator
+
+
+func _on_card_tapped(_index: int) -> void:
+	_on_button_jump_in_pressed()
 
 
 func _on_button_jump_in_pressed() -> void:

--- a/godot/src/ui/components/snap_carousel/snap_carousel.gd
+++ b/godot/src/ui/components/snap_carousel/snap_carousel.gd
@@ -3,6 +3,7 @@ class_name SnapCarousel
 extends VBoxContainer
 
 signal card_changed(index: int)
+signal card_tapped(index: int)
 signal all_cards_loaded
 signal items_loaded(places: Array[Dictionary])
 
@@ -252,6 +253,7 @@ func _gui_input(event: InputEvent) -> void:
 				_on_touch_released()
 				accept_event()
 			else:
+				card_tapped.emit(selected_index)
 				_restart_auto_scroll()
 			_is_touching = false
 			_is_dragging = false

--- a/godot/src/ui/components/snap_carousel/snap_carousel_card.gd
+++ b/godot/src/ui/components/snap_carousel/snap_carousel_card.gd
@@ -22,6 +22,7 @@ var _card_index: int = 0
 
 var _touch_start: Vector2 = Vector2.ZERO
 var _touch_active: bool = false
+var _scroll_detected: bool = false
 
 @onready var async_image: AsyncImage = %AsyncImage
 @onready var button_jump_in: Button = %Button_JumpIn_Banner
@@ -31,6 +32,15 @@ func _ready() -> void:
 	button_jump_in.pressed.connect(_do_banner_jump_in)
 	async_image.image_loaded.connect(func(): image_loaded.emit())
 	_update_jump_in_visibility()
+
+
+func _input(event: InputEvent) -> void:
+	if event is InputEventScreenTouch and event.pressed:
+		_scroll_detected = false
+		_touch_start = event.position
+	elif event is InputEventScreenDrag:
+		if not _scroll_detected and event.position.distance_to(_touch_start) >= TAP_THRESHOLD:
+			_scroll_detected = true
 
 
 func _gui_input(event: InputEvent) -> void:
@@ -51,7 +61,7 @@ func _gui_input(event: InputEvent) -> void:
 
 
 func _do_banner_jump_in() -> void:
-	if _data.is_empty():
+	if _data.is_empty() or _scroll_detected:
 		return
 	(
 		Global


### PR DESCRIPTION
Closes #2107
Closes #2103 

## Summary

- Tapping a card in the FTUE carousel now triggers the same jump-in flow as the "Jump In" button (teleport + metrics tracking + FTUE completion)
- A new `card_tapped` signal is emitted by `SnapCarousel` when a touch ends without dragging
- The scroll/tap distinction relies on the existing drag threshold (20px): `_is_dragging` is only set to `true` when the finger moves more than 20px horizontally, so any touch that stays within that range is treated as a tap. This prevents accidental jump-ins while scrolling through cards
- Fixed the banner "Jump In" button firing during scroll: the button captures touch input before the carousel, so dragging from the button would trigger `pressed` on release even after scrolling. Now the card tracks all touch events via `_input` and sets a `_scroll_detected` flag when drag exceeds the tap threshold (20px). `_do_banner_jump_in` checks this flag and bails out if scrolling occurred

## Changes

- `snap_carousel.gd`: added `card_tapped(index)` signal, emitted on touch release when no drag occurred
- `ftue_screen.gd`: connected `card_tapped` to call `_on_button_jump_in_pressed()`, reusing the full jump-in logic
- `snap_carousel_card.gd`: added `_scroll_detected` flag tracked via `_input` to prevent the banner jump-in button from triggering when the user is scrolling