### PR TITLE
fix: avatar impostors freeze instead of throttling near screen edges

### DIFF
--- a/godot/src/decentraland_components/avatar/avatar.gd
+++ b/godot/src/decentraland_components/avatar/avatar.gd
@@ -12,6 +12,12 @@ const DEBUG_SAVE_AVATAR_DATA = false
 # Useful to filter wearable categories (and distinguish between top_head and head)
 const WEARABLE_NAME_PREFIX = "__"
 
+# AABB for the off-screen freeze notifier — sized to cover the avatar including
+# arms-out emote poses. Erring large is the safe direction: a too-eager "on
+# screen" only animates an avatar that might be off-screen, whereas a too-eager
+# "off screen" freezes a drawn one.
+const SCREEN_NOTIFIER_AABB: AABB = AABB(Vector3(-1.0, -0.3, -1.0), Vector3(2.0, 2.8, 2.0))
+
 const TOON_SHADER = preload("res://assets/avatar/dcl_toon.gdshader")
 const TOON_SHADER_ALPHA_CLIP = preload("res://assets/avatar/dcl_toon_alpha_clip.gdshader")
 const TOON_SHADER_ALPHA_BLEND = preload("res://assets/avatar/dcl_toon_alpha_blend.gdshader")
@@ -174,10 +180,19 @@ var _impostor_layer_is_overflow: bool = false
 # entirely — no multimesh instance, no real layer, no capture. Disk cache makes
 # re-entry fast (texture rehydrates from PNG without recapture).
 var _off_frustum: bool = false
-# Latched while off-frustum: the AnimationTree was paused regardless of LOD
-# state, so when we come back in-frustum we know we have to restore the
+# Driven by _screen_notifier's screen_entered/screen_exited signals: Godot's
+# exact draw state for this avatar. The animation freeze keys off this, NOT the
+# coordinator's approximate _off_frustum sphere test — otherwise an avatar near
+# the screen edge (still drawn, but flagged off-frustum) or one sweeping into
+# view during the coordinator's 6-frame update lag freezes on a stale pose
+# instead of throttling. Default true so a freshly spawned avatar animates until
+# the notifier reports its real state.
+var _on_screen: bool = true
+var _screen_notifier: VisibleOnScreenNotifier3D = null
+# Latched while frozen off-screen: the AnimationTree was paused regardless of LOD
+# state, so when we come back on-screen we know we have to restore the
 # state-driven anim setup (active/manual/throttle).
-var _anim_frozen_off_frustum: bool = false
+var _anim_frozen_off_screen: bool = false
 # Wall-clock ms when the freeze started. Used to advance the AnimationTree by
 # the elapsed time on re-entry so the emote phase matches what it would have
 # been had we not paused — single one-shot recompute, not a frame-by-frame
@@ -258,6 +273,7 @@ func _ready():
 
 	_lod_phase = int(self.unique_id) % AvatarImpostorConfig.DISTANCE_CHECK_PERIOD_FRAMES
 	AvatarLODCoordinator.register(self)
+	_setup_screen_notifier()
 
 	# Setup metadata for raycast detection (same as DCL entities)
 	click_area.set_meta("is_avatar", true)
@@ -1241,7 +1257,10 @@ func _update_lod() -> void:
 			fade_alpha = 0.0
 
 	_apply_lod_state(new_state, dither_alpha, fade_alpha, tint_strength, dist)
