### PR TITLE
fix(hud): disable safe-area top/bottom margins on HUD container

### DIFF
--- a/godot/src/ui/explorer.gd
+++ b/godot/src/ui/explorer.gd
@@ -76,7 +76,6 @@ var _debug_panel_from_settings: bool = false
 @onready var world: Node3D = %world
 
 @onready var timer_broadcast_position: Timer = %Timer_BroadcastPosition
-@onready var safe_margin_container_hud: SafeMarginContainer = %SafeMarginContainerHUD
 
 @onready var navbar: Control = %Navbar
 @onready var joypad: Control = %Joypad

--- a/godot/src/ui/explorer.tscn
+++ b/godot/src/ui/explorer.tscn
@@ -180,7 +180,7 @@ grow_horizontal = 2
 grow_vertical = 2
 mouse_filter = 2
 
-[node name="SafeMarginContainerHUD" type="MarginContainer" parent="UI" unique_id=1210894567]
+[node name="LeftRightSafeContainer" type="MarginContainer" parent="UI" unique_id=1210894567]
 unique_name_in_owner = true
 layout_mode = 1
 anchors_preset = 15
@@ -194,11 +194,11 @@ script = ExtResource("5_c8ksg")
 use_top = false
 use_bottom = false
 
-[node name="InteractableHUD" type="Control" parent="UI/SafeMarginContainerHUD" unique_id=1898741314]
+[node name="InteractableHUD" type="Control" parent="UI/LeftRightSafeContainer" unique_id=1898741314]
 layout_mode = 2
 mouse_filter = 2
 
-[node name="MobileUI" type="Control" parent="UI/SafeMarginContainerHUD/InteractableHUD" unique_id=1539864390]
+[node name="MobileUI" type="Control" parent="UI/LeftRightSafeContainer/InteractableHUD" unique_id=1539864390]
 unique_name_in_owner = true
 layout_mode = 1
 anchors_preset = 15
@@ -208,23 +208,35 @@ grow_horizontal = 2
 grow_vertical = 2
 mouse_filter = 2
 
-[node name="Joypad" parent="UI/SafeMarginContainerHUD/InteractableHUD/MobileUI" unique_id=275799521 instance=ExtResource("7_admxk")]
+[node name="Joypad" parent="UI/LeftRightSafeContainer/InteractableHUD/MobileUI" unique_id=275799521 instance=ExtResource("7_admxk")]
 unique_name_in_owner = true
 editor_description = "Action buttons, to jump and interact."
 layout_mode = 1
 
-[node name="VirtualJoystick_Left" parent="UI/SafeMarginContainerHUD/InteractableHUD/MobileUI" unique_id=858042680 node_paths=PackedStringArray("margin_control") instance=ExtResource("9_lxw33")]
+[node name="VirtualJoystick_Left" parent="UI/LeftRightSafeContainer/InteractableHUD/MobileUI" unique_id=858042680 node_paths=PackedStringArray("margin_control") instance=ExtResource("9_lxw33")]
 unique_name_in_owner = true
 editor_description = "Virtual joystick to control avatar movement."
 layout_mode = 1
 deadzone_size = 0.0
 margin_control = NodePath("../../..")
 
-[node name="ChatPanel" parent="UI/SafeMarginContainerHUD/InteractableHUD" unique_id=1855059198 instance=ExtResource("9_chatpanel")]
-unique_name_in_owner = true
+[node name="TopBottomSafeContainer" type="MarginContainer" parent="UI/LeftRightSafeContainer/InteractableHUD" unique_id=1437253374]
 layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("5_c8ksg")
+use_left = false
+use_right = false
+metadata/_custom_type_script = "uid://bhwm0bl5qoiph"
 
-[node name="HBoxContainer_RightPanels" type="HBoxContainer" parent="UI/SafeMarginContainerHUD/InteractableHUD" unique_id=2005524203]
+[node name="ChatPanel" parent="UI/LeftRightSafeContainer/InteractableHUD/TopBottomSafeContainer" unique_id=1855059198 instance=ExtResource("9_chatpanel")]
+unique_name_in_owner = true
+layout_mode = 2
+
+[node name="HBoxContainer_RightPanels" type="HBoxContainer" parent="UI/LeftRightSafeContainer/InteractableHUD" unique_id=2005524203]
 unique_name_in_owner = true
 layout_mode = 1
 anchors_preset = 15
