### PR TITLE
perf(tween): native Godot Tween for Move/Rotate/Scale [prototype, draft]

### DIFF
--- a/godot/src/tools/gp_benchmark_runner.gd
+++ b/godot/src/tools/gp_benchmark_runner.gd
@@ -811,6 +811,9 @@ func _apply_deeplink_overrides() -> void:
 	var cpbr: String = params.get("cheap-pbr", "")
 	if not cpbr.is_empty():
 		Global.cli.cheap_pbr_enabled = cpbr.to_lower() in ["true", "1", "yes"]
+	var ntw: String = params.get("native-tween", "")
+	if not ntw.is_empty():
+		Global.cli.native_tween_enabled = ntw.to_lower() in ["true", "1", "yes"]
 	var skipg: String = params.get("skip-gltf", "")
 	if not skipg.is_empty():
 		Global.cli.set_skip_gltf_load(skipg.to_lower() in ["true", "1", "yes"])

--- a/godot/src/tools/gp_benchmark_runner.gd
+++ b/godot/src/tools/gp_benchmark_runner.gd
@@ -814,6 +814,9 @@ func _apply_deeplink_overrides() -> void:
 	var ntw: String = params.get("native-tween", "")
 	if not ntw.is_empty():
 		Global.cli.native_tween_enabled = ntw.to_lower() in ["true", "1", "yes"]
+	var kanim: String = params.get("kill-anims", "")
+	if not kanim.is_empty():
+		Global.cli.kill_animations = kanim.to_lower() in ["true", "1", "yes"]
 	var skipg: String = params.get("skip-gltf", "")
 	if not skipg.is_empty():
 		Global.cli.set_skip_gltf_load(skipg.to_lower() in ["true", "1", "yes"])
@@ -954,6 +957,13 @@ func _set_phase(p: String) -> void:
 	phase = p
 	phase_started_at_ms = Time.get_ticks_msec()
 	_log("phase -> %s" % p)
+	# Diagnostic: --kill-animations / kill-anims deeplink — disable every
+	# AnimationPlayer + AnimationTree so the bench measures the animation-free
+	# ceiling. Done at warmup entry so it's settled before sampling. The Rust
+	# tween/animator updates are already gated by Global.cli.kill_animations.
+	if p == "warmup" and Global.cli.kill_animations:
+		var killed := _kill_all_animations(get_tree().root)
+		_log("kill-animations: disabled %d AnimationPlayer/Tree nodes" % killed)
 	# Markers consumed by scripts/bench/profile_android.sh / profile_ios.sh to
 	# trigger simpleperf / xctrace recording exactly during the sampling window.
 	if p == "sampling":
@@ -965,6 +975,26 @@ func _set_phase(p: String) -> void:
 		)
 	elif p == "done":
 		_log("PROFILE_WINDOW_END")
+
+
+func _kill_all_animations(node: Node) -> int:
+	var count := 0
+	if node is AnimationPlayer:
+		(node as AnimationPlayer).stop()
+		(node as AnimationPlayer).active = false
+		(node as AnimationPlayer).callback_mode_process = (
+			AnimationMixer.ANIMATION_CALLBACK_MODE_PROCESS_MANUAL
+		)
+		count += 1
+	elif node is AnimationTree:
+		(node as AnimationTree).active = false
+		(node as AnimationTree).callback_mode_process = (
+			AnimationMixer.ANIMATION_CALLBACK_MODE_PROCESS_MANUAL
+		)
+		count += 1
+	for child in node.get_children():
+		count += _kill_all_animations(child)
+	return count
 
 
 func _phase_elapsed_ms() -> int:

