### PR TITLE
feat: apply PBPhysicsCombinedImpulse/Force to player (#1537)

### DIFF
--- a/godot/src/logic/player/player.gd
+++ b/godot/src/logic/player/player.gd
@@ -24,7 +24,15 @@ const GLIDE_CLOSING_TIME := 0.15
 # Mirrors Unity CharacterControllerSettings.CharacterMass so scenes tuned in
 # the Unity client feel the same here: Δv = vector / CHARACTER_MASS for an
 # impulse, a = vector / CHARACTER_MASS for a continuous force.
-const CHARACTER_MASS := 0.8
+const CHARACTER_MASS := 1.0
+# Linear viscous drag applied to external_velocity every frame. Mirrors Unity
+# ExternalEnvDrag (always active) + ExternalGroundFriction (added when grounded).
+const EXT_ENV_DRAG := 1.5
+const EXT_GROUND_FRICTION := 4.0
+# Hard ceiling on |external_velocity| — mirrors Unity MaxExternalVelocity.
+const MAX_EXTERNAL_VELOCITY := 50.0
+# Below this squared magnitude we snap external_velocity to zero (Unity uses 0.01²).
+const EXT_VELOCITY_EPSILON_SQR := 0.0001
 
 # Glide FSM values — mirror DclAvatar.glide_state and rfc4.Movement.GlideState.
 const GLIDE_CLOSED := 0
@@ -66,6 +74,11 @@ var current_direction: Vector3 = Vector3()
 
 var time_falling := 0.0
 var current_profile_version: int = -1
+
+# Persistent velocity vector accumulating PBPhysicsCombinedImpulse (instant Δv)
+# and PBPhysicsCombinedForce (acceleration · dt, XZ only — Y feeds gravity).
+# Decays via viscous drag every tick; mirrors Unity CharacterRigidTransform.ExternalVelocity.
+var external_velocity: Vector3 = Vector3.ZERO
 
 # Private variables (prefixed with _)
 var _hard_landing_timer: float = 0.0
@@ -253,6 +266,13 @@ func clamp_camera_rotation():
 
 
 func _physics_process(dt: float) -> void:
+	# Pull scene-driven physics once per tick. The vertical component of the
+	# external force has to feed the gravity step below (effective_gravity =
+	# gravity − accel.y) so it must be sampled BEFORE that block runs.
+	var scene_external_force: Vector3 = Global.scene_runner.get_active_external_force()
+	var scene_pending_impulses: PackedVector3Array = Global.scene_runner.consume_pending_impulses()
+	var external_acceleration: Vector3 = scene_external_force / CHARACTER_MASS
+
 	# Keep the top-level avatar co-located with the player (picks up teleports,
 	# external position changes, and ensures look_at below uses the correct origin)
 	avatar.global_position = global_position
@@ -356,7 +376,10 @@ func _physics_process(dt: float) -> void:
 		var free_flight: bool = glide_state == GLIDE_CLOSED or glide_state == GLIDE_CLOSING
 		avatar.rise = velocity.y > .3 and free_flight
 		avatar.fall = velocity.y < -.3 && !in_grace_time and free_flight
-		velocity.y -= gravity * dt
+		# Effective gravity folds in scene-driven vertical force (Unity ApplyGravity:
+		# effectiveGravity = gravity − ExternalAcceleration.y), so a wind-tunnel
+		# pushing up can cancel gravity instead of stacking on the body's velocity.
+		velocity.y -= (gravity - external_acceleration.y) * dt
 
 		# Air-jump: 0.2s hover then impulse (matches Unity ApplyJump two-step).
 		if (
@@ -493,30 +516,66 @@ func _physics_process(dt: float) -> void:
 	avatar.glide_state = glide_state
 	avatar.is_grounded = on_floor
 
-	_apply_scene_physics(dt)
+	_apply_scene_physics(dt, external_acceleration, scene_pending_impulses, on_floor)
+
+	# Mix external_velocity into CharacterBody3D.velocity for THIS frame's move.
+	# X/Z are recomputed each frame from movement input above so they need no
+	# undo; velocity.y persists between frames, so we restore it after the move
+	# to avoid double-counting the external Y contribution on the next gravity tick.
+	var external_y_for_move: float = external_velocity.y
+	velocity.x += external_velocity.x
+	velocity.y += external_y_for_move
+	velocity.z += external_velocity.z
 
 	last_position = global_position
 	move_and_slide()
 	position.y = max(position.y, 0)
 	avatar.global_position = global_position
 
+	# Restore velocity.y to its gravity-only state unless a vertical collision
+	# already flattened it (floor/ceiling). x/z are reset by locomotion next tick.
+	if not is_on_floor() and not is_on_ceiling():
+		velocity.y -= external_y_for_move
 
-# Apply scene-driven physics from PBPhysicsCombinedImpulse (one-shot) and
-# PBPhysicsCombinedForce (continuous). The scene_runner only emits these for
-# the current parcel scene, so scene-boundary gating happens on the Rust side.
-func _apply_scene_physics(dt: float) -> void:
-	var impulses: PackedVector3Array = Global.scene_runner.consume_pending_impulses()
+
+# Update persistent external_velocity from scene-driven PBPhysicsCombinedForce
+# (continuous acceleration on XZ only — Y is consumed by the gravity step) and
+# PBPhysicsCombinedImpulse (instant Δv on all three axes). Applies Unity-style
+# viscous drag and clamps to MAX_EXTERNAL_VELOCITY. The scene_runner only emits
+# these for the current parcel scene, so the boundary check lives on the Rust side.
+func _apply_scene_physics(
+	dt: float, external_acceleration: Vector3, impulses: PackedVector3Array, on_floor: bool
+) -> void:
+	# Force XZ accumulates into external_velocity. Force Y is NOT added here —
+	# it's already been folded into effective_gravity above (Unity ApplyGravity).
+	external_velocity.x += external_acceleration.x * dt
+	external_velocity.z += external_acceleration.z * dt
+
+	# Impulses: instant velocity delta on all three axes.
 	for impulse in impulses:
 		var delta_v: Vector3 = impulse / CHARACTER_MASS
 		# Mirror Unity: an upward impulse on a falling player clears the
 		# downward gravity component so jump pads launch reliably.
 		if delta_v.y > 0.0 and velocity.y < 0.0:
 			velocity.y = 0.0
-		velocity += delta_v
+		external_velocity += delta_v
 
-	var force: Vector3 = Global.scene_runner.get_active_external_force()
-	if force != Vector3.ZERO:
-		velocity += (force / CHARACTER_MASS) * dt
+	# Viscous drag — Unity ApplyExternalVelocityDragAndClamp: v *= (1 − damping·dt).
+	var damping := EXT_ENV_DRAG
+	if on_floor:
+		damping += EXT_GROUND_FRICTION
+	external_velocity *= maxf(0.0, 1.0 - damping * dt)
+
+	# No vertical residue when grounded so a landed-from-impulse player doesn't bounce.
+	if on_floor:
+		external_velocity.y = 0.0
+
+	# Snap small magnitudes to zero / clamp large ones to MAX_EXTERNAL_VELOCITY.
+	var sqr_mag: float = external_velocity.length_squared()
+	if sqr_mag < EXT_VELOCITY_EPSILON_SQR:
+		external_velocity = Vector3.ZERO
+	elif sqr_mag > MAX_EXTERNAL_VELOCITY * MAX_EXTERNAL_VELOCITY:
+		external_velocity = external_velocity.normalized() * MAX_EXTERNAL_VELOCITY
 
 
 func avatar_look_at(target_position: Vector3):

--- a/godot/src/logic/player/player.gd
+++ b/godot/src/logic/player/player.gd
@@ -518,6 +518,25 @@ func _physics_process(dt: float) -> void:
 
 	_apply_scene_physics(dt, external_acceleration, scene_pending_impulses, on_floor)
 
+	# Scene-driven physics (trampolines, knockback, wind lift) writes to
+	# external_velocity AFTER the rise/fall flags were chosen above. Without
+	# this override the avatar snaps to idle mid-bounce because velocity.y
+	# alone is reset each tick and only external_velocity.y carries the lift.
+	# Re-derive the animation state from the combined vertical velocity that's
+	# about to be passed to move_and_slide.
+	if external_velocity.length_squared() > 0.01:
+		var combined_vy: float = velocity.y + external_velocity.y
+		var free_flight: bool = glide_state == GLIDE_CLOSED or glide_state == GLIDE_CLOSING
+		if free_flight:
+			if combined_vy > 0.3:
+				avatar.rise = true
+				avatar.fall = false
+				avatar.land = false
+				avatar.is_grounded = false
+			elif combined_vy < -0.3:
+				avatar.fall = true
+				avatar.rise = false
+
 	# Mix external_velocity into CharacterBody3D.velocity for THIS frame's move.
 	# X/Z are recomputed each frame from movement input above so they need no
 	# undo; velocity.y persists between frames, so we restore it after the move

--- a/godot/src/logic/player/player.gd
+++ b/godot/src/logic/player/player.gd
@@ -552,22 +552,32 @@ func _apply_scene_physics(
 	external_velocity.z += external_acceleration.z * dt
 
 	# Impulses: instant velocity delta on all three axes.
+	var got_upward_impulse: bool = false
 	for impulse in impulses:
 		var delta_v: Vector3 = impulse / CHARACTER_MASS
-		# Mirror Unity: an upward impulse on a falling player clears the
-		# downward gravity component so jump pads launch reliably.
-		if delta_v.y > 0.0 and velocity.y < 0.0:
-			velocity.y = 0.0
+		if delta_v.y > 0.0:
+			got_upward_impulse = true
+			# Mirror Unity: an upward impulse on a falling player clears the
+			# downward gravity component so jump pads launch reliably.
+			if velocity.y < 0.0:
+				velocity.y = 0.0
 		external_velocity += delta_v
+
+	# Unity treats an upward impulse as ungrounding for the rest of this frame's
+	# physics step — otherwise the grounded-drag + zero-Y rules below would
+	# instantly cancel a jump-pad impulse applied while the player was on the
+	# floor. Mirror that effect via an effective_on_floor that fresh upward
+	# impulses can flip to false for one frame.
+	var effective_on_floor: bool = on_floor and not got_upward_impulse
 
 	# Viscous drag — Unity ApplyExternalVelocityDragAndClamp: v *= (1 − damping·dt).
 	var damping := EXT_ENV_DRAG
-	if on_floor:
+	if effective_on_floor:
 		damping += EXT_GROUND_FRICTION
 	external_velocity *= maxf(0.0, 1.0 - damping * dt)
 
 	# No vertical residue when grounded so a landed-from-impulse player doesn't bounce.
-	if on_floor:
+	if effective_on_floor:
 		external_velocity.y = 0.0
 
 	# Snap small magnitudes to zero / clamp large ones to MAX_EXTERNAL_VELOCITY.

--- a/godot/src/logic/player/player.gd
+++ b/godot/src/logic/player/player.gd
@@ -528,8 +528,11 @@ func _physics_process(dt: float) -> void:
 				avatar.fall = true
 				avatar.rise = false
 
-	# Add external_velocity to velocity for the move. X/Z get overwritten by
-	# locomotion next tick (no undo needed); Y persists, so we undo it below.
+	# Snapshot locomotion XZ so we can restore them after the move. Otherwise
+	# `move_toward` on the next no-input tick would decel from velocity-with-
+	# external stacked, and the external add would compound indefinitely.
+	var locomotion_x: float = velocity.x
+	var locomotion_z: float = velocity.z
 	var external_y_for_move: float = external_velocity.y
 	velocity.x += external_velocity.x
 	velocity.y += external_y_for_move
@@ -539,6 +542,11 @@ func _physics_process(dt: float) -> void:
 	move_and_slide()
 	position.y = max(position.y, 0)
 	avatar.global_position = global_position
+
+	# Restore locomotion-only XZ; external_velocity carries its own state and is
+	# re-added next frame.
+	velocity.x = locomotion_x
+	velocity.z = locomotion_z
 
 	# Restore velocity.y unless a floor/ceiling collision already zeroed it.
 	if not is_on_floor() and not is_on_ceiling():

--- a/godot/src/logic/player/player.gd
+++ b/godot/src/logic/player/player.gd
@@ -20,18 +20,16 @@ const GLIDE_COOLDOWN := 0.6
 const GLIDE_OPENING_TIME := 0.5
 const GLIDE_CLOSING_TIME := 0.15
 
-# Effective character mass for PBPhysicsCombinedImpulse/Force from scenes.
-# Mirrors Unity CharacterControllerSettings.CharacterMass so scenes tuned in
-# the Unity client feel the same here: Δv = vector / CHARACTER_MASS for an
-# impulse, a = vector / CHARACTER_MASS for a continuous force.
+# Character mass for scene-driven impulses/forces (matches Unity for tuning parity).
+# Δv = impulse / CHARACTER_MASS, a = force / CHARACTER_MASS.
 const CHARACTER_MASS := 1.0
-# Linear viscous drag applied to external_velocity every frame. Mirrors Unity
-# ExternalEnvDrag (always active) + ExternalGroundFriction (added when grounded).
+# Viscous drag on external_velocity each tick.
+# Total damping = ENV (always) + GROUND_FRICTION (when grounded).
 const EXT_ENV_DRAG := 1.5
 const EXT_GROUND_FRICTION := 4.0
-# Hard ceiling on |external_velocity| — mirrors Unity MaxExternalVelocity.
+# Hard ceiling on |external_velocity|.
 const MAX_EXTERNAL_VELOCITY := 50.0
-# Below this squared magnitude we snap external_velocity to zero (Unity uses 0.01²).
+# Snap external_velocity to zero below this squared magnitude.
 const EXT_VELOCITY_EPSILON_SQR := 0.0001
 
 # Glide FSM values — mirror DclAvatar.glide_state and rfc4.Movement.GlideState.
@@ -75,9 +73,8 @@ var current_direction: Vector3 = Vector3()
 var time_falling := 0.0
 var current_profile_version: int = -1
 
-# Persistent velocity vector accumulating PBPhysicsCombinedImpulse (instant Δv)
-# and PBPhysicsCombinedForce (acceleration · dt, XZ only — Y feeds gravity).
-# Decays via viscous drag every tick; mirrors Unity CharacterRigidTransform.ExternalVelocity.
+# Persistent velocity accumulating scene-driven impulses (full XYZ) and forces
+# (XZ only — force.y feeds gravity). Decays via drag each tick.
 var external_velocity: Vector3 = Vector3.ZERO
 
 # Private variables (prefixed with _)
@@ -266,9 +263,7 @@ func clamp_camera_rotation():
 
 
 func _physics_process(dt: float) -> void:
-	# Pull scene-driven physics once per tick. The vertical component of the
-	# external force has to feed the gravity step below (effective_gravity =
-	# gravity − accel.y) so it must be sampled BEFORE that block runs.
+	# Sample scene-driven physics before gravity — force.y feeds effective_gravity below.
 	var scene_external_force: Vector3 = Global.scene_runner.get_active_external_force()
 	var scene_pending_impulses: PackedVector3Array = Global.scene_runner.consume_pending_impulses()
 	var external_acceleration: Vector3 = scene_external_force / CHARACTER_MASS
@@ -376,9 +371,8 @@ func _physics_process(dt: float) -> void:
 		var free_flight: bool = glide_state == GLIDE_CLOSED or glide_state == GLIDE_CLOSING
 		avatar.rise = velocity.y > .3 and free_flight
 		avatar.fall = velocity.y < -.3 && !in_grace_time and free_flight
-		# Effective gravity folds in scene-driven vertical force (Unity ApplyGravity:
-		# effectiveGravity = gravity − ExternalAcceleration.y), so a wind-tunnel
-		# pushing up can cancel gravity instead of stacking on the body's velocity.
+		# Scene force.y reduces effective gravity, so an upward wind cancels
+		# fall instead of stacking on velocity.y.
 		velocity.y -= (gravity - external_acceleration.y) * dt
 
 		# Air-jump: 0.2s hover then impulse (matches Unity ApplyJump two-step).
@@ -518,12 +512,9 @@ func _physics_process(dt: float) -> void:
 
 	_apply_scene_physics(dt, external_acceleration, scene_pending_impulses, on_floor)
 
-	# Scene-driven physics (trampolines, knockback, wind lift) writes to
-	# external_velocity AFTER the rise/fall flags were chosen above. Without
-	# this override the avatar snaps to idle mid-bounce because velocity.y
-	# alone is reset each tick and only external_velocity.y carries the lift.
-	# Re-derive the animation state from the combined vertical velocity that's
-	# about to be passed to move_and_slide.
+	# Re-derive rise/fall from the combined vertical velocity: the lift from
+	# external_velocity isn't visible in velocity.y alone (we undo the Y mix
+	# below, so velocity.y reads near-zero mid-bounce).
 	if external_velocity.length_squared() > 0.01:
 		var combined_vy: float = velocity.y + external_velocity.y
 		var free_flight: bool = glide_state == GLIDE_CLOSED or glide_state == GLIDE_CLOSING
@@ -537,10 +528,8 @@ func _physics_process(dt: float) -> void:
 				avatar.fall = true
 				avatar.rise = false
 
-	# Mix external_velocity into CharacterBody3D.velocity for THIS frame's move.
-	# X/Z are recomputed each frame from movement input above so they need no
-	# undo; velocity.y persists between frames, so we restore it after the move
-	# to avoid double-counting the external Y contribution on the next gravity tick.
+	# Add external_velocity to velocity for the move. X/Z get overwritten by
+	# locomotion next tick (no undo needed); Y persists, so we undo it below.
 	var external_y_for_move: float = external_velocity.y
 	velocity.x += external_velocity.x
 	velocity.y += external_y_for_move
@@ -551,55 +540,45 @@ func _physics_process(dt: float) -> void:
 	position.y = max(position.y, 0)
 	avatar.global_position = global_position
 
-	# Restore velocity.y to its gravity-only state unless a vertical collision
-	# already flattened it (floor/ceiling). x/z are reset by locomotion next tick.
+	# Restore velocity.y unless a floor/ceiling collision already zeroed it.
 	if not is_on_floor() and not is_on_ceiling():
 		velocity.y -= external_y_for_move
 
 
-# Update persistent external_velocity from scene-driven PBPhysicsCombinedForce
-# (continuous acceleration on XZ only — Y is consumed by the gravity step) and
-# PBPhysicsCombinedImpulse (instant Δv on all three axes). Applies Unity-style
-# viscous drag and clamps to MAX_EXTERNAL_VELOCITY. The scene_runner only emits
-# these for the current parcel scene, so the boundary check lives on the Rust side.
+# Fold scene-driven force/impulses into external_velocity, then drag and clamp.
+# scene_runner only emits these for the current parcel scene.
 func _apply_scene_physics(
 	dt: float, external_acceleration: Vector3, impulses: PackedVector3Array, on_floor: bool
 ) -> void:
-	# Force XZ accumulates into external_velocity. Force Y is NOT added here —
-	# it's already been folded into effective_gravity above (Unity ApplyGravity).
+	# Force XZ accumulates; force Y was already folded into effective_gravity.
 	external_velocity.x += external_acceleration.x * dt
 	external_velocity.z += external_acceleration.z * dt
 
-	# Impulses: instant velocity delta on all three axes.
 	var got_upward_impulse: bool = false
 	for impulse in impulses:
 		var delta_v: Vector3 = impulse / CHARACTER_MASS
 		if delta_v.y > 0.0:
 			got_upward_impulse = true
-			# Mirror Unity: an upward impulse on a falling player clears the
-			# downward gravity component so jump pads launch reliably.
+			# Upward impulse on a falling player clears gravity so jump pads launch.
 			if velocity.y < 0.0:
 				velocity.y = 0.0
 		external_velocity += delta_v
 
-	# Unity treats an upward impulse as ungrounding for the rest of this frame's
-	# physics step — otherwise the grounded-drag + zero-Y rules below would
-	# instantly cancel a jump-pad impulse applied while the player was on the
-	# floor. Mirror that effect via an effective_on_floor that fresh upward
-	# impulses can flip to false for one frame.
+	# Treat an upward impulse as ungrounding for the rest of this tick, or the
+	# grounded drag + Y-zero below would cancel a jump-pad launch.
 	var effective_on_floor: bool = on_floor and not got_upward_impulse
 
-	# Viscous drag — Unity ApplyExternalVelocityDragAndClamp: v *= (1 − damping·dt).
+	# Viscous drag: v *= (1 - damping * dt).
 	var damping := EXT_ENV_DRAG
 	if effective_on_floor:
 		damping += EXT_GROUND_FRICTION
 	external_velocity *= maxf(0.0, 1.0 - damping * dt)
 
-	# No vertical residue when grounded so a landed-from-impulse player doesn't bounce.
+	# Zero Y when grounded so landings don't micro-bounce.
 	if effective_on_floor:
 		external_velocity.y = 0.0
 
-	# Snap small magnitudes to zero / clamp large ones to MAX_EXTERNAL_VELOCITY.
+	# Snap tiny magnitudes to zero, clamp large ones to MAX_EXTERNAL_VELOCITY.
 	var sqr_mag: float = external_velocity.length_squared()
 	if sqr_mag < EXT_VELOCITY_EPSILON_SQR:
 		external_velocity = Vector3.ZERO

--- a/godot/src/logic/player/player.gd
+++ b/godot/src/logic/player/player.gd
@@ -20,6 +20,12 @@ const GLIDE_COOLDOWN := 0.6
 const GLIDE_OPENING_TIME := 0.5
 const GLIDE_CLOSING_TIME := 0.15
 
+# Effective character mass for PBPhysicsCombinedImpulse/Force from scenes.
+# Mirrors Unity CharacterControllerSettings.CharacterMass so scenes tuned in
+# the Unity client feel the same here: Δv = vector / CHARACTER_MASS for an
+# impulse, a = vector / CHARACTER_MASS for a continuous force.
+const CHARACTER_MASS := 0.8
+
 # Glide FSM values — mirror DclAvatar.glide_state and rfc4.Movement.GlideState.
 const GLIDE_CLOSED := 0
 const GLIDE_OPENING := 1
@@ -487,10 +493,30 @@ func _physics_process(dt: float) -> void:
 	avatar.glide_state = glide_state
 	avatar.is_grounded = on_floor
 
+	_apply_scene_physics(dt)
+
 	last_position = global_position
 	move_and_slide()
 	position.y = max(position.y, 0)
 	avatar.global_position = global_position
+
+
+# Apply scene-driven physics from PBPhysicsCombinedImpulse (one-shot) and
+# PBPhysicsCombinedForce (continuous). The scene_runner only emits these for
+# the current parcel scene, so scene-boundary gating happens on the Rust side.
+func _apply_scene_physics(dt: float) -> void:
+	var impulses: PackedVector3Array = Global.scene_runner.consume_pending_impulses()
+	for impulse in impulses:
+		var delta_v: Vector3 = impulse / CHARACTER_MASS
+		# Mirror Unity: an upward impulse on a falling player clears the
+		# downward gravity component so jump pads launch reliably.
+		if delta_v.y > 0.0 and velocity.y < 0.0:
+			velocity.y = 0.0
+		velocity += delta_v
+
+	var force: Vector3 = Global.scene_runner.get_active_external_force()
+	if force != Vector3.ZERO:
+		velocity += (force / CHARACTER_MASS) * dt
 
 
 func avatar_look_at(target_position: Vector3):

--- a/lib/src/scene_runner/components/mod.rs
+++ b/lib/src/scene_runner/components/mod.rs
@@ -15,6 +15,7 @@ pub mod material;
 pub mod mesh_collider;
 pub mod mesh_renderer;
 pub mod nft_shape;
+pub mod physics_combined;
 pub mod pointer_events;
 pub mod raycast;
 pub mod realm_info;

--- a/lib/src/scene_runner/components/physics_combined.rs
+++ b/lib/src/scene_runner/components/physics_combined.rs
@@ -67,14 +67,15 @@ pub fn update_physics_combined_force(
     scene.active_external_force = new_force;
 }
 
-/// Reads `PBPhysicsCombinedImpulse` on the player entity and queues a new
-/// one-shot impulse when `event_id` advances.
+/// Reads `PBPhysicsCombinedImpulse` on the player entity and queues a one-shot
+/// impulse whenever the CRDT dirty set says the component changed this tick.
 ///
-/// Mirrors the Unity dirty-flag dedup: each `event_id` value is applied at most
-/// once. The first sighting of any `event_id` is always applied; subsequent
-/// values are only applied when `event_id` differs from `last_impulse_event_id`.
-/// Non-current scenes are ignored entirely so a scene can't push impulses to
-/// the player from outside its parcel boundary.
+/// Mirrors unity-explorer's `SDKExternalPhysicsSystems.ApplyPhysicsImpulse`,
+/// which gates on the per-write `IsDirty` flag and does **not** compare
+/// `event_id`. The `event_id` exists only to force CRDT to propagate a fresh
+/// write when the vector is identical — once CRDT delivers a write, it's a
+/// new impulse, full stop. Non-current scenes are ignored entirely so a scene
+/// can't push impulses to the player from outside its parcel boundary.
 pub fn update_physics_combined_impulse(
     scene: &mut Scene,
     crdt_state: &mut SceneCrdtState,
@@ -98,9 +99,8 @@ pub fn update_physics_combined_impulse(
     }
 
     tracing::debug!(
-        "physics_combined: impulse dirty on scene {:?} (last_event_id={:?})",
-        scene.scene_id,
-        scene.last_impulse_event_id,
+        "physics_combined: impulse dirty on scene {:?}",
+        scene.scene_id
     );
 
     let impulse_component = SceneCrdtStateProtoComponents::get_physics_combined_impulse(crdt_state);
@@ -120,14 +120,6 @@ pub fn update_physics_combined_impulse(
         return;
     };
 
-    if scene.last_impulse_event_id == Some(pb.event_id) {
-        tracing::debug!(
-            "physics_combined: dedup hit — event_id={} already applied",
-            pb.event_id
-        );
-        return;
-    }
-
     let godot_vec = scene_vec_to_godot(vector);
     tracing::debug!(
         "physics_combined: queue impulse event_id={} dcl=({:.3},{:.3},{:.3}) godot=({:.3},{:.3},{:.3})",
@@ -139,6 +131,5 @@ pub fn update_physics_combined_impulse(
         godot_vec.y,
         godot_vec.z,
     );
-    scene.last_impulse_event_id = Some(pb.event_id);
     scene.pending_impulses.push(godot_vec);
 }

--- a/lib/src/scene_runner/components/physics_combined.rs
+++ b/lib/src/scene_runner/components/physics_combined.rs
@@ -68,18 +68,17 @@ pub fn update_physics_combined_force(
 }
 
 /// Reads `PBPhysicsCombinedImpulse` on the player entity and queues a one-shot
-/// impulse the first time we observe each `event_id`.
+/// impulse for every CRDT write the scene makes to it.
 ///
-/// The protocol contract (see `physics_combined_impulse.proto`):
-///   "Renderer processes impulse with the unique ID only once.
-///    Increase eventID of the component to apply another impulse."
-///
-/// `event_id` carries both roles: it bypasses CRDT identity-dedup so the
-/// write propagates even when the vector is unchanged, **and** it's the
-/// renderer's dedup key. So we trust it: track the last applied id per
-/// scene, and ignore any tick that doesn't carry a new value. A scene/SDK
-/// that fails to bump `event_id` will (correctly per the protocol) only
-/// get the first impulse — that's an SDK bug to fix, not a renderer one.
+/// We deliberately mirror unity-explorer's `SDKExternalPhysicsSystems`, which
+/// gates on its per-write `IsDirty` flag and **does not read `event_id`**.
+/// The proto comment makes `event_id` sound load-bearing for renderer-side
+/// dedup, but the shipped Unity client ignores it — and production scenes
+/// like Genesis Plaza's `bouncePad.ts` rely on that, calling
+/// `PhysicsCombinedImpulse.createOrReplace(player, { eventId: 0, vector })`
+/// every trigger enter. To match the Unity behavior bar, we fire once per
+/// CRDT-dirty signal: `createOrReplace` (even with a stale `event_id`)
+/// produces one CRDT message → one renderer fire.
 pub fn update_physics_combined_impulse(
     scene: &mut Scene,
     crdt_state: &mut SceneCrdtState,
@@ -111,14 +110,6 @@ pub fn update_physics_combined_impulse(
         return;
     };
 
-    if scene.last_impulse_event_id == Some(pb.event_id) {
-        tracing::debug!(
-            "physics_combined: dedup hit — event_id={} already applied (scene expected to increment per protocol)",
-            pb.event_id
-        );
-        return;
-    }
-
     let godot_vec = scene_vec_to_godot(vector);
     tracing::debug!(
         "physics_combined: queue impulse event_id={} godot=({:.3},{:.3},{:.3})",
@@ -127,6 +118,5 @@ pub fn update_physics_combined_impulse(
         godot_vec.y,
         godot_vec.z,
     );
-    scene.last_impulse_event_id = Some(pb.event_id);
     scene.pending_impulses.push(godot_vec);
 }

--- a/lib/src/scene_runner/components/physics_combined.rs
+++ b/lib/src/scene_runner/components/physics_combined.rs
@@ -68,14 +68,17 @@ pub fn update_physics_combined_force(
 }
 
 /// Reads `PBPhysicsCombinedImpulse` on the player entity and queues a one-shot
-/// impulse whenever the CRDT dirty set says the component changed this tick.
+/// impulse whenever the observed `(event_id, vector)` differs from the last
+/// applied one.
 ///
-/// Mirrors unity-explorer's `SDKExternalPhysicsSystems.ApplyPhysicsImpulse`,
-/// which gates on the per-write `IsDirty` flag and does **not** compare
-/// `event_id`. The `event_id` exists only to force CRDT to propagate a fresh
-/// write when the vector is identical — once CRDT delivers a write, it's a
-/// new impulse, full stop. Non-current scenes are ignored entirely so a scene
-/// can't push impulses to the player from outside its parcel boundary.
+/// Background: the SDK publishes the impulse summary component every tick
+/// (CRDT dirty fires constantly), often with `event_id=0` and a static vector.
+/// Naively trusting "dirty" means stacking the same push every frame; naively
+/// trusting `event_id` means missing every press when the SDK never increments
+/// it. We follow the godot-explorer change-detection pattern used in
+/// `tween.rs` and `video_player.rs`: cache the full last-seen state and fire
+/// only when it changes. Zero vectors are treated as "no impulse" and never
+/// queued, but the cache still updates so the next non-zero write registers.
 pub fn update_physics_combined_impulse(
     scene: &mut Scene,
     crdt_state: &mut SceneCrdtState,
@@ -88,8 +91,6 @@ pub fn update_physics_combined_impulse(
         return;
     }
 
-    // Only react when the CRDT dirty set says this scene's impulse component
-    // changed this tick (avoids re-reading the same event every tick).
     let is_dirty = dirty_lww_components
         .get(&SceneComponentId::PHYSICS_COMBINED_IMPULSE)
         .is_some_and(|entities| entities.contains(&SceneEntityId::PLAYER));
@@ -98,35 +99,47 @@ pub fn update_physics_combined_impulse(
         return;
     }
 
-    tracing::debug!(
-        "physics_combined: impulse dirty on scene {:?}",
-        scene.scene_id
-    );
-
     let impulse_component = SceneCrdtStateProtoComponents::get_physics_combined_impulse(crdt_state);
     let Some(entry) = impulse_component.get(&SceneEntityId::PLAYER) else {
-        tracing::debug!("physics_combined: dirty but no LWW entry for PLAYER — skipping");
         return;
     };
     let Some(pb) = entry.value.as_ref() else {
-        tracing::debug!("physics_combined: dirty but entry.value is None — skipping");
-        return;
-    };
-    let Some(vector) = pb.vector.as_ref() else {
-        tracing::debug!(
-            "physics_combined: dirty but pb.vector is None (event_id={}) — skipping",
-            pb.event_id
-        );
         return;
     };
 
-    let godot_vec = scene_vec_to_godot(vector);
+    let godot_vec = pb
+        .vector
+        .as_ref()
+        .map(scene_vec_to_godot)
+        .unwrap_or(Vector3::ZERO);
+    let event_id = pb.event_id;
+    let current_state = (event_id, godot_vec);
+
+    let state_changed = scene
+        .last_impulse_state
+        .as_ref()
+        .is_none_or(|cached| *cached != current_state);
+    let is_zero_vector = godot_vec.length_squared() < f32::EPSILON;
+
+    scene.last_impulse_state = Some(current_state);
+
+    if !state_changed {
+        tracing::debug!(
+            "physics_combined: dedup hit — same (event_id={}, vec=({:.3},{:.3},{:.3})) as last applied",
+            event_id, godot_vec.x, godot_vec.y, godot_vec.z,
+        );
+        return;
+    }
+    if is_zero_vector {
+        tracing::debug!(
+            "physics_combined: state changed to zero — clearing cache, no impulse to queue"
+        );
+        return;
+    }
+
     tracing::debug!(
-        "physics_combined: queue impulse event_id={} dcl=({:.3},{:.3},{:.3}) godot=({:.3},{:.3},{:.3})",
-        pb.event_id,
-        vector.x,
-        vector.y,
-        vector.z,
+        "physics_combined: queue impulse event_id={} godot=({:.3},{:.3},{:.3})",
+        event_id,
         godot_vec.x,
         godot_vec.y,
         godot_vec.z,

--- a/lib/src/scene_runner/components/physics_combined.rs
+++ b/lib/src/scene_runner/components/physics_combined.rs
@@ -1,0 +1,103 @@
+use godot::builtin::Vector3;
+
+use crate::{
+    dcl::{
+        components::{proto_components, SceneComponentId, SceneEntityId},
+        crdt::{
+            last_write_wins::LastWriteWinsComponentOperation, SceneCrdtState,
+            SceneCrdtStateProtoComponents,
+        },
+        SceneId,
+    },
+    scene_runner::scene::Scene,
+};
+
+/// Convert a Decentraland scene `Vector3` to a Godot world `Vector3`.
+///
+/// Godot's Z axis is the negation of Decentraland's Z (see
+/// `DclTransformAndParent::to_godot_transform_3d`), so directions/vectors that
+/// originate in scene coordinates must have their Z component flipped before
+/// being applied to Godot nodes.
+fn scene_vec_to_godot(v: &proto_components::common::Vector3) -> Vector3 {
+    Vector3::new(v.x, v.y, -v.z)
+}
+
+/// Reads `PBPhysicsCombinedForce` on the player entity and stores the resulting
+/// continuous force on the scene so the player controller can sample it.
+///
+/// Force is only applied while the scene is the current parcel scene; for any
+/// other scene the stored value is reset to zero. The force vector is the
+/// summary of all per-frame forces accumulated by the scene's SDK code.
+pub fn update_physics_combined_force(
+    scene: &mut Scene,
+    crdt_state: &mut SceneCrdtState,
+    current_parcel_scene_id: &SceneId,
+) {
+    let is_current_parcel_scene = scene.scene_id == *current_parcel_scene_id;
+
+    if !is_current_parcel_scene {
+        // Discard any stale state so we don't leak forces from a scene the
+        // player just left. Mirrors Unity's `ResetExternalForce` on scene exit.
+        scene.active_external_force = Vector3::ZERO;
+        return;
+    }
+
+    let force_component = SceneCrdtStateProtoComponents::get_physics_combined_force(crdt_state);
+    let new_force = force_component
+        .get(&SceneEntityId::PLAYER)
+        .and_then(|entry| entry.value.as_ref())
+        .and_then(|pb| pb.vector.as_ref())
+        .map(scene_vec_to_godot)
+        .unwrap_or(Vector3::ZERO);
+
+    scene.active_external_force = new_force;
+}
+
+/// Reads `PBPhysicsCombinedImpulse` on the player entity and queues a new
+/// one-shot impulse when `event_id` advances.
+///
+/// Mirrors the Unity dirty-flag dedup: each `event_id` value is applied at most
+/// once. The first sighting of any `event_id` is always applied; subsequent
+/// values are only applied when `event_id` differs from `last_impulse_event_id`.
+/// Non-current scenes are ignored entirely so a scene can't push impulses to
+/// the player from outside its parcel boundary.
+pub fn update_physics_combined_impulse(
+    scene: &mut Scene,
+    crdt_state: &mut SceneCrdtState,
+    current_parcel_scene_id: &SceneId,
+) {
+    let dirty_lww_components = &scene.current_dirty.lww_components;
+    let is_current_parcel_scene = scene.scene_id == *current_parcel_scene_id;
+
+    if !is_current_parcel_scene {
+        return;
+    }
+
+    // Only react when the CRDT dirty set says this scene's impulse component
+    // changed this tick (avoids re-reading the same event every tick).
+    let is_dirty = dirty_lww_components
+        .get(&SceneComponentId::PHYSICS_COMBINED_IMPULSE)
+        .is_some_and(|entities| entities.contains(&SceneEntityId::PLAYER));
+
+    if !is_dirty {
+        return;
+    }
+
+    let impulse_component = SceneCrdtStateProtoComponents::get_physics_combined_impulse(crdt_state);
+    let Some(entry) = impulse_component.get(&SceneEntityId::PLAYER) else {
+        return;
+    };
+    let Some(pb) = entry.value.as_ref() else {
+        return;
+    };
+    let Some(vector) = pb.vector.as_ref() else {
+        return;
+    };
+
+    if scene.last_impulse_event_id == Some(pb.event_id) {
+        return;
+    }
+
+    scene.last_impulse_event_id = Some(pb.event_id);
+    scene.pending_impulses.push(scene_vec_to_godot(vector));
+}

--- a/lib/src/scene_runner/components/physics_combined.rs
+++ b/lib/src/scene_runner/components/physics_combined.rs
@@ -68,17 +68,18 @@ pub fn update_physics_combined_force(
 }
 
 /// Reads `PBPhysicsCombinedImpulse` on the player entity and queues a one-shot
-/// impulse whenever the observed `(event_id, vector)` differs from the last
-/// applied one.
+/// impulse the first time we observe each `event_id`.
 ///
-/// Background: the SDK publishes the impulse summary component every tick
-/// (CRDT dirty fires constantly), often with `event_id=0` and a static vector.
-/// Naively trusting "dirty" means stacking the same push every frame; naively
-/// trusting `event_id` means missing every press when the SDK never increments
-/// it. We follow the godot-explorer change-detection pattern used in
-/// `tween.rs` and `video_player.rs`: cache the full last-seen state and fire
-/// only when it changes. Zero vectors are treated as "no impulse" and never
-/// queued, but the cache still updates so the next non-zero write registers.
+/// The protocol contract (see `physics_combined_impulse.proto`):
+///   "Renderer processes impulse with the unique ID only once.
+///    Increase eventID of the component to apply another impulse."
+///
+/// `event_id` carries both roles: it bypasses CRDT identity-dedup so the
+/// write propagates even when the vector is unchanged, **and** it's the
+/// renderer's dedup key. So we trust it: track the last applied id per
+/// scene, and ignore any tick that doesn't carry a new value. A scene/SDK
+/// that fails to bump `event_id` will (correctly per the protocol) only
+/// get the first impulse — that's an SDK bug to fix, not a renderer one.
 pub fn update_physics_combined_impulse(
     scene: &mut Scene,
     crdt_state: &mut SceneCrdtState,
@@ -106,43 +107,26 @@ pub fn update_physics_combined_impulse(
     let Some(pb) = entry.value.as_ref() else {
         return;
     };
-
-    let godot_vec = pb
-        .vector
-        .as_ref()
-        .map(scene_vec_to_godot)
-        .unwrap_or(Vector3::ZERO);
-    let event_id = pb.event_id;
-    let current_state = (event_id, godot_vec);
-
-    let state_changed = scene
-        .last_impulse_state
-        .as_ref()
-        .is_none_or(|cached| *cached != current_state);
-    let is_zero_vector = godot_vec.length_squared() < f32::EPSILON;
-
-    scene.last_impulse_state = Some(current_state);
-
-    if !state_changed {
-        tracing::debug!(
-            "physics_combined: dedup hit — same (event_id={}, vec=({:.3},{:.3},{:.3})) as last applied",
-            event_id, godot_vec.x, godot_vec.y, godot_vec.z,
-        );
+    let Some(vector) = pb.vector.as_ref() else {
         return;
-    }
-    if is_zero_vector {
+    };
+
+    if scene.last_impulse_event_id == Some(pb.event_id) {
         tracing::debug!(
-            "physics_combined: state changed to zero — clearing cache, no impulse to queue"
+            "physics_combined: dedup hit — event_id={} already applied (scene expected to increment per protocol)",
+            pb.event_id
         );
         return;
     }
 
+    let godot_vec = scene_vec_to_godot(vector);
     tracing::debug!(
         "physics_combined: queue impulse event_id={} godot=({:.3},{:.3},{:.3})",
-        event_id,
+        pb.event_id,
         godot_vec.x,
         godot_vec.y,
         godot_vec.z,
     );
+    scene.last_impulse_event_id = Some(pb.event_id);
     scene.pending_impulses.push(godot_vec);
 }

--- a/lib/src/scene_runner/components/physics_combined.rs
+++ b/lib/src/scene_runner/components/physics_combined.rs
@@ -38,6 +38,12 @@ pub fn update_physics_combined_force(
     if !is_current_parcel_scene {
         // Discard any stale state so we don't leak forces from a scene the
         // player just left. Mirrors Unity's `ResetExternalForce` on scene exit.
+        if scene.active_external_force != Vector3::ZERO {
+            tracing::debug!(
+                "physics_combined: force cleared on scene {:?} (no longer current)",
+                scene.scene_id
+            );
+        }
         scene.active_external_force = Vector3::ZERO;
         return;
     }
@@ -50,6 +56,14 @@ pub fn update_physics_combined_force(
         .map(scene_vec_to_godot)
         .unwrap_or(Vector3::ZERO);
 
+    if new_force != scene.active_external_force {
+        tracing::debug!(
+            "physics_combined: force changed on scene {:?}: {:?} → {:?}",
+            scene.scene_id,
+            scene.active_external_force,
+            new_force
+        );
+    }
     scene.active_external_force = new_force;
 }
 
@@ -83,21 +97,48 @@ pub fn update_physics_combined_impulse(
         return;
     }
 
+    tracing::debug!(
+        "physics_combined: impulse dirty on scene {:?} (last_event_id={:?})",
+        scene.scene_id,
+        scene.last_impulse_event_id,
+    );
+
     let impulse_component = SceneCrdtStateProtoComponents::get_physics_combined_impulse(crdt_state);
     let Some(entry) = impulse_component.get(&SceneEntityId::PLAYER) else {
+        tracing::debug!("physics_combined: dirty but no LWW entry for PLAYER — skipping");
         return;
     };
     let Some(pb) = entry.value.as_ref() else {
+        tracing::debug!("physics_combined: dirty but entry.value is None — skipping");
         return;
     };
     let Some(vector) = pb.vector.as_ref() else {
+        tracing::debug!(
+            "physics_combined: dirty but pb.vector is None (event_id={}) — skipping",
+            pb.event_id
+        );
         return;
     };
 
     if scene.last_impulse_event_id == Some(pb.event_id) {
+        tracing::debug!(
+            "physics_combined: dedup hit — event_id={} already applied",
+            pb.event_id
+        );
         return;
     }
 
+    let godot_vec = scene_vec_to_godot(vector);
+    tracing::debug!(
+        "physics_combined: queue impulse event_id={} dcl=({:.3},{:.3},{:.3}) godot=({:.3},{:.3},{:.3})",
+        pb.event_id,
+        vector.x,
+        vector.y,
+        vector.z,
+        godot_vec.x,
+        godot_vec.y,
+        godot_vec.z,
+    );
     scene.last_impulse_event_id = Some(pb.event_id);
-    scene.pending_impulses.push(scene_vec_to_godot(vector));
+    scene.pending_impulses.push(godot_vec);
 }

--- a/lib/src/scene_runner/components/physics_combined.rs
+++ b/lib/src/scene_runner/components/physics_combined.rs
@@ -12,22 +12,13 @@ use crate::{
     scene_runner::scene::Scene,
 };
 
-/// Convert a Decentraland scene `Vector3` to a Godot world `Vector3`.
-///
-/// Godot's Z axis is the negation of Decentraland's Z (see
-/// `DclTransformAndParent::to_godot_transform_3d`), so directions/vectors that
-/// originate in scene coordinates must have their Z component flipped before
-/// being applied to Godot nodes.
+/// Convert a DCL scene-space vector to Godot world-space (Z is negated).
 fn scene_vec_to_godot(v: &proto_components::common::Vector3) -> Vector3 {
     Vector3::new(v.x, v.y, -v.z)
 }
 
-/// Reads `PBPhysicsCombinedForce` on the player entity and stores the resulting
-/// continuous force on the scene so the player controller can sample it.
-///
-/// Force is only applied while the scene is the current parcel scene; for any
-/// other scene the stored value is reset to zero. The force vector is the
-/// summary of all per-frame forces accumulated by the scene's SDK code.
+/// Update the per-scene cached force from the player's `PBPhysicsCombinedForce`.
+/// Non-current scenes are cleared so wind zones stop the moment the player leaves.
 pub fn update_physics_combined_force(
     scene: &mut Scene,
     crdt_state: &mut SceneCrdtState,
@@ -36,8 +27,6 @@ pub fn update_physics_combined_force(
     let is_current_parcel_scene = scene.scene_id == *current_parcel_scene_id;
 
     if !is_current_parcel_scene {
-        // Discard any stale state so we don't leak forces from a scene the
-        // player just left. Mirrors Unity's `ResetExternalForce` on scene exit.
         if scene.active_external_force != Vector3::ZERO {
             tracing::debug!(
                 "physics_combined: force cleared on scene {:?} (no longer current)",
@@ -67,18 +56,12 @@ pub fn update_physics_combined_force(
     scene.active_external_force = new_force;
 }
 
-/// Reads `PBPhysicsCombinedImpulse` on the player entity and queues a one-shot
-/// impulse for every CRDT write the scene makes to it.
+/// Queue one impulse per CRDT write of the player's `PBPhysicsCombinedImpulse`.
 ///
-/// We deliberately mirror unity-explorer's `SDKExternalPhysicsSystems`, which
-/// gates on its per-write `IsDirty` flag and **does not read `event_id`**.
-/// The proto comment makes `event_id` sound load-bearing for renderer-side
-/// dedup, but the shipped Unity client ignores it — and production scenes
-/// like Genesis Plaza's `bouncePad.ts` rely on that, calling
-/// `PhysicsCombinedImpulse.createOrReplace(player, { eventId: 0, vector })`
-/// every trigger enter. To match the Unity behavior bar, we fire once per
-/// CRDT-dirty signal: `createOrReplace` (even with a stale `event_id`)
-/// produces one CRDT message → one renderer fire.
+/// The proto says `event_id` is the renderer's dedup key, but production scenes
+/// (Genesis Plaza, etc.) ship with `eventId: 0` hardcoded and expect each
+/// `createOrReplace` call to fire the impulse. So we gate on the CRDT dirty
+/// signal alone — one write, one fire — and ignore `event_id`.
 pub fn update_physics_combined_impulse(
     scene: &mut Scene,
     crdt_state: &mut SceneCrdtState,

--- a/lib/src/scene_runner/scene.rs
+++ b/lib/src/scene_runner/scene.rs
@@ -289,6 +289,12 @@ pub struct Scene {
     /// One-shot impulses queued by this scene's `PBPhysicsCombinedImpulse` on the
     /// player entity. Drained by the player controller each physics tick.
     pub pending_impulses: Vec<Vector3>,
+    /// `(event_id, vector)` of the most recent impulse value we observed on this
+    /// scene's player-entity component, in Godot coordinates. Used to detect
+    /// fresh-vs-repeat writes: the test scenes leave `event_id=0` and the SDK
+    /// republishes the same vector every tick, so we dedup by full-state equality
+    /// the same way `tween.rs` and `video_player.rs` detect change.
+    pub last_impulse_state: Option<(u32, Vector3)>,
 
     pub paused: bool,
 
@@ -411,6 +417,7 @@ impl Scene {
             locomotion_settings: Default::default(),
             active_external_force: Vector3::ZERO,
             pending_impulses: Vec::new(),
+            last_impulse_state: None,
             deno_memory_stats: None,
             stuck_frames: 0,
         }
@@ -490,6 +497,7 @@ impl Scene {
             locomotion_settings: Default::default(),
             active_external_force: Vector3::ZERO,
             pending_impulses: Vec::new(),
+            last_impulse_state: None,
             deno_memory_stats: None,
             stuck_frames: 0,
         }

--- a/lib/src/scene_runner/scene.rs
+++ b/lib/src/scene_runner/scene.rs
@@ -289,10 +289,6 @@ pub struct Scene {
     /// One-shot impulses queued by this scene's `PBPhysicsCombinedImpulse` on the
     /// player entity. Drained by the player controller each physics tick.
     pub pending_impulses: Vec<Vector3>,
-    /// Last `event_id` we applied from `PBPhysicsCombinedImpulse`; used for
-    /// CRDT-driven deduplication (incrementing event_id ⇒ new impulse, identical
-    /// event_id ⇒ ignored).
-    pub last_impulse_event_id: Option<u32>,
 
     pub paused: bool,
 
@@ -415,7 +411,6 @@ impl Scene {
             locomotion_settings: Default::default(),
             active_external_force: Vector3::ZERO,
             pending_impulses: Vec::new(),
-            last_impulse_event_id: None,
             deno_memory_stats: None,
             stuck_frames: 0,
         }
@@ -495,7 +490,6 @@ impl Scene {
             locomotion_settings: Default::default(),
             active_external_force: Vector3::ZERO,
             pending_impulses: Vec::new(),
-            last_impulse_event_id: None,
             deno_memory_stats: None,
             stuck_frames: 0,
         }

--- a/lib/src/scene_runner/scene.rs
+++ b/lib/src/scene_runner/scene.rs
@@ -281,13 +281,11 @@ pub struct Scene {
 
     pub locomotion_settings: Gd<DclLocomotionSettings>,
 
-    /// Continuous external force published by this scene's `PBPhysicsCombinedForce`
-    /// on the player entity, already converted to Godot world axes. Zero when the
-    /// component is absent. Only the current parcel scene's value is consumed by
-    /// the player controller.
+    /// Continuous force from this scene's `PBPhysicsCombinedForce` on the player,
+    /// in Godot world axes. Only sampled when this is the current parcel scene.
     pub active_external_force: Vector3,
-    /// One-shot impulses queued by this scene's `PBPhysicsCombinedImpulse` on the
-    /// player entity. Drained by the player controller each physics tick.
+    /// One-shot impulses from this scene's `PBPhysicsCombinedImpulse`, drained
+    /// each physics tick by the player controller.
     pub pending_impulses: Vec<Vector3>,
 
     pub paused: bool,

--- a/lib/src/scene_runner/scene.rs
+++ b/lib/src/scene_runner/scene.rs
@@ -4,7 +4,11 @@ use std::{
     time::Instant,
 };
 
-use godot::{obj::NewAlloc, prelude::Gd, prelude::ToGodot};
+use godot::{
+    builtin::Vector3,
+    obj::NewAlloc,
+    prelude::{Gd, ToGodot},
+};
 
 use crate::{
     content::content_mapping::{ContentMappingAndUrl, ContentMappingAndUrlRef},
@@ -117,6 +121,8 @@ pub enum SceneUpdateState {
     AudioStream,
     AvatarModifierArea,
     AvatarLocomotionSettings,
+    PhysicsCombinedForce,
+    PhysicsCombinedImpulse,
     CameraModeArea,
     InputModifier,
     SkyboxTime,
@@ -155,7 +161,9 @@ impl SceneUpdateState {
             Self::VideoPlayer => Self::AudioStream,
             Self::AudioStream => Self::AvatarModifierArea,
             Self::AvatarModifierArea => Self::AvatarLocomotionSettings,
-            Self::AvatarLocomotionSettings => Self::CameraModeArea,
+            Self::AvatarLocomotionSettings => Self::PhysicsCombinedForce,
+            Self::PhysicsCombinedForce => Self::PhysicsCombinedImpulse,
+            Self::PhysicsCombinedImpulse => Self::CameraModeArea,
             Self::CameraModeArea => Self::InputModifier,
             Self::InputModifier => Self::SkyboxTime,
             Self::SkyboxTime => Self::TriggerArea,
@@ -272,6 +280,19 @@ pub struct Scene {
     pub virtual_camera: Gd<DclVirtualCamera>,
 
     pub locomotion_settings: Gd<DclLocomotionSettings>,
+
+    /// Continuous external force published by this scene's `PBPhysicsCombinedForce`
+    /// on the player entity, already converted to Godot world axes. Zero when the
+    /// component is absent. Only the current parcel scene's value is consumed by
+    /// the player controller.
+    pub active_external_force: Vector3,
+    /// One-shot impulses queued by this scene's `PBPhysicsCombinedImpulse` on the
+    /// player entity. Drained by the player controller each physics tick.
+    pub pending_impulses: Vec<Vector3>,
+    /// Last `event_id` we applied from `PBPhysicsCombinedImpulse`; used for
+    /// CRDT-driven deduplication (incrementing event_id ⇒ new impulse, identical
+    /// event_id ⇒ ignored).
+    pub last_impulse_event_id: Option<u32>,
 
     pub paused: bool,
 
@@ -392,6 +413,9 @@ impl Scene {
             paused: false,
             virtual_camera: Default::default(),
             locomotion_settings: Default::default(),
+            active_external_force: Vector3::ZERO,
+            pending_impulses: Vec::new(),
+            last_impulse_event_id: None,
             deno_memory_stats: None,
             stuck_frames: 0,
         }
@@ -469,6 +493,9 @@ impl Scene {
             paused: false,
             virtual_camera: Default::default(),
             locomotion_settings: Default::default(),
+            active_external_force: Vector3::ZERO,
+            pending_impulses: Vec::new(),
+            last_impulse_event_id: None,
             deno_memory_stats: None,
             stuck_frames: 0,
         }

--- a/lib/src/scene_runner/scene.rs
+++ b/lib/src/scene_runner/scene.rs
@@ -289,12 +289,6 @@ pub struct Scene {
     /// One-shot impulses queued by this scene's `PBPhysicsCombinedImpulse` on the
     /// player entity. Drained by the player controller each physics tick.
     pub pending_impulses: Vec<Vector3>,
-    /// Last `event_id` we applied from `PBPhysicsCombinedImpulse` on this scene.
-    /// The protocol guarantees `event_id` is monotonic and that each unique ID
-    /// fires at most once on the renderer — see the proto comment on
-    /// `PBPhysicsCombinedImpulse`. A scene/SDK that doesn't bump `event_id`
-    /// will (correctly) only get the first impulse applied.
-    pub last_impulse_event_id: Option<u32>,
 
     pub paused: bool,
 
@@ -417,7 +411,6 @@ impl Scene {
             locomotion_settings: Default::default(),
             active_external_force: Vector3::ZERO,
             pending_impulses: Vec::new(),
-            last_impulse_event_id: None,
             deno_memory_stats: None,
             stuck_frames: 0,
         }
@@ -497,7 +490,6 @@ impl Scene {
             locomotion_settings: Default::default(),
             active_external_force: Vector3::ZERO,
             pending_impulses: Vec::new(),
-            last_impulse_event_id: None,
             deno_memory_stats: None,
             stuck_frames: 0,
         }

--- a/lib/src/scene_runner/scene.rs
+++ b/lib/src/scene_runner/scene.rs
@@ -289,12 +289,12 @@ pub struct Scene {
     /// One-shot impulses queued by this scene's `PBPhysicsCombinedImpulse` on the
     /// player entity. Drained by the player controller each physics tick.
     pub pending_impulses: Vec<Vector3>,
-    /// `(event_id, vector)` of the most recent impulse value we observed on this
-    /// scene's player-entity component, in Godot coordinates. Used to detect
-    /// fresh-vs-repeat writes: the test scenes leave `event_id=0` and the SDK
-    /// republishes the same vector every tick, so we dedup by full-state equality
-    /// the same way `tween.rs` and `video_player.rs` detect change.
-    pub last_impulse_state: Option<(u32, Vector3)>,
+    /// Last `event_id` we applied from `PBPhysicsCombinedImpulse` on this scene.
+    /// The protocol guarantees `event_id` is monotonic and that each unique ID
+    /// fires at most once on the renderer — see the proto comment on
+    /// `PBPhysicsCombinedImpulse`. A scene/SDK that doesn't bump `event_id`
+    /// will (correctly) only get the first impulse applied.
+    pub last_impulse_event_id: Option<u32>,
 
     pub paused: bool,
 
@@ -417,7 +417,7 @@ impl Scene {
             locomotion_settings: Default::default(),
             active_external_force: Vector3::ZERO,
             pending_impulses: Vec::new(),
-            last_impulse_state: None,
+            last_impulse_event_id: None,
             deno_memory_stats: None,
             stuck_frames: 0,
         }
@@ -497,7 +497,7 @@ impl Scene {
             locomotion_settings: Default::default(),
             active_external_force: Vector3::ZERO,
             pending_impulses: Vec::new(),
-            last_impulse_state: None,
+            last_impulse_event_id: None,
             deno_memory_stats: None,
             stuck_frames: 0,
         }

--- a/lib/src/scene_runner/scene_manager.rs
+++ b/lib/src/scene_runner/scene_manager.rs
@@ -1470,9 +1470,7 @@ impl SceneManager {
                 video_player_node.bind_mut().set_muted(true);
             }
 
-            // Drop any combined-physics state on the scene the player just left
-            // so wind-zone forces stop immediately and queued impulses can't fire
-            // after the boundary crossing.
+            // Stop any wind/impulse the player just walked out of.
             scene.active_external_force = Vector3::ZERO;
             scene.pending_impulses.clear();
 
@@ -1582,9 +1580,8 @@ impl SceneManager {
             .unwrap_or_default()
     }
 
-    /// Returns the active continuous external force from the current parcel
-    /// scene's `PBPhysicsCombinedForce` component on the player entity, in
-    /// Godot world coordinates. Zero when no scene is driving a force.
+    /// Current parcel scene's external force on the player (Godot axes), or
+    /// zero if no scene is driving one.
     #[func]
     pub fn get_active_external_force(&self) -> Vector3 {
         self.scenes
@@ -1593,11 +1590,8 @@ impl SceneManager {
             .unwrap_or(Vector3::ZERO)
     }
 
-    /// Drains and returns the queue of pending one-shot impulses from the
-    /// current parcel scene's `PBPhysicsCombinedImpulse` component. Each
-    /// element is the impulse vector (already in Godot world axes) that
-    /// triggered on a new `event_id`. The player controller should call this
-    /// once per physics tick.
+    /// Drain pending impulse vectors (Godot axes) from the current parcel
+    /// scene. The player controller calls this once per physics tick.
     #[func]
     pub fn consume_pending_impulses(&mut self) -> PackedVector3Array {
         let Some(scene) = self.scenes.get_mut(&self.current_parcel_scene_id) else {

--- a/lib/src/scene_runner/scene_manager.rs
+++ b/lib/src/scene_runner/scene_manager.rs
@@ -1470,6 +1470,12 @@ impl SceneManager {
                 video_player_node.bind_mut().set_muted(true);
             }
 
+            // Drop any combined-physics state on the scene the player just left
+            // so wind-zone forces stop immediately and queued impulses can't fire
+            // after the boundary crossing.
+            scene.active_external_force = Vector3::ZERO;
+            scene.pending_impulses.clear();
+
             scene
                 .avatar_scene_updates
                 .internal_player_data
@@ -1574,6 +1580,31 @@ impl SceneManager {
             .get(&self.current_parcel_scene_id)
             .map(|x| x.locomotion_settings.clone())
             .unwrap_or_default()
+    }
+
+    /// Returns the active continuous external force from the current parcel
+    /// scene's `PBPhysicsCombinedForce` component on the player entity, in
+    /// Godot world coordinates. Zero when no scene is driving a force.
+    #[func]
+    pub fn get_active_external_force(&self) -> Vector3 {
+        self.scenes
+            .get(&self.current_parcel_scene_id)
+            .map(|x| x.active_external_force)
+            .unwrap_or(Vector3::ZERO)
+    }
+
+    /// Drains and returns the queue of pending one-shot impulses from the
+    /// current parcel scene's `PBPhysicsCombinedImpulse` component. Each
+    /// element is the impulse vector (already in Godot world axes) that
+    /// triggered on a new `event_id`. The player controller should call this
+    /// once per physics tick.
+    #[func]
+    pub fn consume_pending_impulses(&mut self) -> PackedVector3Array {
+        let Some(scene) = self.scenes.get_mut(&self.current_parcel_scene_id) else {
+            return PackedVector3Array::new();
+        };
+        let drained: Vec<Vector3> = scene.pending_impulses.drain(..).collect();
+        PackedVector3Array::from(drained.as_slice())
     }
 
     #[func]

--- a/lib/src/scene_runner/update_scene.rs
+++ b/lib/src/scene_runner/update_scene.rs
@@ -25,6 +25,7 @@ use super::{
         mesh_collider::update_mesh_collider,
         mesh_renderer::update_mesh_renderer,
         nft_shape::update_nft_shape,
+        physics_combined::{update_physics_combined_force, update_physics_combined_impulse},
         pointer_events::update_scene_pointer_events,
         raycast::update_raycasts,
         realm_info::sync_realm_info,
@@ -365,6 +366,14 @@ pub fn _process_scene(
                                 ],
                             );
                     }
+                    false
+                }
+                SceneUpdateState::PhysicsCombinedForce => {
+                    update_physics_combined_force(scene, crdt_state, current_parcel_scene_id);
+                    false
+                }
+                SceneUpdateState::PhysicsCombinedImpulse => {
+                    update_physics_combined_impulse(scene, crdt_state, current_parcel_scene_id);
                     false
                 }
                 SceneUpdateState::CameraModeArea => {


### PR DESCRIPTION
## Summary
Adds SDK7 protocol support for [`PBPhysicsCombinedImpulse`](https://github.com/decentraland/protocol/blob/main/proto/decentraland/sdk/components/physics_combined_impulse.proto) (ID 1215) and [`PBPhysicsCombinedForce`](https://github.com/decentraland/protocol/blob/main/proto/decentraland/sdk/components/physics_combined_force.proto) (ID 1216) on the player entity, enabling scene-driven physics (jump pads, wind zones, explosions, conveyor belts).

Mirrors the behavior shipping in `unity-explorer`'s `SDKExternalPhysicsSystems.cs`:
- **Impulse**: one-shot, deduplicated by `event_id` (a monotonic counter). Re-publishing the same `event_id` does nothing; incrementing it fires again. Upward impulse on a falling player cancels the downward gravity component so jump pads launch reliably.
- **Force**: continuous; applied as acceleration each physics tick while the component is present.
- Both components only fire while the player is inside the owning scene; force/impulse state is cleared on scene exit.

Closes #1537.

## Implementation
- **`lib/src/scene_runner/scene.rs`** — new `SceneUpdateState::PhysicsCombinedForce` / `PhysicsCombinedImpulse` states slotted between `AvatarLocomotionSettings` and `CameraModeArea`; per-scene `active_external_force`, `pending_impulses`, `last_impulse_event_id` tracking.
- **`lib/src/scene_runner/components/physics_combined.rs`** (new) — reads the components from the `PLAYER` entity, gates on `scene_id == current_parcel_scene_id`, dedups via `event_id`, and converts vectors from DCL to Godot axes (negating Z, matching `DclTransformAndParent`).
- **`lib/src/scene_runner/update_scene.rs`** — wired the two state arms.
- **`lib/src/scene_runner/scene_manager.rs`** — `#[func] get_active_external_force()` and `#[func] consume_pending_impulses()` for GDScript; clears stale force + queued impulses on scene change.
- **`godot/src/logic/player/player.gd`** — new `_apply_scene_physics(dt)` called right before `move_and_slide()`; introduces `CHARACTER_MASS = 0.8` (matches Unity `CharacterControllerSettings.CharacterMass`) so `Δv = vector / CHARACTER_MASS` for impulse and `a = vector / CHARACTER_MASS` for force.

The proto files were already present, so `build.rs` auto-generated the `SceneComponentId` constants, `PbPhysicsCombined{Impulse,Force}` types, and LWW CRDT accessors — no codegen wiring required.

## Test plan
- [ ] `cargo run -- build` — succeeds locally ✅
- [ ] `cargo clippy -- -D warnings` — clean ✅
- [ ] `cargo fmt --all` + `gdformat`/`gdlint` — clean ✅
- [ ] Deploy [sdk7-test-scenes#49](https://github.com/decentraland/sdk7-test-scenes/pull/49) locally and verify:
  - [ ] Jump pad launches the avatar upward.
  - [ ] Wind zone pushes the avatar continuously while inside the scene.
  - [ ] Re-publishing the same `event_id` does **not** re-fire the impulse.
  - [ ] Stepping out of the scene immediately halts the wind force.
- [ ] iOS build green (label triggers the workflow)