@@ -237,52 +249,52 @@ theme_override_constants/separation = 0
 alignment = 2
 metadata/_edit_lock_ = true
 
-[node name="MarginContainer" type="MarginContainer" parent="UI/SafeMarginContainerHUD/InteractableHUD/HBoxContainer_RightPanels" unique_id=1719818041]
+[node name="MarginContainer" type="MarginContainer" parent="UI/LeftRightSafeContainer/InteractableHUD/HBoxContainer_RightPanels" unique_id=1719818041]
 layout_mode = 2
 mouse_filter = 2
 theme_override_constants/margin_top = 16
 theme_override_constants/margin_bottom = 16
 
-[node name="VBoxContainer_RightPanels" type="VBoxContainer" parent="UI/SafeMarginContainerHUD/InteractableHUD/HBoxContainer_RightPanels/MarginContainer" unique_id=1190000788]
+[node name="VBoxContainer_RightPanels" type="VBoxContainer" parent="UI/LeftRightSafeContainer/InteractableHUD/HBoxContainer_RightPanels/MarginContainer" unique_id=1190000788]
 custom_minimum_size = Vector2(370, 0)
 layout_mode = 2
 mouse_filter = 2
 
-[node name="NotificationsPanel" parent="UI/SafeMarginContainerHUD/InteractableHUD/HBoxContainer_RightPanels/MarginContainer/VBoxContainer_RightPanels" unique_id=1351118609 instance=ExtResource("14_notif_panel")]
+[node name="NotificationsPanel" parent="UI/LeftRightSafeContainer/InteractableHUD/HBoxContainer_RightPanels/MarginContainer/VBoxContainer_RightPanels" unique_id=1351118609 instance=ExtResource("14_notif_panel")]
 unique_name_in_owner = true
 visible = false
 custom_minimum_size = Vector2(450, 500)
 layout_mode = 2
 size_flags_vertical = 3
 
-[node name="FriendsPanel" parent="UI/SafeMarginContainerHUD/InteractableHUD/HBoxContainer_RightPanels/MarginContainer/VBoxContainer_RightPanels" unique_id=644859130 instance=ExtResource("21_cwgs4")]
+[node name="FriendsPanel" parent="UI/LeftRightSafeContainer/InteractableHUD/HBoxContainer_RightPanels/MarginContainer/VBoxContainer_RightPanels" unique_id=644859130 instance=ExtResource("21_cwgs4")]
 unique_name_in_owner = true
 layout_mode = 2
 
-[node name="SettingsPanel" type="PanelContainer" parent="UI/SafeMarginContainerHUD/InteractableHUD/HBoxContainer_RightPanels/MarginContainer/VBoxContainer_RightPanels" unique_id=580837958]
+[node name="SettingsPanel" type="PanelContainer" parent="UI/LeftRightSafeContainer/InteractableHUD/HBoxContainer_RightPanels/MarginContainer/VBoxContainer_RightPanels" unique_id=580837958]
 unique_name_in_owner = true
 custom_minimum_size = Vector2(640, 0)
 layout_mode = 2
 size_flags_vertical = 3
 theme_override_styles/panel = SubResource("StyleBoxFlat_settings_bg")
 
-[node name="MarginContainer" type="MarginContainer" parent="UI/SafeMarginContainerHUD/InteractableHUD/HBoxContainer_RightPanels/MarginContainer/VBoxContainer_RightPanels/SettingsPanel" unique_id=1052710726]
+[node name="MarginContainer" type="MarginContainer" parent="UI/LeftRightSafeContainer/InteractableHUD/HBoxContainer_RightPanels/MarginContainer/VBoxContainer_RightPanels/SettingsPanel" unique_id=1052710726]
 layout_mode = 2
 theme_override_constants/margin_top = 28
 
-[node name="Settings" parent="UI/SafeMarginContainerHUD/InteractableHUD/HBoxContainer_RightPanels/MarginContainer/VBoxContainer_RightPanels/SettingsPanel/MarginContainer" unique_id=61276201 instance=ExtResource("33_settings")]
+[node name="Settings" parent="UI/LeftRightSafeContainer/InteractableHUD/HBoxContainer_RightPanels/MarginContainer/VBoxContainer_RightPanels/SettingsPanel/MarginContainer" unique_id=61276201 instance=ExtResource("33_settings")]
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
 panel_mode = true
 
