### PR TITLE
fix: chat state reset on loading finish + auto-scroll on mode switch

### DIFF
--- a/godot/src/ui/components/chat/chat_panel.gd
+++ b/godot/src/ui/components/chat/chat_panel.gd
@@ -122,11 +122,13 @@ func _on_panel_chat_on_exit_chat() -> void:
 func _on_chat_enter_write_mode() -> void:
 	_apply_writing_state()
 	Global.chat_write_mode_changed.emit(true)
+	chat.scroll_to_bottom_deferred()
 
 
 func _on_chat_exit_write_mode() -> void:
 	_apply_open_state()
 	Global.chat_write_mode_changed.emit(false)
+	chat.scroll_to_bottom_deferred()
 
 
 func _on_panel_chat_submit_message(message: String) -> void:

--- a/godot/src/ui/components/loading_screen/loading_screen.gd
+++ b/godot/src/ui/components/loading_screen/loading_screen.gd
@@ -60,6 +60,7 @@ func enable_loading_screen():
 
 func async_hide_loading_screen_effect():
 	Global.close_navbar.emit()
+	Global.close_chat.emit()
 	debug_chronometer.lap("Finished loading scene")
 	Global.loading_finished.emit()
 	timer_check_progress_timeout.stop()


### PR DESCRIPTION
## Summary

- **Close chat when loading screen finishes**: `async_hide_loading_screen_effect()` was emitting `Global.close_navbar` but not `Global.close_chat`, so the chat panel was hidden but the chatbar button stayed pressed, showing the flip/rotate button instead of discover and share. Now emits `Global.close_chat` which resets the button state and restores the correct chatbar layout.
- **Auto-scroll chat on write/read mode switch**: When switching between write mode (keyboard open) and read mode (keyboard closed), the message list was not scrolled to the bottom, leaving the user looking at old messages. Added `scroll_to_bottom_deferred()` on both transitions (WRITING → OPEN and OPEN → WRITING).

## Changes

- `loading_screen.gd`: added `Global.close_chat.emit()` in `async_hide_loading_screen_effect()`
- `chat_panel.gd`: added `chat.scroll_to_bottom_deferred()` in `_on_chat_enter_write_mode()` and `_on_chat_exit_write_mode()`

Closes #2109
Closes #2108