### PR TITLE
fix: line_edit content margin top and bottom

### DIFF
--- a/godot/assets/themes/line_edit.tres
+++ b/godot/assets/themes/line_edit.tres
@@ -2,9 +2,9 @@
 
 [resource]
 content_margin_left = 16.0
-content_margin_top = 24.0
+content_margin_top = 12.0
 content_margin_right = 46.0
-content_margin_bottom = 16.0
+content_margin_bottom = 12.0
 bg_color = Color(0, 0, 0, 0.4)
 corner_radius_top_left = 12
 corner_radius_top_right = 12

--- a/godot/assets/themes/line_edit_error.tres
+++ b/godot/assets/themes/line_edit_error.tres
@@ -2,9 +2,9 @@
 
 [resource]
 content_margin_left = 16.0
-content_margin_top = 24.0
+content_margin_top = 12.0
 content_margin_right = 46.0
-content_margin_bottom = 16.0
+content_margin_bottom = 12.0
 bg_color = Color(0, 0, 0, 0.4)
 border_width_left = 1
 border_width_top = 1

--- a/godot/assets/themes/line_edit_focused.tres
+++ b/godot/assets/themes/line_edit_focused.tres
@@ -2,9 +2,9 @@
 
 [resource]
 content_margin_left = 16.0
-content_margin_top = 24.0
+content_margin_top = 12.0
 content_margin_right = 46.0
-content_margin_bottom = 16.0
+content_margin_bottom = 12.0
 bg_color = Color(0, 0, 0, 0.4)
 border_width_left = 1
 border_width_top = 1


### PR DESCRIPTION
## Summary
- Fix `content_margin_top` (24 → 12) and `content_margin_bottom` (16 → 12) in `line_edit.tres`, `line_edit_error.tres`, and `line_edit_focused.tres`
- Aligns vertical padding to be uniform (12px top and bottom)