-[node name="VSeparator" type="VSeparator" parent="UI/SafeMarginContainerHUD/InteractableHUD/HBoxContainer_RightPanels" unique_id=834468868]
+[node name="VSeparator" type="VSeparator" parent="UI/LeftRightSafeContainer/InteractableHUD/HBoxContainer_RightPanels" unique_id=834468868]
 layout_mode = 2
 mouse_filter = 2
 theme_override_constants/separation = 117
 theme_override_styles/separator = SubResource("StyleBoxEmpty_c5h7v")
 
-[node name="HBoxContainer_VersionFPS" type="HBoxContainer" parent="UI/SafeMarginContainerHUD/InteractableHUD" unique_id=193054843]
+[node name="HBoxContainer_VersionFPS" type="HBoxContainer" parent="UI/LeftRightSafeContainer/InteractableHUD" unique_id=193054843]
 layout_mode = 1
 anchors_preset = 7
 anchor_left = 0.5
@@ -296,7 +308,7 @@ offset_bottom = -8.0
 grow_horizontal = 2
 grow_vertical = 0
 
-[node name="Label_Version" type="Label" parent="UI/SafeMarginContainerHUD/InteractableHUD/HBoxContainer_VersionFPS" unique_id=2080384115]
+[node name="Label_Version" type="Label" parent="UI/LeftRightSafeContainer/InteractableHUD/HBoxContainer_VersionFPS" unique_id=2080384115]
 unique_name_in_owner = true
 layout_mode = 2
 theme_override_colors/font_color = Color(1, 1, 1, 0.705882)
@@ -305,7 +317,7 @@ theme_override_constants/outline_size = 4
 theme_override_font_sizes/font_size = 12
 text = "v0.1.0-alpha-abcd1f"
 
-[node name="Label_FPS" type="Label" parent="UI/SafeMarginContainerHUD/InteractableHUD/HBoxContainer_VersionFPS" unique_id=1795956625]
+[node name="Label_FPS" type="Label" parent="UI/LeftRightSafeContainer/InteractableHUD/HBoxContainer_VersionFPS" unique_id=1795956625]
 unique_name_in_owner = true
 layout_mode = 2
 theme_override_colors/font_color = Color(1, 1, 1, 0.705882)
@@ -314,7 +326,7 @@ theme_override_constants/outline_size = 4
 theme_override_font_sizes/font_size = 12
 text = "FPS"
 
-[node name="Label_RAM" type="Label" parent="UI/SafeMarginContainerHUD/InteractableHUD" unique_id=1299140060]
+[node name="Label_RAM" type="Label" parent="UI/LeftRightSafeContainer/InteractableHUD" unique_id=1299140060]
 unique_name_in_owner = true
 layout_mode = 1
 anchors_preset = 7
@@ -334,7 +346,7 @@ theme_override_font_sizes/font_size = 12
 horizontal_alignment = 1
 vertical_alignment = 1
 
-[node name="EmoteWheel" parent="UI/SafeMarginContainerHUD/InteractableHUD" unique_id=228992295 instance=ExtResource("21_pows0")]
+[node name="EmoteWheel" parent="UI/LeftRightSafeContainer/InteractableHUD" unique_id=228992295 instance=ExtResource("21_pows0")]
 unique_name_in_owner = true
 layout_mode = 1
 
@@ -436,12 +448,12 @@ script = ExtResource("20_064cw")
 
 [node name="ChatHandler" parent="." unique_id=440307884 instance=ExtResource("32_cq187")]
 
