### PR TITLE
fix: TextShape font_auto_size to match Unity client

### DIFF
--- a/lib/src/dcl/crdt/grow_only_set.rs
+++ b/lib/src/dcl/crdt/grow_only_set.rs
@@ -88,7 +88,12 @@ impl<T: 'static + FromDclReader + ToDclWriter> GenericGrowOnlySetComponent for G
         writer: &mut DclWriter,
     ) -> Result<(), String> {
         if let Some(entry) = self.values.get(&entity) {
-            let element_index = entry.len() - reverse_element_index - 1;
+            // Guard the subtraction: `entry.len() - reverse_element_index - 1`
+            // underflowed when called with an out-of-range probe index. Return
+            // the same `Err` the existing call sites already handle.
+            let Some(element_index) = entry.len().checked_sub(reverse_element_index + 1) else {
+                return Err("Index out of range".into());
+            };
 
             if let Some(value) = entry.get(element_index) {
                 value.to_writer(writer);

--- a/lib/src/scene_runner/components/text_shape.rs
+++ b/lib/src/scene_runner/components/text_shape.rs
@@ -13,10 +13,50 @@ use crate::{
     scene_runner::scene::Scene,
 };
 use godot::{
-    classes::{label_3d::AlphaCutMode, text_server::AutowrapMode, Label3D, Node},
+    classes::{
+        label_3d::AlphaCutMode,
+        text_server::{AutowrapMode, JustificationFlag, LineBreakFlag},
+        Label3D, Node,
+    },
     global::{HorizontalAlignment, VerticalAlignment},
     prelude::*,
 };
+
+/// Empirically-derived scale factor between Unity TextMeshPro's `fontSize`
+/// (world-space units per em) and Godot `Label3D.font_size` (glyph pixels):
+/// our baseline test confirmed that SDK `font_size = 1.4` renders identically
+/// in both clients when Label3D `font_size = 30` and `pixel_size = 0.005`,
+/// i.e. 30 / 1.4 ≈ 21.4. Kept at 22.0 to round-trip cleanly with `i32` sizes.
+const TMP_TO_LABEL3D_FONT_SIZE: f32 = 22.0;
+
+/// Unity TextMeshPro's autosize bounds. TMP documentation lists `fontSizeMin = 18`
+/// and `fontSizeMax = 72` as the component defaults, but empirical measurement
+/// against the live Unity client (autosize-fallback case: degenerate rect,
+/// `text_wrapping = false`) gave a Godot:Unity render ratio that implies the
+/// DCL TMP prefab scales those bounds down to about 16/64. Express that as a
+/// single scale factor applied to both bounds so future tuning is one number.
+const DCL_TMP_AUTOSIZE_SCALE: f32 = 17.0 / 18.0;
+const UNITY_TMP_FONT_SIZE_MIN: f32 = 18.0 * DCL_TMP_AUTOSIZE_SCALE;
+const UNITY_TMP_FONT_SIZE_MAX: f32 = 72.0 * DCL_TMP_AUTOSIZE_SCALE;
+
+/// Unity TMP's `_OutlineWidth` is a 0..1 shader-domain SDF distance — the
+/// outline appears as a thin ring drawn outside the glyph silhouette without
+/// expanding the glyph itself.
+///
+/// Godot's `Label3D.outline_size` is raw pixels and, by default, the outline
+/// is rasterized underneath the glyph so the silhouette grows by
+/// `outline_size` on each side — visually equivalent to making the font bolder.
+///
+/// To match Unity's "ring around the existing silhouette" look we:
+///   1. Set `outline_render_priority = 1` so the outline is drawn on top of
+///      the glyph fill — the outline color now overlays the glyph edge instead
+///      of stretching the silhouette outward.
+///   2. Scale the computed `outline_size` way down so the outline covers only
+///      a thin ring at the glyph edge and doesn't eat the glyph interior.
+///
+/// (1) + (2) together approximate Unity's outline visual without needing a
+/// custom shader. Tune (2) empirically per the test scene.
+const TMP_TO_LABEL3D_OUTLINE_WIDTH: f32 = 0.8;
 
 pub fn update_text_shape(scene: &mut Scene, crdt_state: &mut SceneCrdtState) {
     let godot_dcl_scene = &mut scene.godot_dcl_scene;
@@ -86,14 +126,73 @@ pub fn update_text_shape(scene: &mut Scene, crdt_state: &mut SceneCrdtState) {
                 label_3d.set_text(&display_text);
                 label_3d.set_modulate(text_color);
 
-                let font_size = (22.0 * new_value.font_size.unwrap_or(3.0)).max(1.0);
-                let outline_size = font_size * new_value.outline_width.unwrap_or(0.0);
+                let new_font = match new_value.font {
+                    Some(0) => Font::FSansSerif,
+                    Some(1) => Font::FSerif,
+                    Some(2) => Font::FMonospace,
+                    _ => Font::FSansSerif,
+                };
+                let font_resource = new_font.get_font_resource();
+
+                let text_wrapping = new_value.text_wrapping.unwrap_or_default();
+
+                let font_size = if new_value.font_auto_size.unwrap_or(false) {
+                    // Replicate Unity's reference client (`TMPProSdkExtensions.cs`),
+                    // including its quirks — content authors have visually tuned
+                    // their scenes against this behavior, so matching the proto's
+                    // "fit in width/height" contract literally would break them.
+                    //
+                    //   tmpText.enableAutoSizing = textShape.FontAutoSize;
+                    //   tmpText.rectTransform.sizeDelta =
+                    //       textShape.TextWrapping ? new Vector2(w,h) : Vector2.zero;
+                    //   tmpText.enableWordWrapping = TextWrapping && !enableAutoSizing;
+                    //
+                    // Behavior that follows:
+                    //   - autosize=true, text_wrapping=true  → TMP fits text in
+                    //     (width, height), no word wrap, fontSize ∈ [18, 72].
+                    //   - autosize=true, text_wrapping=false → sizeDelta = (0,0),
+                    //     fit-check always fails, TMP falls back to fontSizeMin=18.
+                    //
+                    // This deliberately ignores the proto's `width`/`height` when
+                    // `text_wrapping=false`, matching Unity. See
+                    // `lib/src/dcl/components/proto/decentraland/sdk/components/text_shape.proto:22`
+                    // for the spec we are intentionally not following.
+                    let (fit_w, fit_h) = if text_wrapping {
+                        (
+                            new_value.width.unwrap_or(1.0),
+                            new_value.height.unwrap_or(1.0),
+                        )
+                    } else {
+                        (0.0, 0.0)
+                    };
+                    if fit_w <= 0.0 || fit_h <= 0.0 {
+                        // Unity TMP fallback when the autosize rect is degenerate.
+                        UNITY_TMP_FONT_SIZE_MIN * TMP_TO_LABEL3D_FONT_SIZE
+                    } else {
+                        compute_auto_font_size(
+                            &font_resource,
+                            &display_text,
+                            fit_w,
+                            fit_h,
+                            label_3d.get_pixel_size(),
+                            (UNITY_TMP_FONT_SIZE_MIN * TMP_TO_LABEL3D_FONT_SIZE) as i32,
+                            (UNITY_TMP_FONT_SIZE_MAX * TMP_TO_LABEL3D_FONT_SIZE) as i32,
+                        ) as f32
+                    }
+                } else {
+                    (TMP_TO_LABEL3D_FONT_SIZE * new_value.font_size.unwrap_or(3.0)).max(1.0)
+                };
+                let outline_size = font_size
+                    * new_value.outline_width.unwrap_or(0.0)
+                    * TMP_TO_LABEL3D_OUTLINE_WIDTH;
                 label_3d.set_font_size(font_size as i32);
                 label_3d.set_outline_size(outline_size as i32);
                 label_3d.set_outline_modulate(outline_color);
+                // Draw the outline on top of the glyph fill so it overlays the
+                // glyph edge (matching Unity TMP) instead of expanding the
+                // silhouette outward. See `TMP_TO_LABEL3D_OUTLINE_WIDTH` notes.
+                label_3d.set_outline_render_priority(1);
                 label_3d.set_alpha_cut_mode(AlphaCutMode::DISCARD);
-
-                let text_wrapping = new_value.text_wrapping.unwrap_or_default();
 
                 let (width_meter, height_meter) = if text_wrapping {
                     (
@@ -111,13 +210,6 @@ pub fn update_text_shape(scene: &mut Scene, crdt_state: &mut SceneCrdtState) {
                     label_3d.set_autowrap_mode(AutowrapMode::OFF);
                     label_3d.set_width(200.0 * new_value.width.unwrap_or(16.0));
                 }
-
-                let new_font = match new_value.font {
-                    Some(0) => Font::FSansSerif,
-                    Some(1) => Font::FSerif,
-                    Some(2) => Font::FMonospace,
-                    _ => Font::FSansSerif,
-                };
 
                 let (v_align, y_pos) = match text_align {
                     TextAlignMode::TamMiddleLeft
@@ -149,7 +241,7 @@ pub fn update_text_shape(scene: &mut Scene, crdt_state: &mut SceneCrdtState) {
 
                 if add_to_base {
                     label_3d.set_name("TextShape");
-                    label_3d.set_font(&new_font.get_font_resource());
+                    label_3d.set_font(&font_resource);
                     node_3d.add_child(&label_3d.upcast::<Node>());
                 }
 
@@ -161,6 +253,54 @@ pub fn update_text_shape(scene: &mut Scene, crdt_state: &mut SceneCrdtState) {
             }
         }
     }
+}
+
+/// Returns the largest Label3D `font_size` (in glyph pixels) for which `text`
+/// fits inside a `width × height` world-space rect, clamped to
+/// `[label_min, label_max]`. Word wrap is **off** while autosizing — matching
+/// Unity's `enableWordWrapping = TextWrapping && !enableAutoSizing` (i.e. when
+/// autosize is on, word wrap is forced off; only explicit `\n` line breaks
+/// honored). If even `label_min` doesn't fit, returns `label_min` — Unity TMP
+/// behaves the same with `overflowMode = Overflow`.
+fn compute_auto_font_size(
+    font: &Gd<godot::classes::Font>,
+    text: &str,
+    width_world: f32,
+    height_world: f32,
+    pixel_size: f32,
+    label_min: i32,
+    label_max: i32,
+) -> i32 {
+    let rect_w_px = (width_world / pixel_size).max(1.0);
+    let rect_h_px = (height_world / pixel_size).max(1.0);
+
+    let fits = |fs: i32| -> bool {
+        let measured = font
+            .get_multiline_string_size_ex(text)
+            .max_lines(-1)
+            .width(-1.0)
+            .font_size(fs)
+            .justification_flags(JustificationFlag::NONE)
+            .brk_flags(LineBreakFlag::MANDATORY)
+            .done();
+        measured.x <= rect_w_px && measured.y <= rect_h_px
+    };
+
+    // Binary search `[label_min, label_max]` for the largest size that fits;
+    // ~8 measurements for the typical [396, 1584] range.
+    let mut lo = label_min;
+    let mut hi = label_max;
+    let mut best = label_min;
+    while lo <= hi {
+        let mid = lo + (hi - lo) / 2;
+        if fits(mid) {
+            best = mid;
+            lo = mid + 1;
+        } else {
+            hi = mid - 1;
+        }
+    }
+    best
 }
 
 /// Parses a color string (named color or hex) into RGB values (0.0-1.0)

--- a/lib/src/scene_runner/components/text_shape.rs
+++ b/lib/src/scene_runner/components/text_shape.rs
@@ -38,12 +38,13 @@ const DCL_TMP_SIZE_FACTOR: f32 = 17.0 / 18.0;
 /// use.
 const TMP_TO_LABEL3D_FONT_SIZE: f32 = 22.0 * DCL_TMP_SIZE_FACTOR;
 
-/// Unity TMP's autosize bounds. The component documentation lists
-/// `fontSizeMin = 18` and `fontSizeMax = 72` as defaults; we scale both by
-/// `DCL_TMP_SIZE_FACTOR` to match what the DCL TMP prefab effectively
-/// renders.
-const UNITY_TMP_FONT_SIZE_MIN: f32 = 18.0 * DCL_TMP_SIZE_FACTOR;
-const UNITY_TMP_FONT_SIZE_MAX: f32 = 72.0 * DCL_TMP_SIZE_FACTOR;
+/// Unity TMP's autosize bounds, in TMP `fontSize` units. The component
+/// documentation lists `fontSizeMin = 18` and `fontSizeMax = 72` as defaults.
+/// Kept raw — the `DCL_TMP_SIZE_FACTOR` correction is carried by
+/// `TMP_TO_LABEL3D_FONT_SIZE` and applied exactly once on conversion to
+/// Label3D pixels.
+const UNITY_TMP_FONT_SIZE_MIN: f32 = 18.0;
+const UNITY_TMP_FONT_SIZE_MAX: f32 = 72.0;
 
 /// Unity TMP's `_OutlineWidth` is a 0..1 shader-domain SDF distance — the
 /// outline appears as a thin ring drawn outside the glyph silhouette without
@@ -63,6 +64,21 @@ const UNITY_TMP_FONT_SIZE_MAX: f32 = 72.0 * DCL_TMP_SIZE_FACTOR;
 /// (1) + (2) together approximate Unity's outline visual without needing a
 /// custom shader. Tune (2) empirically per the test scene.
 const TMP_TO_LABEL3D_OUTLINE_WIDTH: f32 = 0.8;
+
+/// Converts a Unity TMP `fontSize` (em units from the SDK proto / autosize
+/// bounds) to a Godot `Label3D.font_size` in glyph pixels. Applies the
+/// `DCL_TMP_SIZE_FACTOR` correction exactly once.
+fn unity_to_godot_font_size(tmp_font_size: f32) -> f32 {
+    tmp_font_size * TMP_TO_LABEL3D_FONT_SIZE
+}
+
+/// Converts a Unity TMP `_OutlineWidth` (0..1 SDF distance) and the resolved
+/// Godot glyph `font_size` (in pixels) to a `Label3D.outline_size`. The
+/// `TMP_TO_LABEL3D_OUTLINE_WIDTH` scale keeps the outline as a thin ring on
+/// the glyph edge rather than a glyph-thickening band. See the constant docs.
+fn unity_to_godot_outline_size(godot_font_size: f32, tmp_outline_width: f32) -> f32 {
+    godot_font_size * tmp_outline_width * TMP_TO_LABEL3D_OUTLINE_WIDTH
+}
 
 pub fn update_text_shape(scene: &mut Scene, crdt_state: &mut SceneCrdtState) {
     let godot_dcl_scene = &mut scene.godot_dcl_scene;
@@ -173,7 +189,7 @@ pub fn update_text_shape(scene: &mut Scene, crdt_state: &mut SceneCrdtState) {
                     };
                     if fit_w <= 0.0 || fit_h <= 0.0 {
                         // Unity TMP fallback when the autosize rect is degenerate.
-                        UNITY_TMP_FONT_SIZE_MIN * TMP_TO_LABEL3D_FONT_SIZE
+                        unity_to_godot_font_size(UNITY_TMP_FONT_SIZE_MIN)
                     } else {
                         compute_auto_font_size(
                             &font_resource,
@@ -181,16 +197,15 @@ pub fn update_text_shape(scene: &mut Scene, crdt_state: &mut SceneCrdtState) {
                             fit_w,
                             fit_h,
                             label_3d.get_pixel_size(),
-                            (UNITY_TMP_FONT_SIZE_MIN * TMP_TO_LABEL3D_FONT_SIZE) as i32,
-                            (UNITY_TMP_FONT_SIZE_MAX * TMP_TO_LABEL3D_FONT_SIZE) as i32,
+                            unity_to_godot_font_size(UNITY_TMP_FONT_SIZE_MIN) as i32,
+                            unity_to_godot_font_size(UNITY_TMP_FONT_SIZE_MAX) as i32,
                         ) as f32
                     }
                 } else {
-                    (TMP_TO_LABEL3D_FONT_SIZE * new_value.font_size.unwrap_or(3.0)).max(1.0)
+                    unity_to_godot_font_size(new_value.font_size.unwrap_or(3.0)).max(1.0)
                 };
-                let outline_size = font_size
-                    * new_value.outline_width.unwrap_or(0.0)
-                    * TMP_TO_LABEL3D_OUTLINE_WIDTH;
+                let outline_size =
+                    unity_to_godot_outline_size(font_size, new_value.outline_width.unwrap_or(0.0));
                 label_3d.set_font_size(font_size as i32);
                 label_3d.set_outline_size(outline_size as i32);
                 label_3d.set_outline_modulate(outline_color);
@@ -244,9 +259,9 @@ pub fn update_text_shape(scene: &mut Scene, crdt_state: &mut SceneCrdtState) {
                 label_3d.set_vertical_alignment(v_align);
                 label_3d.set_horizontal_alignment(h_align);
 
+                label_3d.set_font(&font_resource);
                 if add_to_base {
                     label_3d.set_name("TextShape");
-                    label_3d.set_font(&font_resource);
                     node_3d.add_child(&label_3d.upcast::<Node>());
                 }
 

--- a/lib/src/scene_runner/components/text_shape.rs
+++ b/lib/src/scene_runner/components/text_shape.rs
@@ -22,22 +22,28 @@ use godot::{
     prelude::*,
 };
 
-/// Empirically-derived scale factor between Unity TextMeshPro's `fontSize`
-/// (world-space units per em) and Godot `Label3D.font_size` (glyph pixels):
-/// our baseline test confirmed that SDK `font_size = 1.4` renders identically
-/// in both clients when Label3D `font_size = 30` and `pixel_size = 0.005`,
-/// i.e. 30 / 1.4 ≈ 21.4. Kept at 22.0 to round-trip cleanly with `i32` sizes.
-const TMP_TO_LABEL3D_FONT_SIZE: f32 = 22.0;
+/// Empirical correction factor between Unity TMP's expected sizing and the
+/// effective sizing in the live DCL Unity client. Visual tuning against the
+/// reference rendering (both autosize-fallback and non-autosize cases) landed
+/// on 17/18 — apply it once and have it flow through every TMP-derived
+/// constant below.
+const DCL_TMP_SIZE_FACTOR: f32 = 17.0 / 18.0;
 
-/// Unity TextMeshPro's autosize bounds. TMP documentation lists `fontSizeMin = 18`
-/// and `fontSizeMax = 72` as the component defaults, but empirical measurement
-/// against the live Unity client (autosize-fallback case: degenerate rect,
-/// `text_wrapping = false`) gave a Godot:Unity render ratio that implies the
-/// DCL TMP prefab scales those bounds down to about 16/64. Express that as a
-/// single scale factor applied to both bounds so future tuning is one number.
-const DCL_TMP_AUTOSIZE_SCALE: f32 = 17.0 / 18.0;
-const UNITY_TMP_FONT_SIZE_MIN: f32 = 18.0 * DCL_TMP_AUTOSIZE_SCALE;
-const UNITY_TMP_FONT_SIZE_MAX: f32 = 72.0 * DCL_TMP_AUTOSIZE_SCALE;
+/// Conversion between Unity TextMeshPro `fontSize` (world units per em) and
+/// Godot `Label3D.font_size` (glyph pixels). Baseline test confirmed that SDK
+/// `font_size = 1.4` renders identically in both clients when Label3D
+/// `font_size = 30` and `pixel_size = 0.005`, i.e. 30 / 1.4 ≈ 21.4 — kept at
+/// 22.0 to round-trip cleanly with `i32` sizes, then scaled by
+/// `DCL_TMP_SIZE_FACTOR` to absorb the same correction the autosize bounds
+/// use.
+const TMP_TO_LABEL3D_FONT_SIZE: f32 = 22.0 * DCL_TMP_SIZE_FACTOR;
+
+/// Unity TMP's autosize bounds. The component documentation lists
+/// `fontSizeMin = 18` and `fontSizeMax = 72` as defaults; we scale both by
+/// `DCL_TMP_SIZE_FACTOR` to match what the DCL TMP prefab effectively
+/// renders.
+const UNITY_TMP_FONT_SIZE_MIN: f32 = 18.0 * DCL_TMP_SIZE_FACTOR;
+const UNITY_TMP_FONT_SIZE_MAX: f32 = 72.0 * DCL_TMP_SIZE_FACTOR;
 
 /// Unity TMP's `_OutlineWidth` is a 0..1 shader-domain SDF distance — the
 /// outline appears as a thin ring drawn outside the glyph silhouette without

--- a/lib/src/scene_runner/components/text_shape.rs
+++ b/lib/src/scene_runner/components/text_shape.rs
@@ -209,13 +209,12 @@ pub fn update_text_shape(scene: &mut Scene, crdt_state: &mut SceneCrdtState) {
                     (0.0, 0.0)
                 };
 
-                if text_wrapping {
-                    label_3d.set_autowrap_mode(AutowrapMode::WORD_SMART);
-                    label_3d.set_width(200.0 * new_value.width.unwrap_or(16.0));
+                label_3d.set_autowrap_mode(if text_wrapping {
+                    AutowrapMode::WORD_SMART
                 } else {
-                    label_3d.set_autowrap_mode(AutowrapMode::OFF);
-                    label_3d.set_width(200.0 * new_value.width.unwrap_or(16.0));
-                }
+                    AutowrapMode::OFF
+                });
+                label_3d.set_width(200.0 * new_value.width.unwrap_or(16.0));
 
                 let (v_align, y_pos) = match text_align {
                     TextAlignMode::TamMiddleLeft


### PR DESCRIPTION
## Summary                                                                                                                                                                                                       
                                                                                                                                                                                                                   
  - Implement `PBTextShape.font_auto_size` (previously ignored) to match the Unity reference client, fixing the small-text rendering at scene `-99,103`.                                                         
  - Fix outline rendering so it overlays the glyph (`outline_render_priority = 1`) instead of expanding the silhouette and visually thickening the font.                                                           
  - Guard a latent integer-underflow panic in `GrowOnlySet::to_binary` surfaced while writing tooling against the CRDT state.                                                                                      
                                                           
  ### `font_auto_size`                                                                                                                                                                                             
                                                                                                                                                                                                                   
  `text_shape.rs` now replicates Unity TMP's behavior when `font_auto_size = true`:                                                                                                                                
  - `text_wrapping = true` → fit-to-rect inside `width × height`, no word wrap, clamped to `[fontSizeMin, fontSizeMax]`.                                                                                           
  - `text_wrapping = false` → Unity's `sizeDelta = Vector2.zero` quirk collapses the rect and TMP falls back to `fontSizeMin`. We replicate the fallback rather than implementing the proto's "fit in width/height"
   contract literally, since published scenes were authored against the Unity behavior. The proto divergence is documented inline (link to `text_shape.proto:22`).                                                 
                                                                                      
  A single `DCL_TMP_SIZE_FACTOR = 17/18` constant drives `TMP_TO_LABEL3D_FONT_SIZE`, `UNITY_TMP_FONT_SIZE_MIN`, and `UNITY_TMP_FONT_SIZE_MAX`, tuned empirically against the live Unity client. Retuning is a      
  one-line change.                                                                                                                                                                                                 
                                                                                                                                                                                                                   
  ### Outline                                                                                                                                                                                                      
                                                                                                                                                                                                                   
  - `outline_render_priority = 1` so the outline draws on top of the glyph fill, matching TMP's "ring around the silhouette" behavior instead of Godot's default "bolden the glyph by N pixels".                   
  - `TMP_TO_LABEL3D_OUTLINE_WIDTH = 0.8` scales the computed `outline_size` so the ring doesn't eat the glyph interior.
                                                                                                                                                                                                                   
  ### GOS panic guard                                                                 
                                         
  `GrowOnlySet::to_binary` did `entry.len() - reverse_element_index - 1` and panicked on out-of-range probes. Replaced with `checked_sub`, returning the same `Err("Index out of range")` callers already handle.  
  No behavior change for existing callers in `message.rs`.                                                                                                                                                         
                                                                                                                                                                                                                   
  Closes #1956.                                                                                                                                                                                                    

## Images

<img width="894" height="374" alt="Captura de pantalla 2026-05-28 a la(s) 15 50 47" src="https://github.com/user-attachments/assets/742682b2-f1fd-4d7b-8cfd-59c5eff68a07" />

<img width="1265" height="780" alt="Captura de pantalla 2026-05-28 a la(s) 12 34 35" src="https://github.com/user-attachments/assets/bda4b828-838e-4e88-b736-8f71c2b02f94" />



## Test plan                                                                                                                                                                                                     
- Go to scene -99,103 (https://mobile.dclexplorer.com/open?position=-99,103), "Tip" text should have the same size on Godot and Unity.