### PR TITLE
feat(settings): add gamepad mode toggle (default off)

### DIFF
--- a/godot/src/config/config_data.gd
+++ b/godot/src/config/config_data.gd
@@ -89,6 +89,10 @@ var submit_message_closes_chat: bool = false:
 	set(value):
 		submit_message_closes_chat = value
 
+var gamepad_mode_enabled: bool = false:
+	set(value):
+		gamepad_mode_enabled = value
+
 # See FpsLimitMode enum for available options (0=VSYNC, 1=NO_LIMIT, 2=18fps, 3=30fps, 4=60fps, 5=120fps)
 var limit_fps: int = FpsLimitMode.FPS_30:
 	set(value):
@@ -307,6 +311,7 @@ func load_from_default():
 	self.dynamic_skybox = true
 	self.skybox_time = 43200
 	self.submit_message_closes_chat = false
+	self.gamepad_mode_enabled = false
 
 	self.window_mode = 0
 
@@ -377,6 +382,9 @@ func load_from_settings_file():
 	self.skybox_time = settings_file.get_value("config", "skybox_time", data_default.skybox_time)
 	self.submit_message_closes_chat = settings_file.get_value(
 		"config", "submit_message_closes_chat", data_default.submit_message_closes_chat
+	)
+	self.gamepad_mode_enabled = settings_file.get_value(
+		"config", "gamepad_mode_enabled", data_default.gamepad_mode_enabled
 	)
 
 	self.window_mode = settings_file.get_value("config", "window_mode", data_default.window_mode)
@@ -501,6 +509,7 @@ func save_to_settings_file():
 	new_settings_file.set_value(
 		"config", "submit_message_closes_chat", self.submit_message_closes_chat
 	)
+	new_settings_file.set_value("config", "gamepad_mode_enabled", self.gamepad_mode_enabled)
 	new_settings_file.set_value("config", "window_mode", self.window_mode)
 	new_settings_file.set_value("config", "ui_zoom", self.ui_zoom)
 	new_settings_file.set_value("config", "resolution_3d_scale", self.resolution_3d_scale)

--- a/godot/src/ui/components/molecules/pointer_tooltip/tooltip_label.gd
+++ b/godot/src/ui/components/molecules/pointer_tooltip/tooltip_label.gd
@@ -74,7 +74,7 @@ func set_tooltip_data(text_pet_down: String, text_pet_up, action: String):
 	text_up = text_pet_up if !text_pet_up.is_empty() else text_pet_down
 
 	var action_lower: String = action.to_lower()
