### PR TITLE
fix: AvatarModifierArea excludeIds reliably excludes remote avatars (#2166)

### DIFF
--- a/godot/src/decentraland_components/avatar/avatar.gd
+++ b/godot/src/decentraland_components/avatar/avatar.gd
@@ -263,9 +263,8 @@ func try_show():
 func _on_set_avatar_modifier_area(area: DclAvatarModifierArea3D):
 	_unset_avatar_modifier_area()  # Reset state
 
-	for exclude_id in area.exclude_ids:
-		if avatar_id == exclude_id:
-			return  # the avatar is not going to be modified
+	if AvatarExcludeIdMatcher.is_excluded(avatar_id, area.exclude_ids):
+		return  # the avatar is not going to be modified
 
 	for modifier in area.avatar_modifiers:
 		if modifier == 0:  # hide avatar
@@ -348,6 +347,7 @@ func async_update_avatar_from_profile(profile: DclUserProfile):
 		new_avatar_name += "#" + profile.get_ethereum_address().right(4)
 	nickname_ui.name_claimed = profile.has_claimed_name()
 
+	var avatar_id_changed := avatar_id != profile.get_ethereum_address()
 	avatar_id = profile.get_ethereum_address()
 	has_connected_web3 = profile.has_connected_web3()
 	prints("Async update avatar from profile", avatar_id)
@@ -355,6 +355,12 @@ func async_update_avatar_from_profile(profile: DclUserProfile):
 	# Update metadata with the new avatar_id
 	if click_area:
 		click_area.set_meta("avatar_id", avatar_id)
+
+	# Re-evaluate AvatarModifierArea exclusion: the area may have triggered
+	# before the profile arrived (issue #2166 race), leaving the avatar hidden
+	# even though its id is in excludeIds.
+	if avatar_id_changed:
+		try_show()
 
 	await async_update_avatar(avatar, new_avatar_name)
 
@@ -378,6 +384,7 @@ func async_update_avatar(
 			avatar_id = shape_id
 			if click_area:
 				click_area.set_meta("avatar_id", avatar_id)
+			try_show()
 
 	# Update metadata for raycast detection
 	if click_area:

--- a/godot/src/decentraland_components/avatar/avatar_exclude_id_matcher.gd
+++ b/godot/src/decentraland_components/avatar/avatar_exclude_id_matcher.gd
@@ -1,0 +1,23 @@
+class_name AvatarExcludeIdMatcher
+
+
+# Decides whether `avatar_id` is present in `exclude_ids` for the purposes of
+# AvatarModifierArea visibility. Treats Ethereum addresses case-insensitively
+# and tolerates a missing `0x` prefix on either side: profiles delivered over
+# comms may carry the checksummed form, while scenes commonly push lowercase
+# addresses. See issue #2166.
+static func is_excluded(avatar_id: String, exclude_ids) -> bool:
+	if avatar_id.is_empty():
+		return false
+	var normalized := _normalize(avatar_id)
+	for raw in exclude_ids:
+		if _normalize(String(raw)) == normalized:
+			return true
+	return false
+
+
+static func _normalize(addr: String) -> String:
+	var lower := addr.to_lower()
+	if not lower.begins_with("0x"):
+		lower = "0x" + lower
+	return lower

--- a/godot/src/decentraland_components/avatar/avatar_exclude_id_matcher.gd.uid
+++ b/godot/src/decentraland_components/avatar/avatar_exclude_id_matcher.gd.uid
@@ -1,0 +1,1 @@
+uid://bdhljqrgorgsx

--- a/godot/src/decentraland_components/avatar_modifier_area.gd
+++ b/godot/src/decentraland_components/avatar_modifier_area.gd
@@ -12,3 +12,22 @@ func _ready():
 	var shape = BoxShape3D.new()
 	shape.set_size(area)
 	collision_shape_3d.set_shape(shape)
+
+
+# Called from Rust (avatar_modifier_area.rs) after exclude_ids / modifiers /
+# area are updated on an existing node. Forces overlapping AvatarModifierArea
+# detectors to re-evaluate so freshly-added excludeIds take effect on avatars
+# that already entered the area. See issue #2166.
+func refresh_overlapping_detectors() -> void:
+	# Issue #2166: do NOT rely on Area3D.get_overlapping_areas() — it returns
+	# stale data when invoked from a CRDT update tick (physics has not yet
+	# settled). Instead, ask every known avatar to re-evaluate; each one's
+	# detector decides whether this AMA applies to it.
+	var avatars_root = Global.avatars
+	if avatars_root != null:
+		for a in avatars_root.get_avatars():
+			if a.has_method("try_show"):
+				a.try_show()
+	var player_avatar = Global.scene_runner.player_avatar_node
+	if player_avatar != null and player_avatar.has_method("try_show"):
+		player_avatar.try_show()

--- a/godot/src/test/avatar/test_avatar_modifier_exclude_ids.gd
+++ b/godot/src/test/avatar/test_avatar_modifier_exclude_ids.gd
@@ -1,0 +1,96 @@
+extends SceneTree
+
+# Regression test for issue #2166.
+#
+# AvatarModifierArea.excludeIds must keep remote avatars visible even when the
+# address casing differs (checksummed vs lowercase) and when no `0x` prefix is
+# used. Comms / wire profile sometimes deliver mixed-case addresses, while
+# scenes commonly push lowercase IDs in excludeIds.
+#
+# Run with the project's godot binary, e.g.:
+#   .bin/godot/godot4_bin --headless --path godot \
+#     --script res://src/test/avatar/test_avatar_modifier_exclude_ids.gd
+
+const MATCHER := preload("res://src/decentraland_components/avatar/avatar_exclude_id_matcher.gd")
+
+const ADDR_LOWER := "0xabcdef0123456789abcdef0123456789abcdef01"
+const ADDR_CHECKSUM := "0xAbCdEf0123456789AbCdEf0123456789aBcDeF01"
+const ADDR_NO_PREFIX := "abcdef0123456789abcdef0123456789abcdef01"
+const OTHER_ADDR := "0x1111111111111111111111111111111111111111"
+
+
+func _init() -> void:
+	var failures: Array[String] = []
+
+	# Sanity: identical casing matches.
+	_expect("exact lowercase match", failures, ADDR_LOWER, [ADDR_LOWER], true)
+
+	# Sanity: no overlap.
+	_expect("no overlap", failures, ADDR_LOWER, [OTHER_ADDR], false)
+
+	# Bug #2166: scene sent lowercase, profile delivered checksummed.
+	_expect(
+		"checksum avatar_id vs lowercase exclude (bug #2166)",
+		failures,
+		ADDR_CHECKSUM,
+		[ADDR_LOWER],
+		true
+	)
+
+	# Bug #2166 inverse: profile lowercase, scene listed checksummed.
+	_expect(
+		"lowercase avatar_id vs checksum exclude (bug #2166)",
+		failures,
+		ADDR_LOWER,
+		[ADDR_CHECKSUM],
+		true
+	)
+
+	# Bug #2166: missing 0x prefix on the scene-side id.
+	_expect(
+		"lowercase avatar_id vs no-prefix exclude (bug #2166)",
+		failures,
+		ADDR_LOWER,
+		[ADDR_NO_PREFIX],
+		true
+	)
+
+	# Race-condition guard: avatar_id not yet populated when area triggers.
+	# Empty id must never silently match a non-empty exclude entry.
+	_expect("empty avatar_id never matches", failures, "", [ADDR_LOWER], false)
+
+	# Multi-entry list: one of several entries matches with mixed casing.
+	_expect(
+		"mixed-casing entry among many is found",
+		failures,
+		ADDR_LOWER,
+		[OTHER_ADDR, ADDR_CHECKSUM, "0x0000000000000000000000000000000000000000"],
+		true
+	)
+
+	if failures.is_empty():
+		print("[test_avatar_modifier_exclude_ids] PASS (all 7 cases)")
+		quit(0)
+		return
+
+	for f in failures:
+		printerr(f)
+	printerr("[test_avatar_modifier_exclude_ids] FAIL: %d case(s) failing" % failures.size())
+	quit(1)
+
+
+func _expect(
+	case_name: String,
+	failures: Array[String],
+	avatar_id: String,
+	exclude_ids: Array,
+	expected: bool
+) -> void:
+	var actual: bool = MATCHER.is_excluded(avatar_id, exclude_ids)
+	if actual != expected:
+		failures.append(
+			(
+				"[%s] expected is_excluded=%s, got %s (avatar_id=%s, exclude_ids=%s)"
+				% [case_name, expected, actual, avatar_id, str(exclude_ids)]
+			)
+		)

--- a/godot/src/test/avatar/test_avatar_modifier_exclude_ids.gd.uid
+++ b/godot/src/test/avatar/test_avatar_modifier_exclude_ids.gd.uid
@@ -1,0 +1,1 @@
+uid://2yvl03xiuu6k

--- a/lib/src/scene_runner/components/avatar_modifier_area.rs
+++ b/lib/src/scene_runner/components/avatar_modifier_area.rs
@@ -62,6 +62,11 @@ pub fn update_avatar_modifier_area(scene: &mut Scene, crdt_state: &mut SceneCrdt
                     avatar_modifier_area_3d
                         .bind_mut()
                         .set_exclude_ids(exclude_ids);
+                    // Issue #2166: scenes commonly push excludeIds *after* the
+                    // avatar has already entered the area. The setter alone
+                    // does not re-trigger detection, so we nudge overlapping
+                    // detectors to re-evaluate.
+                    avatar_modifier_area_3d.call("refresh_overlapping_detectors", &[]);
                 } else {
                     let mut avatar_modifier_area = godot::tools::load::<PackedScene>(
                         "res://src/decentraland_components/avatar_modifier_area.tscn",


### PR DESCRIPTION
Fixes #2166

## Summary

`AvatarModifierArea.excludeIds` was failing to keep remote avatars visible on mobile — three independent gaps were stacking up to make the failure look flaky:

1. **Address casing** — profiles delivered over comms can carry checksummed eth addresses while scenes typically push lowercase. Direct `==` comparison missed those. Extracted into `AvatarExcludeIdMatcher` with normalization (lowercase + tolerant `0x` prefix).
2. **Race on profile arrival** — a remote avatar could enter the area before its profile (and thus `avatar_id`) was populated, hiding it permanently. `async_update_avatar_from_profile` now calls `try_show()` after `avatar_id` changes so the area is re-evaluated.
3. **Stale excludeIds on already-overlapping avatars** — when the scene updates `excludeIds` after avatars are already inside the area, the Rust `set_exclude_ids` setter alone doesn't retrigger detection. `avatar_modifier_area.rs` now invokes `refresh_overlapping_detectors`, which iterates `Global.avatars` (rather than `Area3D.get_overlapping_areas()`, whose state is stale mid-CRDT-tick) and asks each avatar to re-evaluate via `try_show()`.

In `carrito.dcl.eth` (1 large AMA + scene adds player IDs to excludeIds) two clients now consistently see each other. Without this fix the user that joined first never saw the second.

## Files

- `godot/src/decentraland_components/avatar/avatar_exclude_id_matcher.gd` — new pure helper with `is_excluded(avatar_id, exclude_ids) -> bool`.
- `godot/src/decentraland_components/avatar/avatar.gd` — `_on_set_avatar_modifier_area` uses the matcher; `async_update_avatar_from_profile` calls `try_show()` after `avatar_id` changes (both wire-profile and AvatarShape branches).
- `godot/src/decentraland_components/avatar_modifier_area.gd` — new `refresh_overlapping_detectors()` that iterates `Global.avatars`.
- `lib/src/scene_runner/components/avatar_modifier_area.rs` — calls `refresh_overlapping_detectors` after updating an existing area's properties.
- `godot/src/test/avatar/test_avatar_modifier_exclude_ids.gd` — regression test covering case/prefix mismatches and the empty-`avatar_id` race.

## Test plan

- [x] `cargo run -- full-tests --skip-visual` passes (cargo fmt/clippy, gdformat/gdlint, gdscript validation, rust + integration tests)
- [x] Regression test passes:
  ```
  .bin/godot/godot4_bin --headless --path godot \
    --script res://src/test/avatar/test_avatar_modifier_exclude_ids.gd
  # → [test_avatar_modifier_exclude_ids] PASS (all 7 cases)
  ```
- [x] Manual repro on `carrito.dcl.eth`, two clients (macOS + iOS): both see each other regardless of join order.
- [ ] CI green