-[connection signal="load_scenes_pressed" from="UI/SafeMarginContainerHUD/InteractableHUD/ChatPanel" to="." method="_on_button_load_scenes_pressed"]
-[connection signal="share_place" from="UI/SafeMarginContainerHUD/InteractableHUD/ChatPanel" to="." method="_share_place"]
-[connection signal="submit_message" from="UI/SafeMarginContainerHUD/InteractableHUD/ChatPanel" to="." method="_on_panel_chat_submit_message"]
-[connection signal="gui_input" from="UI/SafeMarginContainerHUD/InteractableHUD/HBoxContainer_RightPanels" to="." method="_on_h_box_container_right_panels_gui_input"]
-[connection signal="emote_wheel_closed" from="UI/SafeMarginContainerHUD/InteractableHUD/EmoteWheel" to="." method="_on_emote_wheel_emote_wheel_closed"]
-[connection signal="emote_wheel_opened" from="UI/SafeMarginContainerHUD/InteractableHUD/EmoteWheel" to="." method="_on_emote_wheel_emote_wheel_opened"]
+[connection signal="load_scenes_pressed" from="UI/LeftRightSafeContainer/InteractableHUD/TopBottomSafeContainer/ChatPanel" to="." method="_on_button_load_scenes_pressed"]
+[connection signal="share_place" from="UI/LeftRightSafeContainer/InteractableHUD/TopBottomSafeContainer/ChatPanel" to="." method="_share_place"]
+[connection signal="submit_message" from="UI/LeftRightSafeContainer/InteractableHUD/TopBottomSafeContainer/ChatPanel" to="." method="_on_panel_chat_submit_message"]
+[connection signal="gui_input" from="UI/LeftRightSafeContainer/InteractableHUD/HBoxContainer_RightPanels" to="." method="_on_h_box_container_right_panels_gui_input"]
+[connection signal="emote_wheel_closed" from="UI/LeftRightSafeContainer/InteractableHUD/EmoteWheel" to="." method="_on_emote_wheel_emote_wheel_closed"]
+[connection signal="emote_wheel_opened" from="UI/LeftRightSafeContainer/InteractableHUD/EmoteWheel" to="." method="_on_emote_wheel_emote_wheel_opened"]
 [connection signal="timeout" from="UI/Timer_FPSLabel" to="." method="_on_timer_fps_label_timeout"]
 [connection signal="hide_menu" from="UI/Control_Menu" to="." method="_on_control_menu_hide_menu"]
 [connection signal="jump_to" from="UI/Control_Menu" to="." method="_on_control_menu_jump_to"]

--- a/godot/src/ui/explorer.tscn
+++ b/godot/src/ui/explorer.tscn
@@ -189,7 +189,10 @@ anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
 mouse_filter = 2
+theme_override_constants/margin_top = 0
 script = ExtResource("5_c8ksg")
+use_top = false
+use_bottom = false
 
 [node name="InteractableHUD" type="Control" parent="UI/SafeMarginContainerHUD" unique_id=1898741314]
 layout_mode = 2

--- a/godot/src/ui/explorer.tscn
+++ b/godot/src/ui/explorer.tscn
@@ -227,6 +227,7 @@ anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
+mouse_filter = 2
 script = ExtResource("5_c8ksg")
 use_left = false
 use_right = false


### PR DESCRIPTION
## Summary
- Restore `use_top=false` / `use_bottom=false` (and force `margin_top=0`) on `UI/SafeMarginContainerHUD` in `explorer.tscn`.
- Fixes a regression introduced in #1894 ("feat: chat system rework — portrait/landscape support", shipped in v66 / iOS 1.5): the HUD subtree was restructured and the two `use_*` overrides were dropped, so since 1.5 the HUD has been inset by device safe-area on top and bottom (notch / home indicator), pushing joypad, chat, right panels, version/FPS labels and emote wheel away from the screen edges.
- Brings this container back in line with iOS 1.4 behavior and with the other `SafeMarginContainer` nodes in the same scene that already set `use_top=false` / `use_bottom=false`.

## Regression source
- Last good: `4be0648d7a` (iOS 1.4 bump) — `SafeMarginContainerHUD` had `use_top=false`, `use_bottom=false`.
- Broken in: `e4a4f2d20e` (#1894, v66 / iOS 1.5) — node was restructured, properties dropped.

## Test plan
- [ ] Launch on a notched iOS device, confirm joypad/chat/right-panel stack extend to the edges as in 1.4.
- [ ] Confirm Android and desktop HUD layouts are unchanged (safe-area insets are 0 there, so no visual delta expected).
- [ ] Confirm `SafeMarginContainer` instances that still need safe-area padding (settings/discover/friends panels) are unaffected.