-	var gamepad_connected := (
+	var gamepad_connected: bool = (
 		Global.get_config().gamepad_mode_enabled and Input.get_connected_joypads().size() > 0
 	)
 

--- a/godot/src/ui/components/molecules/pointer_tooltip/tooltip_label.gd
+++ b/godot/src/ui/components/molecules/pointer_tooltip/tooltip_label.gd
@@ -74,8 +74,9 @@ func set_tooltip_data(text_pet_down: String, text_pet_up, action: String):
 	text_up = text_pet_up if !text_pet_up.is_empty() else text_pet_down
 
 	var action_lower: String = action.to_lower()
-	# TODO: replace with a proper gamepad mode flag once the enter-gamepad-mode dialog is implemented.
-	var gamepad_connected := false  # Input.get_connected_joypads().size() > 0
+	var gamepad_connected := (
+		Global.get_config().gamepad_mode_enabled and Input.get_connected_joypads().size() > 0
+	)
 
 	if not label_text:
 		return

--- a/godot/src/ui/components/molecules/pointer_tooltip/tooltip_label.gd
+++ b/godot/src/ui/components/molecules/pointer_tooltip/tooltip_label.gd
@@ -74,7 +74,8 @@ func set_tooltip_data(text_pet_down: String, text_pet_up, action: String):
 	text_up = text_pet_up if !text_pet_up.is_empty() else text_pet_down
 
 	var action_lower: String = action.to_lower()
-	var gamepad_connected := Input.get_connected_joypads().size() > 0
+	# TODO: replace with a proper gamepad mode flag once the enter-gamepad-mode dialog is implemented.
+	var gamepad_connected := false  # Input.get_connected_joypads().size() > 0
 
 	if not label_text:
 		return

--- a/godot/src/ui/explorer.gd
+++ b/godot/src/ui/explorer.gd
@@ -255,11 +255,8 @@ func _ready():
 		mobile_ui.show()
 		label_crosshair.show()
 		reset_cursor_position()
-		# TODO: replace automatic gamepad detection with a dialog asking the user
-		# to enter gamepad mode. Re-enable the lines below once the dialog is implemented.
-		#Input.joy_connection_changed.connect(_on_joy_connection_changed)
-		#_gamepad_connected = Input.get_connected_joypads().size() > 0
-		#_update_virtual_controls_visibility()
+		Input.joy_connection_changed.connect(_on_joy_connection_changed)
+		apply_gamepad_mode()
 	else:
 		mobile_ui.hide()
 
@@ -1561,30 +1558,30 @@ func _on_emote_wheel_emote_wheel_opened() -> void:
 	virtual_joystick.hide()
 
 
-# TODO: replace automatic gamepad detection with a dialog asking the user
-# to enter gamepad mode. Re-enable and adapt these functions once the dialog is implemented.
 func _on_joy_connection_changed(_device: int, _connected: bool) -> void:
-	pass
-	#_gamepad_connected = Input.get_connected_joypads().size() > 0
-	#_update_virtual_controls_visibility()
+	apply_gamepad_mode()
+
+
+func apply_gamepad_mode() -> void:
+	var enabled := Global.get_config().gamepad_mode_enabled
+	_gamepad_connected = enabled and Input.get_connected_joypads().size() > 0
+	_update_virtual_controls_visibility()
 
 
 func _update_virtual_controls_visibility() -> void:
-	pass
-	#if _gamepad_connected:
-	#	joypad.hide()
-	#	virtual_joystick.hide()
-	#else:
-	#	# Only restore if no panel is covering them
-	#	var panel_open := (
-	#		friends_panel.visible
-	#		or notifications_panel.visible
-	#		or settings_panel.visible
-	#		or profile_container.visible
-	#	)
-	#	if not panel_open:
-	#		joypad.show()
-	#	virtual_joystick.show()
+	if _gamepad_connected:
+		joypad.hide()
+		virtual_joystick.hide()
+	else:
+		var panel_open := (
+			friends_panel.visible
+			or notifications_panel.visible
+			or settings_panel.visible
+			or profile_container.visible
+		)
+		if not panel_open:
+			joypad.show()
+		virtual_joystick.show()
 
 
 func _on_backpack_emote_opened(on_emotes := false) -> void:

--- a/godot/src/ui/explorer.gd
+++ b/godot/src/ui/explorer.gd
@@ -1563,7 +1563,7 @@ func _on_joy_connection_changed(_device: int, _connected: bool) -> void:
 
 
 func apply_gamepad_mode() -> void:
-	var enabled := Global.get_config().gamepad_mode_enabled
+	var enabled: bool = Global.get_config().gamepad_mode_enabled
 	_gamepad_connected = enabled and Input.get_connected_joypads().size() > 0
 	_update_virtual_controls_visibility()
 

--- a/godot/src/ui/explorer.gd
+++ b/godot/src/ui/explorer.gd
@@ -255,10 +255,11 @@ func _ready():
 		mobile_ui.show()
 		label_crosshair.show()
 		reset_cursor_position()
-		# Detect physical gamepad to hide virtual controls
-		Input.joy_connection_changed.connect(_on_joy_connection_changed)
-		_gamepad_connected = Input.get_connected_joypads().size() > 0
-		_update_virtual_controls_visibility()
+		# TODO: replace automatic gamepad detection with a dialog asking the user
+		# to enter gamepad mode. Re-enable the lines below once the dialog is implemented.
+		#Input.joy_connection_changed.connect(_on_joy_connection_changed)
+		#_gamepad_connected = Input.get_connected_joypads().size() > 0
+		#_update_virtual_controls_visibility()
 	else:
 		mobile_ui.hide()
 
@@ -1560,26 +1561,30 @@ func _on_emote_wheel_emote_wheel_opened() -> void:
 	virtual_joystick.hide()
 
 
+# TODO: replace automatic gamepad detection with a dialog asking the user
+# to enter gamepad mode. Re-enable and adapt these functions once the dialog is implemented.
 func _on_joy_connection_changed(_device: int, _connected: bool) -> void:
-	_gamepad_connected = Input.get_connected_joypads().size() > 0
-	_update_virtual_controls_visibility()
+	pass
+	#_gamepad_connected = Input.get_connected_joypads().size() > 0
+	#_update_virtual_controls_visibility()
 
 
 func _update_virtual_controls_visibility() -> void:
-	if _gamepad_connected:
-		joypad.hide()
-		virtual_joystick.hide()
-	else:
-		# Only restore if no panel is covering them
-		var panel_open := (
-			friends_panel.visible
-			or notifications_panel.visible
-			or settings_panel.visible
-			or profile_container.visible
-		)
-		if not panel_open:
-			joypad.show()
-		virtual_joystick.show()
+	pass
+	#if _gamepad_connected:
+	#	joypad.hide()
+	#	virtual_joystick.hide()
+	#else:
+	#	# Only restore if no panel is covering them
+	#	var panel_open := (
+	#		friends_panel.visible
+	#		or notifications_panel.visible
+	#		or settings_panel.visible
+	#		or profile_container.visible
+	#	)
+	#	if not panel_open:
+	#		joypad.show()
+	#	virtual_joystick.show()
 
 
 func _on_backpack_emote_opened(on_emotes := false) -> void:

--- a/godot/src/ui/explorer.tscn
+++ b/godot/src/ui/explorer.tscn
@@ -1,7 +1,7 @@
 [gd_scene format=3 uid="uid://deq5v42fmh0y7"]
 
 [ext_resource type="Script" uid="uid://b7upym7ptmks0" path="res://src/ui/explorer.gd" id="1_5n8xk"]
-[ext_resource type="Script" path="res://src/logic/player/mobile_camera_input.gd" id="1_mcinput"]
+[ext_resource type="Script" uid="uid://bv8yaml1r4cmi" path="res://src/logic/player/mobile_camera_input.gd" id="1_mcinput"]
 [ext_resource type="PackedScene" uid="uid://cb6bcbjrusl4p" path="res://src/helpers_components/broadcast_position.tscn" id="4_2dkhu"]
 [ext_resource type="Theme" uid="uid://chwr8vock83p4" path="res://assets/themes/dark_dcl_theme/dark_dcl_theme.tres" id="4_2vs87"]
 [ext_resource type="PackedScene" uid="uid://pg3ssuep5dm7" path="res://assets/environment/environment_selector.tscn" id="4_f5cdi"]
@@ -177,8 +177,8 @@ vertical_alignment = 1
 
 [node name="Control_PointerTooltip" parent="UI" unique_id=944970499 instance=ExtResource("11_qjs00")]
 unique_name_in_owner = true
-layout_mode = 1
 z_index = -4096
+layout_mode = 1
 metadata/_edit_lock_ = true
 
 [node name="LeftRightSafeContainer" type="MarginContainer" parent="UI" unique_id=1210894567]

--- a/godot/src/ui/pages/settings/settings.gd
+++ b/godot/src/ui/pages/settings/settings.gd
@@ -123,10 +123,10 @@ func _ready():
 		Global.session_hide_ui_options_sync.connect(_on_session_hide_ui_options_sync)
 	_refresh_hide_explorer_ui_row()
 
-	# gamepad
+	# TODO: replace with a proper gamepad mode flag once the enter-gamepad-mode dialog is implemented.
 	_init_gamepad_sensitivity.call_deferred()
-	container_gamepad.visible = Input.get_connected_joypads().size() > 0
-	Input.joy_connection_changed.connect(_on_joy_connection_changed)
+	container_gamepad.visible = false  # Input.get_connected_joypads().size() > 0
+	#Input.joy_connection_changed.connect(_on_joy_connection_changed)
 
 	dropdown_list_max_cache_size.add_item("1 GB", 0)
 	dropdown_list_max_cache_size.add_item("2 GB", 1)
@@ -885,8 +885,10 @@ func _on_gamepad_camera_sensitivity_value_changed(value: float) -> void:
 	Global.get_config().save_to_settings_file()
 
 
+# TODO: replace with a proper gamepad mode flag once the enter-gamepad-mode dialog is implemented.
 func _on_joy_connection_changed(_device: int, _connected: bool) -> void:
-	container_gamepad.visible = Input.get_connected_joypads().size() > 0
+	pass
+	#container_gamepad.visible = Input.get_connected_joypads().size() > 0
 
 
 func _on_custom_button_sign_out_pressed() -> void:

--- a/godot/src/ui/pages/settings/settings.gd
+++ b/godot/src/ui/pages/settings/settings.gd
@@ -50,6 +50,7 @@ var check_button_submit_message_closes_chat: CheckButton = %CheckButton_SubmitMe
 @onready var hide_world_interactions_row: HBoxContainer = %HideWorldInteractions
 @onready var hide_player_names_row: HBoxContainer = %HidePlayerNames
 @onready var gamepad_camera_sensitivity: SettingsSlider = %GamepadCameraSensitivity
+@onready var check_button_gamepad_mode_enabled: CheckButton = %CheckButton_GamepadModeEnabled
 @onready var preview_camera_3d: Camera3D = %PreviewCamera3D
 @onready var preview_viewport_container: SubViewportContainer = %PreviewViewportContainer
 @onready var container_interface: MarginContainer = %Container_Interface
@@ -123,10 +124,12 @@ func _ready():
 		Global.session_hide_ui_options_sync.connect(_on_session_hide_ui_options_sync)
 	_refresh_hide_explorer_ui_row()
 
-	# TODO: replace with a proper gamepad mode flag once the enter-gamepad-mode dialog is implemented.
 	_init_gamepad_sensitivity.call_deferred()
-	container_gamepad.visible = false  # Input.get_connected_joypads().size() > 0
-	#Input.joy_connection_changed.connect(_on_joy_connection_changed)
+	var gamepad_enabled := Global.get_config().gamepad_mode_enabled
+	check_button_gamepad_mode_enabled.button_pressed = gamepad_enabled
+	container_gamepad.visible = Global.is_mobile()
+	gamepad_camera_sensitivity.visible = gamepad_enabled
+	Input.joy_connection_changed.connect(_on_joy_connection_changed)
 
 	dropdown_list_max_cache_size.add_item("1 GB", 0)
 	dropdown_list_max_cache_size.add_item("2 GB", 1)
@@ -885,10 +888,20 @@ func _on_gamepad_camera_sensitivity_value_changed(value: float) -> void:
 	Global.get_config().save_to_settings_file()
 
 
-# TODO: replace with a proper gamepad mode flag once the enter-gamepad-mode dialog is implemented.
+func _on_check_button_gamepad_mode_enabled_toggled(toggled_on: bool) -> void:
+	if Global.get_config().gamepad_mode_enabled != toggled_on:
+		Global.get_config().gamepad_mode_enabled = toggled_on
+		Global.get_config().save_to_settings_file()
+	gamepad_camera_sensitivity.visible = toggled_on
+	var explorer = Global.get_explorer()
+	if is_instance_valid(explorer):
+		explorer.apply_gamepad_mode()
+
+
 func _on_joy_connection_changed(_device: int, _connected: bool) -> void:
-	pass
-	#container_gamepad.visible = Input.get_connected_joypads().size() > 0
+	var explorer = Global.get_explorer()
+	if is_instance_valid(explorer):
+		explorer.apply_gamepad_mode()
 
 
 func _on_custom_button_sign_out_pressed() -> void:

--- a/godot/src/ui/pages/settings/settings.gd
+++ b/godot/src/ui/pages/settings/settings.gd
@@ -125,7 +125,7 @@ func _ready():
 	_refresh_hide_explorer_ui_row()
 
 	_init_gamepad_sensitivity.call_deferred()
-	var gamepad_enabled := Global.get_config().gamepad_mode_enabled
+	var gamepad_enabled: bool = Global.get_config().gamepad_mode_enabled
 	check_button_gamepad_mode_enabled.button_pressed = gamepad_enabled
 	container_gamepad.visible = Global.is_mobile()
 	gamepad_camera_sensitivity.visible = gamepad_enabled

--- a/godot/src/ui/pages/settings/settings.tscn
+++ b/godot/src/ui/pages/settings/settings.tscn
@@ -509,6 +509,25 @@ mouse_filter = 2
 theme_override_constants/separation = 24
 theme_override_styles/separator = SubResource("StyleBoxEmpty_xewta")
 
+[node name="EnableGamepadMode" type="HBoxContainer" parent="VBoxContainer/MarginContainer_Content/ContentScrollContainer/VBoxContainer_Sections/VBoxContainer_Gameplay/Container_Gamepad/SectionGamepad/VBoxContainer"]
+layout_mode = 2
+theme_override_constants/separation = 32
+
+[node name="Label_Title" type="Label" parent="VBoxContainer/MarginContainer_Content/ContentScrollContainer/VBoxContainer_Sections/VBoxContainer_Gameplay/Container_Gamepad/SectionGamepad/VBoxContainer/EnableGamepadMode"]
+layout_mode = 2
+size_flags_horizontal = 3
+theme_override_colors/font_color = Color(1, 1, 1, 1)
+theme_override_fonts/font = ExtResource("16_blskf")
+theme_override_font_sizes/font_size = 14
+text = "Enable Gamepad Mode"
+label_settings = ExtResource("17_67hd5")
+
+[node name="CheckButton_GamepadModeEnabled" type="CheckButton" parent="VBoxContainer/MarginContainer_Content/ContentScrollContainer/VBoxContainer_Sections/VBoxContainer_Gameplay/Container_Gamepad/SectionGamepad/VBoxContainer/EnableGamepadMode"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_vertical = 0
+theme = ExtResource("12_sa1v7")
+
 [node name="GamepadCameraSensitivity" parent="VBoxContainer/MarginContainer_Content/ContentScrollContainer/VBoxContainer_Sections/VBoxContainer_Gameplay/Container_Gamepad/SectionGamepad/VBoxContainer" unique_id=1354992146 instance=ExtResource("21_xewta")]
 unique_name_in_owner = true
 layout_mode = 2
@@ -1345,6 +1364,7 @@ font = ExtResource("25_jf4mt")
 [connection signal="toggled" from="VBoxContainer/MarginContainer_Content/ContentScrollContainer/VBoxContainer_Sections/VBoxContainer_Gameplay/Container_Interface/VBoxContainer/HidePlayerNames/CheckButton_HidePlayerNames" to="." method="_on_check_button_hide_player_names_toggled"]
 [connection signal="toggled" from="VBoxContainer/MarginContainer_Content/ContentScrollContainer/VBoxContainer_Sections/VBoxContainer_Gameplay/Container_Interface/VBoxContainer/HideViewProfile/CheckButton_HideViewProfile" to="." method="_on_check_button_hide_view_profile_toggled"]
 [connection signal="toggled" from="VBoxContainer/MarginContainer_Content/ContentScrollContainer/VBoxContainer_Sections/VBoxContainer_Gameplay/Container_Interface/VBoxContainer/HideWorldInteractions/CheckButton_HideWorldInteractions" to="." method="_on_check_button_hide_world_interactions_toggled"]
+[connection signal="toggled" from="VBoxContainer/MarginContainer_Content/ContentScrollContainer/VBoxContainer_Sections/VBoxContainer_Gameplay/Container_Gamepad/SectionGamepad/VBoxContainer/EnableGamepadMode/CheckButton_GamepadModeEnabled" to="." method="_on_check_button_gamepad_mode_enabled_toggled"]
 [connection signal="value_changed" from="VBoxContainer/MarginContainer_Content/ContentScrollContainer/VBoxContainer_Sections/VBoxContainer_Gameplay/Container_Gamepad/SectionGamepad/VBoxContainer/GamepadCameraSensitivity" to="." method="_on_gamepad_camera_sensitivity_value_changed"]
 [connection signal="visibility_changed" from="VBoxContainer/MarginContainer_Content/ContentScrollContainer/VBoxContainer_Sections/VBoxContainer_Storage" to="." method="_on_container_storage_visibility_changed"]
 [connection signal="pressed" from="VBoxContainer/MarginContainer_Content/ContentScrollContainer/VBoxContainer_Sections/VBoxContainer_Storage/Button_ClearCache" to="." method="_on_button_clear_cache_pressed"]


### PR DESCRIPTION
## Summary

- Adds a **Gamepad Mode** toggle in Settings > Gameplay > Gamepad (default: **off**)
- When **off**: gamepad detection is fully disabled — virtual controls always show, gamepad never hides UI
- When **on** and a physical gamepad is connected: virtual joystick/buttons hide, gamepad tooltips and camera sensitivity slider appear
- Setting is persisted to disk across sessions
- Replaces the previous approach of commenting out all gamepad code

Fixes https://github.com/decentraland/godot-explorer/issues/2167

### Files changed

- **`config_data.gd`** — New `gamepad_mode_enabled` bool setting with load/save/default
- **`settings.tscn`** — "Enable Gamepad Mode" toggle row in the Gamepad section
- **`settings.gd`** — Toggle handler, gamepad section always visible on mobile, sensitivity slider gated on toggle
- **`explorer.gd`** — New `apply_gamepad_mode()` combining setting + joystick detection; restores virtual controls logic
- **`tooltip_label.gd`** — Gamepad tooltip icons check `gamepad_mode_enabled && connected_joypads > 0`

## Test plan

- [ ] On mobile without gamepad: Gamepad section visible in settings, toggle is off, sensitivity slider hidden, virtual controls show
- [ ] Toggle gamepad mode on without a gamepad connected: sensitivity slider appears, virtual controls remain (no gamepad detected)
- [ ] Toggle on + connect Bluetooth gamepad: virtual joystick/buttons hide, gamepad tooltips appear
- [ ] Toggle off while gamepad connected: virtual controls restore immediately
- [ ] Restart app: toggle state persists
- [ ] Desktop: no regression (mobile-only section)