-	_apply_off_frustum_anim_freeze()
+	# Reconcile against the notifier's current state in case a screen_entered /
+	# screen_exited signal was missed; idempotent thanks to the _anim_frozen_off_screen
+	# latch. Unfreezing still happens immediately in the signal handler.
+	AvatarLODHelpers.apply_screen_freeze(self)
 
 
 func _apply_lod_state(
@@ -1309,71 +1328,41 @@ func _release_impostor() -> void:
 
 
 func _on_lod_state_changed(new_state: int, _prev_state: int) -> void:
-	match new_state:
-		LODState.FULL:
-			AvatarLODHelpers.set_meshes_visible(self, true)
-			AvatarLODHelpers.set_animation_active(self, true)
-			AvatarLODHelpers.set_animation_speed(self, 1.0)
-			AvatarLODHelpers.set_animation_throttle(self, false)
-			AvatarLODHelpers.set_particles_visible(self, true)
-			AvatarLODHelpers.set_click_active(self, true)
-			_apply_nickname_visibility()
-		LODState.MID:
-			AvatarLODHelpers.set_meshes_visible(self, true)
-			AvatarLODHelpers.set_animation_active(self, true)
-			AvatarLODHelpers.set_animation_speed(self, 1.0)
-			AvatarLODHelpers.set_animation_throttle(self, true)
-			AvatarLODHelpers.set_particles_visible(self, false)
-			AvatarLODHelpers.set_click_active(self, false)
-			_apply_nickname_visibility()
-		LODState.CROSSFADE:
-			AvatarLODHelpers.set_meshes_visible(self, true)
-			AvatarLODHelpers.set_animation_active(self, true)
-			AvatarLODHelpers.set_animation_speed(self, 1.0)
-			AvatarLODHelpers.set_animation_throttle(self, true)
-			AvatarLODHelpers.set_particles_visible(self, false)
-			AvatarLODHelpers.set_click_active(self, false)
-			_apply_nickname_visibility()
-		LODState.FAR:
-			AvatarLODHelpers.set_meshes_visible(self, false)
-			AvatarLODHelpers.set_animation_active(self, false)
-			AvatarLODHelpers.set_animation_speed(self, 1.0)
-			AvatarLODHelpers.set_animation_throttle(self, false)
-			AvatarLODHelpers.set_particles_visible(self, false)
-			AvatarLODHelpers.set_click_active(self, false)
-			_apply_nickname_visibility()
+	var full: bool = new_state == LODState.FULL
+	AvatarLODHelpers.set_meshes_visible(self, new_state != LODState.FAR)
+	AvatarLODHelpers.set_particles_visible(self, full)
+	AvatarLODHelpers.set_click_active(self, full)
+	AvatarLODHelpers.set_animation_speed(self, 1.0)
+	# Animation drive is on-screen-aware so an off-screen avatar that changes LOD
+	# stays frozen rather than re-animating; apply_screen_freeze restores it on
+	# re-entry. Single source of truth shared with the freeze, so callback mode
+	# and throttle flag can never drift into the frozen-while-drawn state.
+	var drive: Dictionary = AvatarLODHelpers.resolve_anim_drive(_on_screen, new_state)
+	AvatarLODHelpers.set_animation_active(self, drive.active)
+	AvatarLODHelpers.set_animation_throttle(self, drive.throttle)
+	_apply_nickname_visibility()
 
 
-# Freeze the AnimationTree when off-frustum, regardless of LOD state. The mesh
-# is still visible logically (so re-entry doesn't pop), but Godot's GPU
-# frustum cull skips drawing it and the AnimationTree pauses CPU-side. On
-# re-entry we restore the state-driven anim setup and advance the tree by the
-# wall-clock time we were paused, so emote phase matches what it would have
-# been had we not paused — single recompute, no frame-by-frame catch-up.
-func _apply_off_frustum_anim_freeze() -> void:
-	if animation_tree == null:
-		return
-	if _off_frustum:
-		if not _anim_frozen_off_frustum:
-			animation_tree.active = false
-			_anim_throttle_active = false
-			_anim_freeze_start_ms = Time.get_ticks_msec()
-			_anim_frozen_off_frustum = true
-	elif _anim_frozen_off_frustum:
-		_anim_frozen_off_frustum = false
-		var elapsed_s: float = (Time.get_ticks_msec() - _anim_freeze_start_ms) / 1000.0
-		match _lod_state:
-			LODState.FULL:
-				AvatarLODHelpers.set_animation_active(self, true)
-				AvatarLODHelpers.set_animation_throttle(self, false)
-			LODState.MID, LODState.CROSSFADE:
-				AvatarLODHelpers.set_animation_active(self, true)
-				AvatarLODHelpers.set_animation_throttle(self, true)
-			LODState.FAR:
-				AvatarLODHelpers.set_animation_active(self, false)
-				AvatarLODHelpers.set_animation_throttle(self, false)
-		if animation_tree.active and elapsed_s > 0.0:
-			animation_tree.advance(elapsed_s)
+# Drive the animation freeze off Godot's own on-screen detection instead of the
+# coordinator's approximate, 6-frame-lagged _off_frustum flag. screen_entered /
+# screen_exited fire exactly when the avatar starts/stops being drawn, so the
+# freeze can never leave a visible avatar stuck on a stale pose.
+func _setup_screen_notifier() -> void:
+	_screen_notifier = VisibleOnScreenNotifier3D.new()
+	_screen_notifier.aabb = SCREEN_NOTIFIER_AABB
+	add_child(_screen_notifier)
+	_screen_notifier.screen_entered.connect(_on_avatar_screen_entered)
+	_screen_notifier.screen_exited.connect(_on_avatar_screen_exited)
+
+
+func _on_avatar_screen_entered() -> void:
+	_on_screen = true
+	AvatarLODHelpers.apply_screen_freeze(self)
+
+
+func _on_avatar_screen_exited() -> void:
+	_on_screen = false
+	AvatarLODHelpers.apply_screen_freeze(self)
 
 
 func _tick_animation_throttle(delta: float) -> void:
@@ -1406,9 +1395,9 @@ func _process(delta):
 		animation_tree.active = false
 		return
 
-	# Ensure animation tree is active for normal avatars
-	if not animation_tree.active:
-		animation_tree.active = true
+	# Ensure animation tree is active for normal avatars — but never undo an
+	# off-screen freeze (that re-activation is what left frozen avatars stuck).
+	AvatarLODHelpers.ensure_anim_active(self)
 
 	# #b18: `is_grounded` guard suppresses the all-false condition window at the
 	# jump apex (rise/fall ±0.3 deadband) so Idle doesn't leak in mid-air.

--- a/godot/src/decentraland_components/avatar/impostor/avatar_lod_helpers.gd
+++ b/godot/src/decentraland_components/avatar/impostor/avatar_lod_helpers.gd
@@ -1,8 +1,20 @@
 class_name AvatarLODHelpers
 extends RefCounted
 
-# Per-state node toggles used by Avatar._on_lod_state_changed. Extracted from
-# avatar.gd to keep that file under the gdlint max-file-lines cap.
+# Per-state node toggles used by Avatar._on_lod_state_changed, plus the
+# animation freeze/throttle policy (resolve_anim_drive / apply_screen_freeze /
+# ensure_anim_active). Extracted from avatar.gd to keep that file under the
+# gdlint max-file-lines cap and so the freeze/throttle invariant is unit-testable
+# headless without a full Avatar scene (see test/avatar/test_avatar_anim_throttle.gd).
+
+# Mirror of Avatar.LODState. Kept local so this helper and its unit test don't
+# pull in the full Avatar class (avoids a cyclic class_name reference, since
+# Avatar already depends on AvatarLODHelpers). Must stay in sync with avatar.gd;
+# the test asserts the values match.
+const LOD_FULL := 0
+const LOD_MID := 1
+const LOD_CROSSFADE := 2
+const LOD_FAR := 3
 
 
 static func set_meshes_visible(avatar, visible: bool) -> void:
@@ -49,6 +61,61 @@ static func set_animation_throttle(avatar, throttled: bool) -> void:
 		avatar.animation_tree.callback_mode_process = (
 			AnimationMixer.ANIMATION_CALLBACK_MODE_PROCESS_IDLE
 		)
+
+
+# Single source of truth for how the AnimationTree should be driven given the
+# avatar's real on-screen state (from VisibleOnScreenNotifier3D) and LOD state.
+# Returns {active, throttle}:
+#   off-screen        -> not active        (frozen; cull hides it, CPU saved)
+#   on-screen FULL    -> active, no throttle (full-rate animation)
+#   on-screen MID/XF  -> active, throttled  (~20fps via manual advance)
+#   on-screen FAR     -> not active        (real mesh hidden, impostor drawn)
+static func resolve_anim_drive(on_screen: bool, lod_state: int) -> Dictionary:
+	if not on_screen:
+		return {"active": false, "throttle": false}
+	match lod_state:
+		LOD_FULL:
+			return {"active": true, "throttle": false}
+		LOD_MID, LOD_CROSSFADE:
+			return {"active": true, "throttle": true}
+		_:
+			return {"active": false, "throttle": false}
+
+
+# Freeze the AnimationTree while the avatar is not being drawn, restore it when
+# it comes back. Always routes the throttle through set_animation_throttle so the
+# callback mode and _anim_throttle_active stay consistent: the freeze resets the
+# callback to IDLE, so even if something re-activates the tree (see
+# ensure_anim_active) it advances normally instead of being stuck in MANUAL with
+# no advance — the frozen-while-drawn bug. The local player is never frozen.
+static func apply_screen_freeze(avatar) -> void:
+	if avatar.animation_tree == null or avatar.is_local_player:
+		return
+	if not avatar._on_screen:
+		if not avatar._anim_frozen_off_screen:
+			set_animation_active(avatar, false)
+			set_animation_throttle(avatar, false)
+			avatar._anim_freeze_start_ms = Time.get_ticks_msec()
+			avatar._anim_frozen_off_screen = true
+	elif avatar._anim_frozen_off_screen:
+		avatar._anim_frozen_off_screen = false
+		var elapsed_s: float = (Time.get_ticks_msec() - avatar._anim_freeze_start_ms) / 1000.0
+		var drive: Dictionary = resolve_anim_drive(avatar._on_screen, avatar._lod_state)
+		set_animation_active(avatar, drive.active)
+		set_animation_throttle(avatar, drive.throttle)
+		# Advance by the wall-clock time we were paused so emote phase matches what
+		# it would have been — single recompute, no frame-by-frame catch-up.
+		if avatar.animation_tree.active and elapsed_s > 0.0:
+			avatar.animation_tree.advance(elapsed_s)
+
+
+# Keep the tree active for drawn avatars, but never undo an off-screen freeze.
+# Re-activating while frozen is what left avatars stuck instead of throttling.
+static func ensure_anim_active(avatar) -> void:
+	if avatar.animation_tree == null:
+		return
+	if not avatar._anim_frozen_off_screen and not avatar.animation_tree.active:
+		avatar.animation_tree.active = true
 
 
 static func set_particles_visible(avatar, visible: bool) -> void:

--- a/godot/src/test/avatar/test_avatar_anim_throttle.gd
+++ b/godot/src/test/avatar/test_avatar_anim_throttle.gd
@@ -1,0 +1,235 @@
+extends SceneTree
+
+# Regression test for the avatar-impostor "freezes instead of throttling" bug.
+#
+# When an avatar transitions from FULL (full-rate animation) to MID/CROSSFADE
+# (throttled), the AnimationTree is driven in MANUAL callback mode and advanced
+# every N frames. The off-screen freeze used to switch _anim_throttle_active off
+# WITHOUT resetting the callback mode, leaving the tree in MANUAL with nothing
+# advancing it; the per-frame re-activation then forced active=true, so an avatar
+# the on-screen check flagged as off-screen (screen edge / camera-pan lag) but
+# that Godot still drew appeared frozen on a stale pose instead of throttling.
+#
+# The fix routes every throttle change through AvatarLODHelpers.set_animation_throttle
+# (callback mode and flag move together) and drives the freeze off the real
+# VisibleOnScreenNotifier3D state. This test pins the invariant that makes the
+# bug impossible: the tree is never left "active + MANUAL + throttle-off".
+#
+# Run headless:
+#   .bin/godot/godot4_bin --headless --path godot \
+#     --script res://src/test/avatar/test_avatar_anim_throttle.gd
+
+# Preload only the (Global-free, RefCounted) helper so this test compiles
+# standalone under --script, without dragging in avatar.gd / the Global autoload.
+const H := preload("res://src/decentraland_components/avatar/impostor/avatar_lod_helpers.gd")
+
+# LODState values (mirror of Avatar.LODState / AvatarLODHelpers.LOD_*).
+const FULL := 0
+const MID := 1
+const CROSSFADE := 2
+const FAR := 3
+
+var _failures: Array[String] = []
+
+
+# Duck-typed stand-in for Avatar: exposes exactly the fields AvatarLODHelpers
+# reads/writes, plus a real (minimal) AnimationTree so advance()/active/callback
+# behave like production without needing the full Avatar scene.
+class FakeAvatar:
+	extends Node
+
+	var animation_tree: AnimationTree
+	var animation_player: AnimationPlayer = null
+	var is_local_player: bool = false
+	var _on_screen: bool = true
+	var _lod_state: int = 0
+	var _anim_throttle_active: bool = false
+	var _anim_throttle_acc: float = 0.0
+	var _anim_throttle_counter: int = 0
+	var _anim_frozen_off_screen: bool = false
+	var _anim_freeze_start_ms: int = 0
+
+
+func _initialize() -> void:
+	_test_local_constants_match_helper()
+	_test_resolve_policy()
+	_test_state_invariant_across_transitions()
+	_test_detects_frozen_while_drawn()
+	_finish()
+
+
+func _make_fake_avatar() -> FakeAvatar:
+	var fa := FakeAvatar.new()
+	var tree := AnimationTree.new()
+	var lib := AnimationLibrary.new()
+	var anim := Animation.new()
+	anim.length = 1.0
+	anim.loop_mode = Animation.LOOP_LINEAR
+	lib.add_animation("loop", anim)
+	tree.add_animation_library("", lib)
+	var anim_root := AnimationNodeAnimation.new()
+	anim_root.animation = "loop"
+	tree.tree_root = anim_root
+	fa.add_child(tree)
+	fa.animation_tree = tree
+	root.add_child(fa)
+	return fa
+
+
+func _is_manual(fa: FakeAvatar) -> bool:
+	return (
+		fa.animation_tree.callback_mode_process
+		== AnimationMixer.ANIMATION_CALLBACK_MODE_PROCESS_MANUAL
+	)
+
+
+# The core invariant: callback mode and the throttle flag must always agree, so
+# the tree can never sit "active + MANUAL + throttle-off" (frozen while drawn).
+func _check_invariant(fa: FakeAvatar, ctx: String) -> void:
+	var manual := _is_manual(fa)
+	if manual != fa._anim_throttle_active:
+		_fail(
+			(
+				"%s: callback MANUAL=%s but _anim_throttle_active=%s (inconsistent)"
+				% [ctx, manual, fa._anim_throttle_active]
+			)
+		)
+	if fa.animation_tree.active and manual and not fa._anim_throttle_active:
+		_fail("%s: FROZEN-WHILE-DRAWN (active + MANUAL + throttle off)" % ctx)
+	# On-screen, animating LOD ⇒ the tree must actually be running.
+	if fa._on_screen and fa._lod_state != FAR and not fa.is_local_player:
+		if not fa.animation_tree.active:
+			_fail("%s: on-screen LOD=%d but tree inactive (frozen)" % [ctx, fa._lod_state])
+	# Off-screen (non-FAR) ⇒ frozen, so the CPU saving actually holds.
+	if not fa._on_screen and not fa.is_local_player:
+		if fa.animation_tree.active:
+			_fail("%s: off-screen but tree still active (freeze didn't take)" % ctx)
+
+
+# Replicates Avatar._on_lod_state_changed's animation portion.
+func _set_lod(fa: FakeAvatar, lod: int) -> void:
+	fa._lod_state = lod
+	var drive: Dictionary = H.resolve_anim_drive(fa._on_screen, lod)
+	H.set_animation_active(fa, drive.active)
+	H.set_animation_throttle(fa, drive.throttle)
+
+
+# Replicates Avatar's screen notifier handler.
+func _set_on_screen(fa: FakeAvatar, on_screen: bool) -> void:
+	fa._on_screen = on_screen
+	H.apply_screen_freeze(fa)
+
+
+# Replicates one Avatar._process tick: reconcile freeze + guarded re-activation.
+func _tick(fa: FakeAvatar) -> void:
+	H.apply_screen_freeze(fa)
+	H.ensure_anim_active(fa)
+
+
+func _test_local_constants_match_helper() -> void:
+	_expect_eq("LOD_FULL", FULL, H.LOD_FULL)
+	_expect_eq("LOD_MID", MID, H.LOD_MID)
+	_expect_eq("LOD_CROSSFADE", CROSSFADE, H.LOD_CROSSFADE)
+	_expect_eq("LOD_FAR", FAR, H.LOD_FAR)
+
+
+func _test_resolve_policy() -> void:
+	# off-screen ⇒ frozen regardless of LOD
+	for lod in [FULL, MID, CROSSFADE, FAR]:
+		var d: Dictionary = H.resolve_anim_drive(false, lod)
+		_expect_drive("off-screen LOD=%d" % lod, d, false, false)
+	_expect_drive("on FULL", H.resolve_anim_drive(true, FULL), true, false)
+	_expect_drive("on MID", H.resolve_anim_drive(true, MID), true, true)
+	_expect_drive("on CROSSFADE", H.resolve_anim_drive(true, CROSSFADE), true, true)
+	_expect_drive("on FAR", H.resolve_anim_drive(true, FAR), false, false)
+
+
+# Walk the bug-prone transition sequences and assert the invariant after every
+# step. The headline case: FULL→MID (throttle on) → off-screen (freeze) → a
+# couple of _process ticks (re-activation) → back on-screen (restore).
+func _test_state_invariant_across_transitions() -> void:
+	var fa := _make_fake_avatar()
+
+	_set_on_screen(fa, true)
+	_set_lod(fa, FULL)
+	_check_invariant(fa, "on-screen FULL")
+
+	_set_lod(fa, MID)
+	_check_invariant(fa, "FULL→MID throttled")
+
+	_set_on_screen(fa, false)
+	_check_invariant(fa, "MID then off-screen (freeze)")
+
+	# The exact bug trigger: re-activation ticks while frozen must not unfreeze.
+	_tick(fa)
+	_check_invariant(fa, "frozen + _process tick #1")
+	_tick(fa)
+	_check_invariant(fa, "frozen + _process tick #2")
+
+	_set_on_screen(fa, true)
+	_check_invariant(fa, "back on-screen MID (restore)")
+	if not fa._anim_throttle_active:
+		_fail("back on-screen MID: throttle not restored (should be throttling)")
+
+	# Full matrix of on/off × every LOD, each followed by a tick.
+	for on_screen in [true, false]:
+		for lod in [FULL, MID, CROSSFADE, FAR]:
+			_set_lod(fa, lod)
+			_set_on_screen(fa, on_screen)
+			_tick(fa)
+			_check_invariant(fa, "matrix on=%s LOD=%d" % [on_screen, lod])
+
+	fa.queue_free()
+
+
+# Guard that the invariant check actually detects the historical bug state,
+# constructed by hand the way the old freeze + unguarded re-activation produced it.
+func _test_detects_frozen_while_drawn() -> void:
+	var fa := _make_fake_avatar()
+	fa._on_screen = true
+	fa._lod_state = MID
+	H.set_animation_throttle(fa, true)  # MANUAL + throttle flag on
+	# Old bug: freeze cleared the flag directly, leaving callback in MANUAL …
+	fa._anim_throttle_active = false
+	# … then the unguarded re-activation forced the tree back on.
+	fa.animation_tree.active = true
+
+	var before := _failures.size()
+	_check_invariant(fa, "synthetic old-bug state")
+	if _failures.size() == before:
+		_fail("invariant check failed to detect the frozen-while-drawn bug state")
+	else:
+		# Expected detections — drop them so the suite still passes.
+		_failures.resize(before)
+
+	fa.queue_free()
+
+
+func _expect_drive(ctx: String, d: Dictionary, active: bool, throttle: bool) -> void:
+	if d.get("active") != active or d.get("throttle") != throttle:
+		_fail(
+			(
+				"%s: resolve_anim_drive=%s, expected {active:%s, throttle:%s}"
+				% [ctx, str(d), active, throttle]
+			)
+		)
+
+
+func _expect_eq(ctx: String, actual: int, expected: int) -> void:
+	if actual != expected:
+		_fail("%s: got %d, expected %d" % [ctx, actual, expected])
+
+
+func _fail(msg: String) -> void:
+	_failures.append(msg)
+
+
+func _finish() -> void:
+	if _failures.is_empty():
+		print("[test_avatar_anim_throttle] PASS")
+		quit(0)
+		return
+	for f in _failures:
+		printerr(f)
+	printerr("[test_avatar_anim_throttle] FAIL: %d case(s)" % _failures.size())
+	quit(1)

--- a/godot/src/test/avatar/test_avatar_anim_throttle.gd.uid
+++ b/godot/src/test/avatar/test_avatar_anim_throttle.gd.uid
@@ -1,0 +1,1 @@
+uid://dx2li15hluye4


### PR DESCRIPTION
Closes #2177

## Problem

Avatar impostors at MID/CROSSFADE range sometimes **froze on a static pose instead of throttling** — the bug reported as "se clava sin animación en vez de throttlear" when going from fully-animated to throttled.

### Root cause

Throttled avatars drive the `AnimationTree` in `MANUAL` callback mode and advance it every N frames. The off-screen animation freeze cleared `_anim_throttle_active` **without resetting the callback mode**, leaving the tree in `MANUAL` with nothing to advance it. The per-frame re-activation (`if not active: active = true`) then forced `active = true`, producing the stuck state:

> `active = true` + callback `MANUAL` + `_anim_throttle_active = false` → tree "active" but never advanced → **frozen pose**.

It only showed up "sometimes" because the freeze was driven by the LOD coordinator's **approximate, 6-frame-lagged** frustum test (a single `is_position_in_frustum` on a sphere point). Avatars at **screen edges** or sweeping in **during a camera pan** got flagged off-screen while Godot still drew them — so they sat frozen-while-visible and never hit the clean restore path.

## Fix

- **Drive the freeze off the avatar's real on-screen state** via `VisibleOnScreenNotifier3D` (`screen_entered`/`screen_exited`) instead of the coordinator's approximate flag, so freeze ⟺ actually not drawn (no edge-band or lag false positives). The coordinator's `_off_frustum` now only governs impostor-slot release.
- **Route every throttle change through `set_animation_throttle`** so callback mode and the throttle flag always move together. The freeze now resets the callback to `IDLE`, so even a stray re-activation animates normally instead of freezing.
- **Centralize the animation drive** in `AvatarLODHelpers` (`resolve_anim_drive` / `apply_screen_freeze` / `ensure_anim_active`) as a single source of truth, replacing the scattered per-LOD-state animation toggles.
- The local player is never frozen.

## Test

Adds `godot/src/test/avatar/test_avatar_anim_throttle.gd` — a headless `SceneTree` regression test (same style as `test_avatar_modifier_exclude_ids.gd`) that walks the real transition sequences (FULL→MID→off-screen→ticks→on-screen + the full on/off × LOD matrix) over a duck-typed avatar with a real `AnimationTree`, using the real `AvatarLODHelpers` functions, and pins the invariant:

> an on-screen avatar in FULL/MID/CROSSFADE is **never** left `active + MANUAL + throttle-off` (frozen while drawn).

Verified the test **fails on the old behavior** (reintroduced the bug → `FROZEN-WHILE-DRAWN` detected, exit 1) and **passes on the fix** (exit 0). Run it with:

\`\`\`
.bin/godot/godot4_bin --headless --path godot --script res://src/test/avatar/test_avatar_anim_throttle.gd
\`\`\`

## Verification

- Pre-commit `full-tests` green (fmt / gdlint / cargo check / clippy / rust tests / GDScript validation).
- Deployed and confirmed working on physical iPhone 16e (iOS) and Galaxy A54 (Android).