### PR TITLE
feat: populate screen_inset_area on PbUiCanvasInformation

### DIFF
--- a/lib/src/scene_runner/scene_manager.rs
+++ b/lib/src/scene_runner/scene_manager.rs
@@ -1384,17 +1384,19 @@ impl SceneManager {
         let right = (canvas_size.x - ia_end.x as f32).clamp(0.0, canvas_size.x);
         let bottom = (canvas_size.y - ia_end.y as f32).clamp(0.0, canvas_size.y);
 
+        let border_rect = BorderRect {
+            top,
+            left,
+            right,
+            bottom,
+        };
+
         PbUiCanvasInformation {
             device_pixel_ratio,
             width: canvas_size.x as i32,
             height: canvas_size.y as i32,
-            interactable_area: Some(BorderRect {
-                top,
-                left,
-                right,
-                bottom,
-            }),
-            screen_inset_area: None,
+            interactable_area: Some(border_rect.clone()),
+            screen_inset_area: Some(border_rect),
         }
     }
 


### PR DESCRIPTION
## Summary
- `PbUiCanvasInformation.screen_inset_area` was being sent as `None` ever since the protocol bump added the field (see d8f7c0741c). Scenes that read it currently get nothing.
- Mirror the same `BorderRect` we already compute for `interactable_area` into `screen_inset_area` so scenes can use it.
- The two values match today (the explorer's safe area is the only inset we know about). If hardware-imposed insets diverge from the HUD-driven interactable area in the future we can split them.

## Test plan
- [ ] `cd lib && cargo check` — verifies the struct field is populated.
- [ ] Run the client and confirm scenes that consume `UiCanvasInformation.screenInsetArea` (notch/safe-area aware SDK7 UIs) receive non-null values matching `interactableArea`.
- [ ] Resize the window / toggle HUD elements — both rects should update together.