--- a/lib/src/godot_classes/dcl_cli.rs
+++ b/lib/src/godot_classes/dcl_cli.rs
@@ -163,6 +163,13 @@ pub struct DclCli {
     #[var]
     pub kill_sky: bool,
 
+    // Diagnostic: disable ALL animation drivers — skips update_tween +
+    // update_animator on the Rust side, and a GDScript sweep sets every
+    // AnimationPlayer / AnimationTree active=false. Measures the
+    // animation-free frame ceiling.
+    #[var]
+    pub kill_animations: bool,
+
     // Arguments with values
     #[var(get)]
     pub asset_server_port: i32,
@@ -529,6 +536,12 @@ impl DclCli {
                 category: "Debugging".to_string(),
             },
             ArgDefinition {
+                name: "--kill-animations".to_string(),
+                description: "Diagnostic: disable all animation drivers (tween + animator + AnimationPlayer/Tree sweep) to measure the animation-free frame ceiling. Default OFF".to_string(),
+                arg_type: ArgType::Flag,
+                category: "Debugging".to_string(),
+            },
+            ArgDefinition {
                 name: "--inspect-scene-title".to_string(),
                 description: "Attach the V8 inspector (port 9222) to the SDK7 scene whose title matches. Requires `--features enable_inspector`. Empty string = no scene gets inspector (default)".to_string(),
                 arg_type: ArgType::Value("<title>".to_string()),
@@ -750,6 +763,7 @@ impl INode for DclCli {
         let native_tween_enabled = args_map.contains_key("--native-tween");
         let skip_gltf_load = args_map.contains_key("--skip-gltf");
         let kill_sky = args_map.contains_key("--kill-sky");
+        let kill_animations = args_map.contains_key("--kill-animations");
         // bench_mode auto-enabled when gp_benchmark is set, so the desktop
         // CLI doesn't have to pass both. Mobile flips this from
         // deep_link_router.gd when it sees gp-benchmark=true.
@@ -881,6 +895,7 @@ impl INode for DclCli {
             native_tween_enabled,
             skip_gltf_load,
             kill_sky,
+            kill_animations,
             bench_mode,
             inspect_scene_title,
             asset_server_port,

--- a/lib/src/godot_classes/dcl_cli.rs
+++ b/lib/src/godot_classes/dcl_cli.rs
@@ -143,6 +143,14 @@ pub struct DclCli {
     #[var]
     pub cheap_pbr_enabled: bool,
 
+    // Migrate SDK7 Tween Move/Rotate/Scale modes from per-frame Rust
+    // interpolation + CRDT re-dirty to Godot's native Tween (RefCounted).
+    // Eliminates the double-pass (Rust calc → CRDT put → transform_and_parent
+    // apply); Godot processes all active tweens in one C++ loop. Continuous
+    // and TextureMove modes stay on the Rust path.
+    #[var]
+    pub native_tween_enabled: bool,
+
     // Diagnostic: skip every GltfContainer instantiation. Drains the dirty
     // set in `update_gltf_container` so the bench can measure the rendering
     // floor without any scene meshes loaded. Pure perf-debug knob.
@@ -503,6 +511,12 @@ impl DclCli {
                 category: "Performance".to_string(),
             },
             ArgDefinition {
+                name: "--native-tween".to_string(),
+                description: "Migrate SDK7 Tween Move/Rotate/Scale to Godot's native Tween. Default OFF".to_string(),
+                arg_type: ArgType::Flag,
+                category: "Performance".to_string(),
+            },
+            ArgDefinition {
                 name: "--skip-gltf".to_string(),
                 description: "Diagnostic: skip every GltfContainer instantiation so the renderer floor (sky+UI+avatar) can be measured. Default OFF".to_string(),
                 arg_type: ArgType::Flag,
@@ -733,6 +747,7 @@ impl INode for DclCli {
             .map(GString::from)
             .unwrap_or_default();
         let cheap_pbr_enabled = !args_map.contains_key("--no-cheap-pbr");
+        let native_tween_enabled = args_map.contains_key("--native-tween");
         let skip_gltf_load = args_map.contains_key("--skip-gltf");
         let kill_sky = args_map.contains_key("--kill-sky");
         // bench_mode auto-enabled when gp_benchmark is set, so the desktop
@@ -863,6 +878,7 @@ impl INode for DclCli {
             rs_gltf_direct,
             optimized_content_base_url,
             cheap_pbr_enabled,
+            native_tween_enabled,
             skip_gltf_load,
             kill_sky,
             bench_mode,

--- a/lib/src/scene_runner/components/animator.rs
+++ b/lib/src/scene_runner/components/animator.rs
@@ -19,6 +19,13 @@ fn get_gltf_container(godot_entity_node: &mut GodotEntityNode) -> Option<Gd<DclG
 }
 
 pub fn update_animator(scene: &mut Scene, crdt_state: &mut SceneCrdtState) {
+    // Diagnostic: --kill-animations disables every animation driver.
+    if crate::godot_classes::dcl_global::DclGlobal::try_singleton()
+        .map(|g| g.bind().cli.bind().kill_animations)
+        .unwrap_or(false)
+    {
+        return;
+    }
     let godot_dcl_scene = &mut scene.godot_dcl_scene;
     let dirty_lww_components = &scene.current_dirty.lww_components;
     if let Some(animator_dirty) = dirty_lww_components.get(&SceneComponentId::ANIMATOR) {

--- a/lib/src/scene_runner/components/tween.rs
+++ b/lib/src/scene_runner/components/tween.rs
@@ -2,7 +2,7 @@ use std::time::Duration;
 
 use godot::{
     builtin::Basis,
-    classes::{BaseMaterial3D, MeshInstance3D, Node3D},
+    classes::{tween::EaseType, tween::TransitionType, BaseMaterial3D, MeshInstance3D, Node3D},
     prelude::*,
 };
 
@@ -40,6 +40,14 @@ pub struct Tween {
     /// removes ~50 % of all `dirty_lww_entries/frame` in GP (measured
     /// 2026-05-06: TweenState=135/frame, ≈51 % of recv pressure).
     pub last_emitted_state: Option<i32>,
+    /// When `--native-tween` is enabled and the mode is Move/Rotate/Scale,
+    /// this holds the Godot Tween that drives `node.position/rotation/scale`
+    /// directly from C++. None means: tween not yet bound, or mode is not
+    /// native-eligible (Continuous / TextureMove still run via Rust loop).
+    pub godot_tween: Option<Gd<godot::classes::Tween>>,
+    /// Set to true once we've written the final transform value back to CRDT
+    /// after a native Godot tween finished, so SDK7 readout sees the end pose.
+    pub native_finalized: bool,
 }
 
 impl Tween {
@@ -150,6 +158,211 @@ fn apply_texture_animation_to_entity(
     }
 }
 
+fn easing_to_godot(ef: EasingFunction) -> (TransitionType, EaseType) {
+    use EasingFunction::*;
+    match ef {
+        EfLinear => (TransitionType::LINEAR, EaseType::IN_OUT),
+        EfEaseinquad => (TransitionType::QUAD, EaseType::IN),
+        EfEaseoutquad => (TransitionType::QUAD, EaseType::OUT),
+        EfEasequad => (TransitionType::QUAD, EaseType::IN_OUT),
+        EfEaseinsine => (TransitionType::SINE, EaseType::IN),
+        EfEaseoutsine => (TransitionType::SINE, EaseType::OUT),
+        EfEasesine => (TransitionType::SINE, EaseType::IN_OUT),
+        EfEaseinexpo => (TransitionType::EXPO, EaseType::IN),
+        EfEaseoutexpo => (TransitionType::EXPO, EaseType::OUT),
+        EfEaseexpo => (TransitionType::EXPO, EaseType::IN_OUT),
+        EfEaseinelastic => (TransitionType::ELASTIC, EaseType::IN),
+        EfEaseoutelastic => (TransitionType::ELASTIC, EaseType::OUT),
+        EfEaseelastic => (TransitionType::ELASTIC, EaseType::IN_OUT),
+        EfEaseinbounce => (TransitionType::BOUNCE, EaseType::IN),
+        EfEaseoutbounce => (TransitionType::BOUNCE, EaseType::OUT),
+        EfEasebounce => (TransitionType::BOUNCE, EaseType::IN_OUT),
+        EfEaseincubic => (TransitionType::CUBIC, EaseType::IN),
+        EfEaseoutcubic => (TransitionType::CUBIC, EaseType::OUT),
+        EfEasecubic => (TransitionType::CUBIC, EaseType::IN_OUT),
+        EfEaseinquart => (TransitionType::QUART, EaseType::IN),
+        EfEaseoutquart => (TransitionType::QUART, EaseType::OUT),
+        EfEasequart => (TransitionType::QUART, EaseType::IN_OUT),
+        EfEaseinquint => (TransitionType::QUINT, EaseType::IN),
+        EfEaseoutquint => (TransitionType::QUINT, EaseType::OUT),
+        EfEasequint => (TransitionType::QUINT, EaseType::IN_OUT),
+        EfEaseincirc => (TransitionType::CIRC, EaseType::IN),
+        EfEaseoutcirc => (TransitionType::CIRC, EaseType::OUT),
+        EfEasecirc => (TransitionType::CIRC, EaseType::IN_OUT),
+        EfEaseinback => (TransitionType::BACK, EaseType::IN),
+        EfEaseoutback => (TransitionType::BACK, EaseType::OUT),
+        EfEaseback => (TransitionType::BACK, EaseType::IN_OUT),
+    }
+}
+
+/// Modes where Godot's native Tween can drive the node property directly:
+/// position, quaternion, scale. Continuous + TextureMove stay on the Rust
+/// path because they need per-frame delta-time / UV callbacks.
+fn is_native_eligible(mode: &Option<Mode>) -> bool {
+    matches!(
+        mode,
+        Some(Mode::Move(_)) | Some(Mode::Rotate(_)) | Some(Mode::Scale(_))
+    )
+}
+
+/// Returns the final CRDT-side transform an SDK7 tween will produce when
+/// it completes. Caller writes this back to the CRDT after the Godot Tween
+/// finishes so SDK7 readout matches the rendered pose.
+fn final_transform_for(
+    crdt_state: &mut SceneCrdtState,
+    entity: &crate::dcl::components::SceneEntityId,
+    data: &PbTween,
+) -> Option<crate::dcl::components::transform_and_parent::DclTransformAndParent> {
+    let mut transform: crate::dcl::components::transform_and_parent::DclTransformAndParent =
+        crdt_state
+            .get_transform_mut()
+            .get(entity)
+            .and_then(|t| t.value.clone())
+            .unwrap_or_default();
+    match &data.mode {
+        Some(Mode::Move(d)) => {
+            let end = d.end.clone()?.to_godot();
+            if d.face_direction == Some(true) {
+                let start = d.start.clone()?.to_godot();
+                let direction = (end - start).normalized();
+                if !direction.is_zero_approx() {
+                    let v_x = godot::builtin::Vector3::UP.cross(direction);
+                    let v_x = if v_x.is_zero_approx() {
+                        godot::builtin::Vector3::FORWARD.cross(direction)
+                    } else {
+                        v_x
+                    }
+                    .normalized();
+                    let v_y = direction.cross(v_x);
+                    let mut basis = Basis::IDENTITY;
+                    basis.set_col_a(v_x);
+                    basis.set_col_b(v_y);
+                    basis.set_col_c(direction);
+                    transform.rotation = basis.get_quaternion();
+                }
+            }
+            transform.translation = end;
+            Some(transform)
+        }
+        Some(Mode::Rotate(d)) => {
+            transform.rotation = d.end.clone()?.to_godot();
+            Some(transform)
+        }
+        Some(Mode::Scale(d)) => {
+            transform.scale = d.end.clone()?.to_godot();
+            Some(transform)
+        }
+        _ => None,
+    }
+}
+
+/// Build a Godot `Tween` (RefCounted) bound to the entity's Node3D and
+/// configure it to drive position/quaternion/scale for the duration of
+/// the SDK7 tween. Stores the Gd<Tween> on the per-entity `Tween` so the
+/// main loop can poll its run state.
+fn setup_native_tween(scene: &mut Scene, entity: &crate::dcl::components::SceneEntityId) {
+    let Some(t) = scene.tweens.get(entity) else {
+        return;
+    };
+    let data = t.data.clone();
+    let ease_fn_input = match EasingFunction::from_i32(data.easing_function) {
+        Some(ef) => ef,
+        None => return,
+    };
+    let (trans_type, ease_type) = easing_to_godot(ease_fn_input);
+    let duration_secs = (data.duration as f64) / 1000.0;
+
+    // Get the entity's Node3D. ensure_node_3d returns a tuple — we want the
+    // Node3D handle.
+    let (_, mut node) = scene.godot_dcl_scene.ensure_node_3d(entity);
+
+    // For Move with face_direction, set the rotation upfront (one-shot)
+    // and let the tween drive position only.
+    if let Some(Mode::Move(d)) = &data.mode {
+        if d.face_direction == Some(true) {
+            if let (Some(start), Some(end)) = (d.start.clone(), d.end.clone()) {
+                let s = start.to_godot();
+                let e = end.to_godot();
+                let direction = (e - s).normalized();
+                if !direction.is_zero_approx() {
+                    let v_x = godot::builtin::Vector3::UP.cross(direction);
+                    let v_x = if v_x.is_zero_approx() {
+                        godot::builtin::Vector3::FORWARD.cross(direction)
+                    } else {
+                        v_x
+                    }
+                    .normalized();
+                    let v_y = direction.cross(v_x);
+                    let mut basis = Basis::IDENTITY;
+                    basis.set_col_a(v_x);
+                    basis.set_col_b(v_y);
+                    basis.set_col_c(direction);
+                    node.set_quaternion(basis.get_quaternion());
+                }
+            }
+        }
+    }
+
+    // Build the Godot Tween. node.create_tween() returns Option<Gd<Tween>>.
+    let Some(mut gt) = node.create_tween() else {
+        return;
+    };
+    gt.set_trans(trans_type);
+    gt.set_ease(ease_type);
+
+    match &data.mode {
+        Some(Mode::Move(d)) => {
+            let Some(start) = d.start.clone() else { return };
+            let Some(end) = d.end.clone() else { return };
+            // Set node position to start, then tween to end. Godot's Tween
+            // captures the "from" value at the moment tween_property is
+            // called; setting it explicitly avoids races with the parent
+            // hierarchy update.
+            node.set_position(start.to_godot());
+            if let Some(mut prop) = gt.tween_property(
+                &node.clone().upcast::<godot::classes::Object>(),
+                "position",
+                &end.to_godot().to_variant(),
+                duration_secs,
+            ) {
+                prop.from(&start.to_godot().to_variant());
+            }
+        }
+        Some(Mode::Rotate(d)) => {
+            let Some(start) = d.start.clone() else { return };
+            let Some(end) = d.end.clone() else { return };
+            node.set_quaternion(start.to_godot());
+            if let Some(mut prop) = gt.tween_property(
+                &node.clone().upcast::<godot::classes::Object>(),
+                "quaternion",
+                &end.to_godot().to_variant(),
+                duration_secs,
+            ) {
+                prop.from(&start.to_godot().to_variant());
+            }
+        }
+        Some(Mode::Scale(d)) => {
+            let Some(start) = d.start.clone() else { return };
+            let Some(end) = d.end.clone() else { return };
+            node.set_scale(start.to_godot());
+            if let Some(mut prop) = gt.tween_property(
+                &node.clone().upcast::<godot::classes::Object>(),
+                "scale",
+                &end.to_godot().to_variant(),
+                duration_secs,
+            ) {
+                prop.from(&start.to_godot().to_variant());
+            }
+        }
+        _ => {}
+    }
+
+    // Store the Gd<Tween> so the main loop can poll its run state.
+    if let Some(t_mut) = scene.tweens.get_mut(entity) {
+        t_mut.godot_tween = Some(gt);
+    }
+}
+
 pub fn update_tween(scene: &mut Scene, crdt_state: &mut SceneCrdtState) {
     let dirty_lww_components = &scene.current_dirty.lww_components;
     let tween_component = SceneCrdtStateProtoComponents::get_tween(crdt_state);
@@ -158,6 +371,10 @@ pub fn update_tween(scene: &mut Scene, crdt_state: &mut SceneCrdtState) {
 
     let mut tweens_to_delete = Vec::new();
     let mut texture_animations_to_apply = Vec::new();
+
+    let native_enabled = crate::godot_classes::dcl_global::DclGlobal::try_singleton()
+        .map(|g| g.bind().cli.bind().native_tween_enabled)
+        .unwrap_or(false);
 
     if let Some(tween_dirty) = dirty_lww_components.get(&SceneComponentId::TWEEN) {
         for entity in tween_dirty {
@@ -199,6 +416,12 @@ pub fn update_tween(scene: &mut Scene, crdt_state: &mut SceneCrdtState) {
                         || new_value.current_time.is_some();
                     if reset_tween {
                         existing_tween.start_time = now - offset_time;
+                        // Kill any active native Godot tween; the new mode/data
+                        // requires a fresh one (or falls back to Rust path).
+                        if let Some(mut gt) = existing_tween.godot_tween.take() {
+                            gt.kill();
+                        }
+                        existing_tween.native_finalized = false;
                     }
 
                     // copy new tween values
@@ -227,6 +450,8 @@ pub fn update_tween(scene: &mut Scene, crdt_state: &mut SceneCrdtState) {
                             playing: None,
                             last_update: now,
                             last_emitted_state: None,
+                            godot_tween: None,
+                            native_finalized: false,
                         },
                     );
                 };
@@ -235,7 +460,11 @@ pub fn update_tween(scene: &mut Scene, crdt_state: &mut SceneCrdtState) {
     }
 
     for entity in tweens_to_delete {
-        scene.tweens.remove(entity);
+        if let Some(mut t) = scene.tweens.remove(entity) {
+            if let Some(mut gt) = t.godot_tween.take() {
+                gt.kill();
+            }
+        }
         // Also clean up any texture animation state
         scene.texture_animations.remove(entity);
 
@@ -243,7 +472,91 @@ pub fn update_tween(scene: &mut Scene, crdt_state: &mut SceneCrdtState) {
         SceneCrdtStateProtoComponents::get_tween_state_mut(crdt_state).put(*entity, None);
     }
 
+    // ============================================================
+    // Native Godot Tween path (Move / Rotate / Scale only).
+    // ============================================================
+    // Pre-pass 1: setup Godot Tweens for newly-active native-eligible
+    // entities. Done outside the main loop so we can borrow both
+    // scene.tweens and scene.godot_dcl_scene.
+    if native_enabled {
+        let to_setup: Vec<crate::dcl::components::SceneEntityId> = scene
+            .tweens
+            .iter()
+            .filter(|(_, t)| {
+                is_native_eligible(&t.data.mode)
+                    && t.godot_tween.is_none()
+                    && !t.native_finalized
+                    && t.playing != Some(false)
+            })
+            .map(|(e, _)| *e)
+            .collect();
+        for entity in to_setup {
+            setup_native_tween(scene, &entity);
+        }
+    }
+
     for (entity, tween) in &mut scene.tweens {
+        // Native-path: Godot drives the property directly. We only emit
+        // TweenState on transitions and finalize CRDT once at the end.
+        if native_enabled && tween.godot_tween.is_some() {
+            let still_running = tween
+                .godot_tween
+                .as_mut()
+                .map(|gt| gt.is_running())
+                .unwrap_or(false);
+            let new_state_status = if !still_running {
+                TweenStateStatus::TsCompleted
+            } else if tween.playing == Some(false) {
+                TweenStateStatus::TsPaused
+            } else {
+                TweenStateStatus::TsActive
+            };
+            let new_state = new_state_status as i32;
+            if tween.last_emitted_state != Some(new_state) {
+                let progress = match new_state_status {
+                    TweenStateStatus::TsCompleted => 1.0,
+                    _ => {
+                        let elapsed = now.duration_since(tween.start_time).as_millis() as f32;
+                        (elapsed / tween.data.duration).clamp(0.0, 1.0)
+                    }
+                };
+                SceneCrdtStateProtoComponents::get_tween_state_mut(crdt_state).put(
+                    *entity,
+                    Some(PbTweenState {
+                        current_time: progress,
+                        state: new_state,
+                    }),
+                );
+                tween.last_emitted_state = Some(new_state);
+            }
+            // On completion, write final transform into CRDT so SDK7 readout
+            // sees the end pose (the Godot tween already wrote the node).
+            if !still_running && !tween.native_finalized {
+                if let Some(end_transform) = final_transform_for(crdt_state, entity, &tween.data) {
+                    crdt_state
+                        .get_transform_mut()
+                        .put(*entity, Some(end_transform));
+                    if let Some(dirty) = scene
+                        .current_dirty
+                        .lww_components
+                        .get_mut(&SceneComponentId::TRANSFORM)
+                    {
+                        dirty.insert_if_not_exists(*entity);
+                    } else {
+                        scene
+                            .current_dirty
+                            .lww_components
+                            .insert(SceneComponentId::TRANSFORM, vec![*entity]);
+                    }
+                }
+                tween.native_finalized = true;
+                // Drop the Gd<Tween> so it gets freed (it's already inert).
+                tween.godot_tween = None;
+            }
+            scene.kinematic_entities.insert(*entity);
+            continue;
+        }
+
         if tween.playing == Some(false) {
             continue;
         }

--- a/lib/src/scene_runner/components/tween.rs
+++ b/lib/src/scene_runner/components/tween.rs
@@ -364,6 +364,13 @@ fn setup_native_tween(scene: &mut Scene, entity: &crate::dcl::components::SceneE
 }
 
 pub fn update_tween(scene: &mut Scene, crdt_state: &mut SceneCrdtState) {
+    // Diagnostic: --kill-animations disables every animation driver.
+    if crate::godot_classes::dcl_global::DclGlobal::try_singleton()
+        .map(|g| g.bind().cli.bind().kill_animations)
+        .unwrap_or(false)
+    {
+        return;
+    }
     let dirty_lww_components = &scene.current_dirty.lww_components;
     let tween_component = SceneCrdtStateProtoComponents::get_tween(crdt_state);
 


### PR DESCRIPTION
## What

Prototype migrating SDK7 `Tween` Move/Rotate/Scale modes from the per-frame Rust interpolation loop to Godot's native `Tween` (RefCounted, no Node overhead). Stacked on #2025 (perf stack).

**Draft** — perf-neutral on Genesis Plaza; kept as an architectural reference + the diagnostic flag it produced. See findings below before merging.

## Changes

- **`--native-tween` flag** (default OFF, deeplink `native-tween=true`). When on, SDK7 Tween components with Move/Rotate/Scale modes are driven by a `Gd<Tween>` created via `node.create_tween()`, configured with the mapped Godot `TransitionType` + `EaseType`. Eliminates the double-pass (Rust calc → CRDT `put` → re-dirty → `transform_and_parent` apply); Godot processes all active tweens in one C++ loop.
  - `setup_native_tween()` builds the tween on first frame; the main loop only polls `is_running()` to emit `TweenState` on transition.
  - On completion: writes final transform back to CRDT (SDK7 readout parity), drops the `Gd<Tween>`.
  - On reset/delete/mode-change: `kill()` the existing tween.
  - Continuous + TextureMove modes stay on the Rust path (need per-frame delta-time / UV callbacks).
- **`--kill-animations` flag** (default OFF, deeplink `kill-anims=true`) — diagnostic. Gates `update_tween` + `update_animator` (Rust early-return) and sweeps the scene tree at warmup setting every AnimationPlayer/AnimationTree `active=false`. Measures the animation-free frame ceiling.

## Bench findings (A54, HIGH, GP ea9cc738)

### native-tween A/B

| metric | rust tween | native tween | Δ |
|---|---:|---:|---:|
| fps | 17.17 | 17.19 | +0.02 |
| render_gpu_ms | 55.49 | 54.88 | −0.61 |
| render_cpu_ms | 7.99 | 8.30 | +0.31 |
| primitives | 2.22M | 2.22M | ~0 |

**Perf-neutral.** GP barely uses SDK7 Move/Rotate/Scale tweens — its animation load is 144 AnimationPlayers + AnimationTrees (glTF/avatar), a different subsystem. The fogata (16 fire particles × Move+Rotate+Scale via `createOrReplace`) is the heaviest SDK7-tween user and renders **identically** with native ON (correctness validated visually), but ~48 tweens is too few to move the frame. Native tween would win on a scene with hundreds of long-lived concurrent tweens; GP isn't that scene.

### kill-animations diagnostic (counterintuitive)

| metric | baseline | kill-anims | Δ |
|---|---:|---:|---:|
| fps | 17.17 | 16.36 | **−0.81** |
| primitives | 2.22M | 2.90M | **+30%** |
| draws | 1951 | 2338 | **+387** |

Disabling all 209 AnimationPlayer/Tree nodes made perf **worse**: GP's animations do implicit culling (scale-to-0 particles, visibility tracks, off-screen motion). Frozen at bind-pose, that geometry strands on-screen → +30% primitives. **Animation is not the bottleneck in GP — it's the raw primitive/draw count** (geometry: tris, LODs, mesh dup). Confirms the scene-side GLTF audit is where the real lever is.

## Recommendation

Don't merge for perf — it's net-neutral on GP. Options:
- Keep as reference for scenes that ARE tween-heavy.
- Merge anyway for the architectural cleanup (no double-pass, ~250 LOC less Rust interpolation for those modes) if reviewers value it.
- The `--kill-animations` diagnostic flag is worth keeping regardless (cheap, gated, useful for future profiling).

## Test plan

- [x] `cargo clippy --release -- -D warnings` clean.
- [x] Fogata (Move/Rotate/Scale + createOrReplace churn) visually identical with native ON.
- [x] Bench A/B JSONs captured.
- [ ] Stress scene with 200+ concurrent long-lived tweens (not done — would quantify the theoretical upside).