### PR TITLE
fix: full session teardown on sign out (fresh lobby like an app restart)

### DIFF
--- a/godot/src/global.gd
+++ b/godot/src/global.gd
@@ -727,10 +727,14 @@ func sign_out() -> void:
 	#    second logout() no-ops once the address is already cleared.
 	comms.disconnect(true)
 
-	# 6. The Explorer reparents scene_runner.base_ui into its tree; freeing the
-	#    Explorer leaves a dangling pointer. Recreate it now so nothing touches a
-	#    freed node before the next Explorer load.
+	# 6. Reset the scene_runner's Godot-node handles before the Explorer (and its
+	#    Player) is freed. The #[var] player-node getters PANIC on a freed instance
+	#    and survivors poll them after sign-out (e.g. the analytics first-move poll
+	#    reads player_body_node); base_ui is reparented into the Explorer and would
+	#    dangle too. Reset them to safe placeholders / a fresh instance now.
+	scene_runner.clear_player_nodes()
 	scene_runner.recreate_base_ui()
+	player_camera_node = null
 
 	# 7. Erase the persisted session (ephemeral keys / wallet bytes) from disk.
 	#    Everything else (graphics, last realm, content cache) is intentionally

--- a/godot/src/global.gd
+++ b/godot/src/global.gd
@@ -139,6 +139,12 @@ var _safe_margin_debug_overlay: SafeMarginDebugOverlay = null
 # Startup instrumentation timestamp (set once at load time)
 var _startup_time: int = Time.get_ticks_msec()
 
+# Guards sign_out() against re-entrancy. comms.disconnect(true) emits the
+# player_identity.logout signal deferred, which can route back into sign_out() a
+# frame later; without this the whole teardown + scene swap would run twice.
+# Cleared in lobby._ready once we're back on a clean screen.
+var _signing_out: bool = false
+
 
 func is_xr() -> bool:
 	return OS.has_feature("xr") or get_viewport().use_xr
@@ -675,7 +681,25 @@ func get_explorer() -> Explorer:
 	return null
 
 
+## Single canonical sign-out / logout entry point. Tears down the live session —
+## explorer signals & timers, social streams, every running DCL scene, comms,
+## realm, scene-fetcher state and the Rust player identity — then returns to a
+## fresh lobby so the next login starts as if the app had restarted. Every UI
+## logout button and the disconnect handler funnel through here.
 func sign_out() -> void:
+	if _signing_out:
+		return
+	_signing_out = true
+
+	# 1. Tear down the live Explorer first, while it is still in the tree, so its
+	#    autoload-signal callbacks and retry timers are severed before the steps
+	#    below re-emit any of those signals (orientation, realm clear, scene kill)
+	#    or free the Explorer node.
+	var explorer := get_explorer()
+	if explorer != null:
+		explorer.prepare_for_logout()
+
+	# 2. Stop session pollers and tear down the social gRPC streams.
 	NotificationsManager.stop_polling()
 	social_service.unsubscribe_from_updates()
 	social_service.unsubscribe_from_connectivity_updates()
@@ -686,12 +710,42 @@ func sign_out() -> void:
 	social_service.disconnect()
 	social_blacklist.clear_blocked()
 	social_blacklist.clear_muted()
+
+	# 3. Kill every running DCL scene. kill_all_scenes() marks them ToKill; the
+	#    SceneManager reaps them in the background (reap_dying_scenes runs even
+	#    while the lobby pauses the runner), tearing down their V8/Deno threads.
+	scene_runner.kill_all_scenes()
+
+	# 4. Reset realm and scene-fetcher state so nothing from the old session leaks
+	#    into the next login. async_clear_realm() runs synchronously here (it only
+	#    zeroes realm fields and kills scenes — no network await before returning).
+	realm.async_clear_realm()
+	scene_fetcher.reset_for_logout()
+
+	# 5. Close comms (MainRoom / SceneRoom / LiveKit) AND clear the Rust player
+	#    identity (wallet + ephemeral keys). disconnect(true) is idempotent: a
+	#    second logout() no-ops once the address is already cleared.
+	comms.disconnect(true)
+
+	# 6. The Explorer reparents scene_runner.base_ui into its tree; freeing the
+	#    Explorer leaves a dangling pointer. Recreate it now so nothing touches a
+	#    freed node before the next Explorer load.
+	scene_runner.recreate_base_ui()
+
+	# 7. Erase the persisted session (ephemeral keys / wallet bytes) from disk.
+	#    Everything else (graphics, last realm, content cache) is intentionally
+	#    kept — this is a sign-out, not a factory reset.
 	get_config().session_account = {}
 	get_config().save_to_settings_file()
+
 	# Lobby/login is portrait-only; reset orientation so logging out from a
 	# landscape screen (e.g. settings panel) doesn't strand the user there.
 	set_orientation_portrait()
-	get_tree().change_scene_to_file("res://src/ui/pages/auth/lobby.tscn")
+
+	# 8. Swap to a fresh lobby on the next frame, after the current signal/await
+	#    stack fully unwinds (sign_out may have been reached via the deferred
+	#    logout signal). lobby._ready clears _signing_out.
+	get_tree().change_scene_to_file.call_deferred("res://src/ui/pages/auth/lobby.tscn")
 
 
 func explorer_has_focus() -> bool:

--- a/godot/src/global.gd
+++ b/godot/src/global.gd
@@ -701,6 +701,11 @@ func sign_out() -> void:
 
 	# 2. Stop session pollers and tear down the social gRPC streams.
 	NotificationsManager.stop_polling()
+	# The analytics first-move poll (a Timer under this autoload) reads
+	# scene_runner.player_body_node; left running it would poll the freed Player
+	# after the swap, panicking the #[var] getter. It restarts on the next login.
+	if analytics_controller != null:
+		analytics_controller.cancel_first_move_poll()
 	social_service.unsubscribe_from_updates()
 	social_service.unsubscribe_from_connectivity_updates()
 	social_service.unsubscribe_from_block_updates()
@@ -727,19 +732,14 @@ func sign_out() -> void:
 	#    second logout() no-ops once the address is already cleared.
 	comms.disconnect(true)
 
-	# 6. Reset the scene_runner's dangling player-node handles before the Explorer
-	#    (and its Player) is freed. The #[var] player-node getters PANIC on a freed
-	#    instance and survivors poll them after sign-out (e.g. the analytics
-	#    first-move poll reads player_body_node), so swap in safe placeholders.
-	#    base_ui is intentionally NOT recreated here: it (and the dying scenes' UI
-	#    roots parented under it) must stay alive until the scenes are reaped;
-	#    explorer._ready() recreates it on the next login.
-	scene_runner.clear_player_nodes()
-	player_camera_node = null
-
-	# 7. Erase the persisted session (ephemeral keys / wallet bytes) from disk.
+	# 6. Erase the persisted session (ephemeral keys / wallet bytes) from disk.
 	#    Everything else (graphics, last realm, content cache) is intentionally
 	#    kept — this is a sign-out, not a factory reset.
+	#
+	#    Note: the scene_runner's player-node handles (and base_ui) are deliberately
+	#    left as-is — once the Explorer is freed they report is_instance_valid()==false
+	#    and the SceneManager's existing guards skip them; explorer._ready() reassigns
+	#    them on the next login.
 	get_config().session_account = {}
 	get_config().save_to_settings_file()
 

--- a/godot/src/global.gd
+++ b/godot/src/global.gd
@@ -727,13 +727,14 @@ func sign_out() -> void:
 	#    second logout() no-ops once the address is already cleared.
 	comms.disconnect(true)
 
-	# 6. Reset the scene_runner's Godot-node handles before the Explorer (and its
-	#    Player) is freed. The #[var] player-node getters PANIC on a freed instance
-	#    and survivors poll them after sign-out (e.g. the analytics first-move poll
-	#    reads player_body_node); base_ui is reparented into the Explorer and would
-	#    dangle too. Reset them to safe placeholders / a fresh instance now.
+	# 6. Reset the scene_runner's dangling player-node handles before the Explorer
+	#    (and its Player) is freed. The #[var] player-node getters PANIC on a freed
+	#    instance and survivors poll them after sign-out (e.g. the analytics
+	#    first-move poll reads player_body_node), so swap in safe placeholders.
+	#    base_ui is intentionally NOT recreated here: it (and the dying scenes' UI
+	#    roots parented under it) must stay alive until the scenes are reaped;
+	#    explorer._ready() recreates it on the next login.
 	scene_runner.clear_player_nodes()
-	scene_runner.recreate_base_ui()
 	player_camera_node = null
 
 	# 7. Erase the persisted session (ephemeral keys / wallet bytes) from disk.

--- a/godot/src/global.gd
+++ b/godot/src/global.gd
@@ -145,6 +145,11 @@ var _startup_time: int = Time.get_ticks_msec()
 # Cleared in lobby._ready once we're back on a clean screen.
 var _signing_out: bool = false
 
+# Guards return_to_discover() against re-entrancy (e.g. a double tap on the Dev
+# Tools button before the deferred scene swap runs). Cleared in menu._ready once
+# we're back on the standalone Discover screen.
+var _returning_to_discover: bool = false
+
 
 func is_xr() -> bool:
 	return OS.has_feature("xr") or get_viewport().use_xr
@@ -753,6 +758,69 @@ func sign_out() -> void:
 	get_tree().change_scene_to_file.call_deferred("res://src/ui/pages/auth/lobby.tscn")
 
 
+## Soft sign-out used by the Dev Tools "RETURN TO DISCOVER" button. Leaves the
+## current world and drops the user back on the standalone Discover menu WHILE
+## staying signed in: it tears down the live Explorer, every running DCL scene,
+## comms world rooms and realm / scene-fetcher state, but deliberately KEEPS the
+## player identity, the persisted session, the social gRPC streams and the
+## notification polling intact.
+##
+## This mirrors the world-teardown half of [sign_out]; the two intentionally
+## differ — sign_out additionally drops the social streams, wipes the
+## session/identity and returns to the sign-in lobby. When adding a new
+## world/scene subsystem to tear down, update BOTH paths.
+func return_to_discover() -> void:
+	if _returning_to_discover or _signing_out:
+		return
+	_returning_to_discover = true
+
+	# 1. Tear down the live Explorer first, while it is still in the tree, so its
+	#    autoload-signal callbacks and retry timers are severed before the steps
+	#    below re-emit any of those signals or free the Explorer node. No-op when
+	#    the button is pressed from the standalone Discover menu (no Explorer yet).
+	var explorer := get_explorer()
+	if explorer != null:
+		explorer.prepare_for_logout()
+
+	# 2. Stop the analytics first-move poll: it reads scene_runner.player_body_node,
+	#    which is freed once the Explorer goes away — left running, its #[var]
+	#    getter would panic on the freed Player. It re-arms on the next
+	#    loading_finished (i.e. when the user jumps into a world again).
+	if analytics_controller != null:
+		analytics_controller.cancel_first_move_poll()
+
+	# 3. Kill every running DCL scene. The SceneManager reaps them in the
+	#    background (reap_dying_scenes runs even while Discover pauses the runner).
+	scene_runner.kill_all_scenes()
+
+	# 4. Reset realm and scene-fetcher state so nothing from the world we just left
+	#    leaks into the next jump-in. This matches the post-login Discover state,
+	#    where no realm is joined yet.
+	realm.async_clear_realm()
+	scene_fetcher.reset_for_logout()
+
+	# 5. Close comms world rooms (MainRoom / SceneRoom / LiveKit). Pass `false` so
+	#    the Rust player identity (wallet + ephemeral keys) is KEPT — this is the
+	#    key difference from sign_out, which passes `true` to also log out.
+	comms.disconnect(false)
+
+	# NOTE: unlike sign_out we deliberately DO NOT stop NotificationsManager
+	# polling, drop the social gRPC streams, clear the blacklist, or wipe the
+	# persisted session — the session stays alive and the Discover screen's
+	# friends/notifications keep working.
+
+	# Discover/menu is portrait-only; reset orientation so returning from a
+	# landscape in-world screen (settings) doesn't strand the user in landscape.
+	set_orientation_portrait()
+
+	# Swap to the standalone Discover menu on the next frame, after the current
+	# call stack (the settings button handler) fully unwinds. menu._ready clears
+	# _returning_to_discover.
+	get_tree().change_scene_to_file.call_deferred(
+		"res://src/ui/components/organisms/menu/menu.tscn"
+	)
+
+
 func explorer_has_focus() -> bool:
 	var explorer = get_explorer()
 	if explorer == null:
@@ -1047,7 +1115,7 @@ func async_join_world(world_realm: String) -> void:
 		get_tree().change_scene_to_file("res://src/ui/explorer.tscn")
 
 
-func http_method_to_string(method: int) -> String:
+func _http_method_to_string(method: int) -> String:
 	match method:
 		HTTPClient.METHOD_GET:
 			return "GET"
@@ -1073,7 +1141,7 @@ func http_method_to_string(method: int) -> String:
 
 func async_signed_fetch(url: String, method: int, _body: String = ""):
 	var headers_promise = Global.player_identity.async_get_identity_headers(
-		url, _body, http_method_to_string(method)
+		url, _body, _http_method_to_string(method)
 	)
 	var headers_result = await PromiseUtils.async_awaiter(headers_promise)
 

--- a/godot/src/logic/metrics/analytics_controller.gd
+++ b/godot/src/logic/metrics/analytics_controller.gd
@@ -114,6 +114,13 @@ func _stop_first_move_poller() -> void:
 	_first_move_poll_timer = null
 
 
+## Public entry for sign-out: stop polling the player's first move so the timer
+## doesn't read scene_runner.player_body_node after the Player is freed. The poll
+## restarts on the next login via _on_wallet_connected_track_login().
+func cancel_first_move_poll() -> void:
+	_stop_first_move_poller()
+
+
 func _on_first_move_poll_tick() -> void:
 	if Global.scene_runner == null:
 		return

--- a/godot/src/logic/scene_fetcher.gd
+++ b/godot/src/logic/scene_fetcher.gd
@@ -573,6 +573,29 @@ func _unload_scenes_except_current(current_scene_id: int) -> void:
 		loaded_scenes.erase(scene_id)
 
 
+## Reset all per-session scene bookkeeping so the next login starts from a clean
+## slate. Called from Global.sign_out(). The Rust scenes themselves are torn down
+## by scene_runner.kill_all_scenes(); here we drop the GDScript-side state and the
+## floating-island / floor / wall visuals that still reference them. The scene
+## entity coordinator is left as-is: the next realm change reconfigures it via
+## config() / set_fixed_desired_entities_urns().
+func reset_for_logout() -> void:
+	loaded_scenes.clear()
+	current_position = INVALID_PARCEL
+	current_scene_entity_id = ""
+	last_version_updated = -1
+	last_version_checked = -1
+	last_scene_group_hash = ""
+	desired_portable_experiences_urns.clear()
+
+	if is_instance_valid(islands_manager):
+		islands_manager.clear_all()
+	if is_instance_valid(wall_manager):
+		wall_manager.clear_walls()
+	if is_instance_valid(base_floor_manager):
+		base_floor_manager.clear_all_floors()
+
+
 ## Coalesced entry point for callers that may fire several regen requests in
 ## the same frame (e.g. spawning multiple scenes via `call_deferred`).
 func _request_regenerate_floating_islands() -> void:

--- a/godot/src/ui/components/organisms/menu/menu.gd
+++ b/godot/src/ui/components/organisms/menu/menu.gd
@@ -45,6 +45,10 @@ var _close_node_to_free: PlaceholderManager = null
 
 
 func _ready():
+	# Back on the standalone Discover screen — release the soft sign-out guard so a
+	# later Dev Tools "RETURN TO DISCOVER" press works (no-op when set from in-game).
+	Global._returning_to_discover = false
+
 	# Out of the lobby — restore the relaxed 10s flush cadence so feed/search events batch.
 	Global.metrics.set_flush_interval(10.0)
 

--- a/godot/src/ui/components/organisms/profile_settings/profile_settings.gd
+++ b/godot/src/ui/components/organisms/profile_settings/profile_settings.gd
@@ -22,5 +22,6 @@ func _async_on_profile_changed(profile: DclUserProfile):
 
 
 func _on_button_logout_pressed():
-	Global.scene_runner.set_pause(true)
-	Global.comms.disconnect(true)
+	# Route through the single canonical teardown (kills scenes, closes comms,
+	# clears identity, resets realm) instead of just pausing + dropping comms.
+	Global.sign_out()

--- a/godot/src/ui/explorer.gd
+++ b/godot/src/ui/explorer.gd
@@ -402,27 +402,57 @@ func _push_scene_interactable_area() -> void:
 
 
 func _on_player_logout():
-	# Mark session inactive first so any in-flight retry awaits exit on next check
-	_session_active = false
+	# Funnel any logout signal (e.g. session expiry) into the single canonical
+	# teardown instead of quitting the app. Global.sign_out() is re-entrancy
+	# guarded, so this is safe even when sign_out() is what emitted the signal.
+	Global.sign_out()
 
-	# Stop re-subscribe timer
+
+## Sever this Explorer from every persistent (autoload / window / Rust singleton)
+## emitter and stop its retry timers, while the node is still in the tree. Called
+## by Global.sign_out() BEFORE it kills scenes / clears realm / changes orientation,
+## so none of those re-emit into this about-to-be-freed Explorer. Idempotent.
+func prepare_for_logout() -> void:
+	# Drain any in-flight subscription retry loops on their next check.
+	_session_active = false
+	_subscription_reconnecting = false
+
 	if _resubscribe_timer != null:
 		_resubscribe_timer.stop()
 		_resubscribe_timer.queue_free()
 		_resubscribe_timer = null
 
-	# Stop notifications polling
-	NotificationsManager.stop_polling()
+	_disconnect_persistent_signals()
 
-	# Clean stored session
-	Global.get_config().session_account = {}
-	Global.get_config().save_to_settings_file()
 
-	# TODO: It's crashing. Logout = exit app
-	#get_tree().change_scene_to_file("res://src/main.tscn")
+## Disconnect this Explorer from persistent emitters (autoloads / Rust singletons).
+## Godot auto-severs any connection whose RECEIVER is freed, so the many
+## Global.* -> _on_*() UI callbacks are cleaned up automatically when this node is
+## freed. We only manually sever the connections Godot would NOT clean up, or that
+## can fire synchronously into this node during the sign-out teardown (before the
+## deferred free): the Global -> Global connection (leaks one callback per login
+## otherwise) and the persistent Rust/autoload emitters used during teardown.
+func _disconnect_persistent_signals() -> void:
+	_safe_disconnect(Global.scene_runner.on_change_scene_id, _on_change_scene_id)
+	_safe_disconnect(Global.scene_runner.pointer_tooltip_changed, _on_pointer_tooltip_changed)
+	_safe_disconnect(Global.change_parcel, _on_change_parcel)
+	_safe_disconnect(Global.orientation_changed, _on_orientation_changed)
+	_safe_disconnect(Global.player_identity.logout, _on_player_logout)
 
-	# TODO: Temporal solution
-	get_tree().quit()
+	if Global.avatars != null:
+		# Global -> Global: not auto-severed, would leak one callback per login.
+		var profile_changed: Signal = Global.player_identity.profile_changed
+		_safe_disconnect(profile_changed, Global.avatars.update_primary_player_profile)
+		_safe_disconnect(Global.avatars.avatar_added, _on_avatar_added_apply_hide_ui)
+
+	if Global.social_service != null:
+		_safe_disconnect(Global.social_service.block_update_received, _on_block_update_received)
+		_safe_disconnect(Global.social_service.subscription_dropped, _async_on_subscription_dropped)
+
+
+func _safe_disconnect(sig: Signal, callable: Callable) -> void:
+	if sig.is_connected(callable):
+		sig.disconnect(callable)
 
 
 func _on_player_profile_changed(_profile: DclUserProfile) -> void:

--- a/godot/src/ui/pages/auth/lobby.gd
+++ b/godot/src/ui/pages/auth/lobby.gd
@@ -266,6 +266,9 @@ func async_close_sign_in():
 # gdlint:ignore = async-function-name
 func _ready():
 	print("[Startup] lobby._ready start: %dms" % (Time.get_ticks_msec() - Global._startup_time))
+	# Back on a clean screen — release the sign-out re-entrancy guard so a future
+	# logout can run (no-op on normal startup, where it is already false).
+	Global._signing_out = false
 	label_version.set_text(DclGlobal.get_version_with_env())
 	button_enter_as_guest.visible = false
 

--- a/godot/src/ui/pages/backpack/backpack.gd
+++ b/godot/src/ui/pages/backpack/backpack.gd
@@ -515,7 +515,9 @@ func _on_wearable_unequip(wearable_id: String):
 
 
 func _on_button_logout_pressed():
-	Global.comms.disconnect(true)
+	# Route through the single canonical teardown (kills scenes, closes comms,
+	# clears identity, resets realm) instead of just dropping comms.
+	Global.sign_out()
 
 
 func _on_color_picker_panel_pick_color(color: Color):

--- a/godot/src/ui/pages/chat/chat.gd
+++ b/godot/src/ui/pages/chat/chat.gd
@@ -120,9 +120,8 @@ func _scroll_to_bottom() -> void:
 func _async_scroll_to_bottom_after_layout() -> void:
 	# _async_update_layout needs 3 frames: (1) reset sizes, (2) measure content,
 	# (3) Godot applies min sizes. If scroll is still off, increase frame count here.
-	await get_tree().process_frame
-	await get_tree().process_frame
-	await get_tree().process_frame
+	if not await _async_await_frames(3):
+		return
 	if not scroll_container_chats_list or not is_instance_valid(scroll_container_chats_list):
 		return
 
@@ -208,8 +207,8 @@ func async_start_chat():
 	# Re-layout all messages now that we have a valid width
 	_relayout_all_messages()
 	if !scrolled:
-		await get_tree().process_frame
-		_scroll_to_bottom()
+		if await _async_await_frames(1):
+			_scroll_to_bottom()
 
 
 func _relayout_all_messages() -> void:
@@ -223,10 +222,21 @@ func _async_deferred_relayout_all_messages() -> void:
 	# iOS needs 3 frames for orientation change to propagate the new window size
 	# before relayout can measure correctly. If layout glitches on orientation
 	# change, increase the frame count here.
-	await get_tree().process_frame
-	await get_tree().process_frame
-	await get_tree().process_frame
+	if not await _async_await_frames(3):
+		return
 	_relayout_all_messages()
+
+
+## Await `count` process frames, returning false if this node left the tree
+## mid-await. A queued coroutine (e.g. an orientation relayout) can outlive the
+## node when sign-out frees the chat between frames; resuming would then call
+## get_tree() on a null instance and crash. Callers must bail when this is false.
+func _async_await_frames(count: int) -> bool:
+	for _i in count:
+		if not is_inside_tree():
+			return false
+		await get_tree().process_frame
+	return is_inside_tree()
 
 
 func _on_chat_message_arrived(address: String, message: String, timestamp: float):
@@ -284,7 +294,8 @@ func reset_safe_area_insets() -> void:
 func async_apply_system_bar_insets() -> void:
 	if not OS.get_name() == "Android":
 		return
-	await get_tree().process_frame
+	if not await _async_await_frames(1):
+		return
 	var insets := _get_android_system_bar_insets()
 	var win_size := DisplayServer.window_get_size()
 	var viewport_size := get_viewport().get_visible_rect().size

--- a/godot/src/ui/pages/loading_screen/loading_screen.gd
+++ b/godot/src/ui/pages/loading_screen/loading_screen.gd
@@ -125,6 +125,10 @@ func set_item(index: int, right_direction: bool = true):
 
 
 func set_bg_shader_color(from: Color, to: Color):
+	# Bail if we've left the tree (e.g. sign-out freed the loading screen between
+	# frames): get_tree() would be null and create_tween() would crash.
+	if not is_inside_tree():
+		return
 	var tween = get_tree().create_tween()
 	tween.tween_method(set_shader_background_color, from, to, 0.25)
 
@@ -141,6 +145,10 @@ func set_progress(new_progress: float):
 	progress = new_progress
 
 	loading_progress_label.text = "LOADING %d%%" % floor(progress)
+	# Bail if we've left the tree (e.g. sign-out freed the loading screen between
+	# frames): get_tree() would be null and create_tween() would crash.
+	if not is_inside_tree():
+		return
 	var tween = get_tree().create_tween()
 	var new_width = loading_progress.get_parent().size.x * (progress / 100.0)
 	tween.tween_property(loading_progress, "position:x", new_width, 0.1)

--- a/godot/src/ui/pages/settings/settings.gd
+++ b/godot/src/ui/pages/settings/settings.gd
@@ -880,3 +880,9 @@ func _on_avatar_and_emotes_volume_value_changed(value: float) -> void:
 
 func _on_custom_button_sign_out_pressed() -> void:
 	Global.sign_out()
+
+
+func _on_button_return_to_discover_pressed() -> void:
+	# Dev Tools: leave the current world and return to the Discover menu while
+	# staying signed in (soft sign-out). See Global.return_to_discover().
+	Global.return_to_discover()

--- a/godot/src/ui/pages/settings/settings.tscn
+++ b/godot/src/ui/pages/settings/settings.tscn
@@ -1123,6 +1123,15 @@ mouse_filter = 2
 theme_override_constants/separation = 74
 theme_override_styles/separator = SubResource("StyleBoxEmpty_ewc0a")
 
+[node name="Button_ReturnToDiscover" type="Button" parent="VBoxContainer/MarginContainer_Content/ContentScrollContainer/VBoxContainer_Sections/VBoxContainer_Advanced" unique_id=1709283746]
+unique_name_in_owner = true
+custom_minimum_size = Vector2(300, 96)
+layout_mode = 2
+focus_mode = 0
+theme = ExtResource("12_sa1v7")
+theme_type_variation = &"SecondaryOutlinedButton"
+text = "RETURN TO DISCOVER"
+
 [node name="VBoxContainer_Account" type="VBoxContainer" parent="VBoxContainer/MarginContainer_Content/ContentScrollContainer/VBoxContainer_Sections" unique_id=1178397413]
 unique_name_in_owner = true
 visible = false
@@ -1374,6 +1383,7 @@ font = ExtResource("25_jf4mt")
 [connection signal="item_selected" from="VBoxContainer/MarginContainer_Content/ContentScrollContainer/VBoxContainer_Sections/VBoxContainer_Advanced/DropdownList_Realm" to="." method="_on_dropdown_list_realm_item_selected"]
 [connection signal="pressed" from="VBoxContainer/MarginContainer_Content/ContentScrollContainer/VBoxContainer_Sections/VBoxContainer_Advanced/Button_TestNotification" to="." method="_on_button_test_notification_pressed"]
 [connection signal="pressed" from="VBoxContainer/MarginContainer_Content/ContentScrollContainer/VBoxContainer_Sections/VBoxContainer_Advanced/Button_OpenUserData" to="." method="_on_button_open_user_data_pressed"]
+[connection signal="pressed" from="VBoxContainer/MarginContainer_Content/ContentScrollContainer/VBoxContainer_Sections/VBoxContainer_Advanced/Button_ReturnToDiscover" to="." method="_on_button_return_to_discover_pressed"]
 [connection signal="pressed" from="VBoxContainer/MarginContainer_Content/ContentScrollContainer/VBoxContainer_Sections/VBoxContainer_Account/SectionReport/VBoxContainer/VBoxContainer/Button_ReportBug" to="." method="_on_button_report_bug_pressed"]
 [connection signal="pressed" from="VBoxContainer/MarginContainer_Content/ContentScrollContainer/VBoxContainer_Sections/VBoxContainer_Account/SectionReport/VBoxContainer/VBoxContainer/Button_ReportContent" to="." method="_on_button_report_content_pressed"]
 [connection signal="pressed" from="VBoxContainer/MarginContainer_Content/ContentScrollContainer/VBoxContainer_Sections/VBoxContainer_Account/SectionHelp/VBoxContainer/VBoxContainer2/Button_PrivacyPolicy" to="." method="_on_button_privacy_policy_pressed"]

--- a/lib/src/scene_runner/godot_dcl_scene.rs
+++ b/lib/src/scene_runner/godot_dcl_scene.rs
@@ -375,20 +375,16 @@ impl GodotDclScene {
     /// Free the root nodes after they've been removed from the tree.
     /// This should be called via call_deferred after remove_child completes.
     pub fn free_root_nodes(&mut self) {
-        let child_count_3d = self.root_node_3d.get_child_count();
-        let in_tree_3d = self.root_node_3d.is_inside_tree();
-        let child_count_ui = self.root_node_ui.get_child_count();
-        let in_tree_ui = self.root_node_ui.is_inside_tree();
-
-        tracing::info!(
-            "free_root_nodes: 3D root has {} children, in_tree={}, UI root has {} children, in_tree={}",
-            child_count_3d,
-            in_tree_3d,
-            child_count_ui,
-            in_tree_ui
-        );
-
-        self.root_node_3d.queue_free();
-        self.root_node_ui.queue_free();
+        // The UI root lives under SceneManager.base_ui, which is reparented into the
+        // Explorer; on sign-out / change_scene_to_file the Explorer (hence base_ui and
+        // this UI root) is freed before the scene is reaped. Guard each root so a
+        // double queue_free() on an already-freed node can't panic and abort teardown
+        // (which would leave the scene id stuck in dying_scene_ids and spam the log).
+        if self.root_node_3d.is_instance_valid() {
+            self.root_node_3d.queue_free();
+        }
+        if self.root_node_ui.is_instance_valid() {
+            self.root_node_ui.queue_free();
+        }
     }
 }

--- a/lib/src/scene_runner/scene_manager.rs
+++ b/lib/src/scene_runner/scene_manager.rs
@@ -798,37 +798,9 @@ impl SceneManager {
         player_body_node: Gd<Node3D>,
         console: Callable,
     ) {
-        // Free any leftover placeholder from clear_player_nodes() before replacing,
-        // so the orphan stand-in nodes don't leak across logout/login cycles.
-        Self::free_if_orphan_placeholder(&mut self.player_avatar_node);
-        Self::free_if_orphan_placeholder(&mut self.player_body_node);
         self.player_avatar_node = player_avatar_node.clone();
         self.player_body_node = player_body_node.clone();
         self.console = console;
-    }
-
-    /// Reset the player node handles to fresh placeholders. Called on sign-out:
-    /// change_scene_to_file frees the Explorer's Player node, leaving these #[var]
-    /// Gd<Node3D> handles dangling. Their auto-generated getters call to_godot(),
-    /// which PANICS on a freed instance — and several GDScript readers touch them
-    /// after sign-out (e.g. the analytics first-move poll on the Global autoload
-    /// reads player_body_node). Swapping in valid orphan placeholders keeps every
-    /// getter safe; they are replaced by the next set_player_node() on Explorer load.
-    #[func]
-    fn clear_player_nodes(&mut self) {
-        Self::free_if_orphan_placeholder(&mut self.player_avatar_node);
-        Self::free_if_orphan_placeholder(&mut self.player_body_node);
-        self.player_avatar_node = Node3D::new_alloc();
-        self.player_body_node = Node3D::new_alloc();
-    }
-
-    /// Free a player-node handle iff it is a leftover orphan placeholder (valid but
-    /// not in the scene tree). The real player node is owned by the Explorer's tree
-    /// and must NOT be freed here — change_scene_to_file handles it.
-    fn free_if_orphan_placeholder(node: &mut Gd<Node3D>) {
-        if node.is_instance_valid() && !node.is_inside_tree() {
-            node.clone().free();
-        }
     }
 
     #[func]

--- a/lib/src/scene_runner/scene_manager.rs
+++ b/lib/src/scene_runner/scene_manager.rs
@@ -798,9 +798,37 @@ impl SceneManager {
         player_body_node: Gd<Node3D>,
         console: Callable,
     ) {
+        // Free any leftover placeholder from clear_player_nodes() before replacing,
+        // so the orphan stand-in nodes don't leak across logout/login cycles.
+        Self::free_if_orphan_placeholder(&mut self.player_avatar_node);
+        Self::free_if_orphan_placeholder(&mut self.player_body_node);
         self.player_avatar_node = player_avatar_node.clone();
         self.player_body_node = player_body_node.clone();
         self.console = console;
+    }
+
+    /// Reset the player node handles to fresh placeholders. Called on sign-out:
+    /// change_scene_to_file frees the Explorer's Player node, leaving these #[var]
+    /// Gd<Node3D> handles dangling. Their auto-generated getters call to_godot(),
+    /// which PANICS on a freed instance — and several GDScript readers touch them
+    /// after sign-out (e.g. the analytics first-move poll on the Global autoload
+    /// reads player_body_node). Swapping in valid orphan placeholders keeps every
+    /// getter safe; they are replaced by the next set_player_node() on Explorer load.
+    #[func]
+    fn clear_player_nodes(&mut self) {
+        Self::free_if_orphan_placeholder(&mut self.player_avatar_node);
+        Self::free_if_orphan_placeholder(&mut self.player_body_node);
+        self.player_avatar_node = Node3D::new_alloc();
+        self.player_body_node = Node3D::new_alloc();
+    }
+
+    /// Free a player-node handle iff it is a leftover orphan placeholder (valid but
+    /// not in the scene tree). The real player node is owned by the Explorer's tree
+    /// and must NOT be freed here — change_scene_to_file handles it.
+    fn free_if_orphan_placeholder(node: &mut Gd<Node3D>) {
+        if node.is_instance_valid() && !node.is_inside_tree() {
+            node.clone().free();
+        }
     }
 
     #[func]

--- a/lib/src/scene_runner/scene_manager.rs
+++ b/lib/src/scene_runner/scene_manager.rs
@@ -1144,6 +1144,13 @@ impl SceneManager {
     }
 
     fn scene_runner_update(&mut self, delta: f64) {
+        // Scene teardown must always make progress, even when the runner is paused
+        // (the lobby pauses it) or the player avatar is gone (post sign-out). The
+        // early-returns below would otherwise skip the kill state machine, leaving
+        // scenes marked ToKill on sign-out / realm change alive forever with live
+        // V8/Deno threads. Reaping here guarantees background teardown either way.
+        self.reap_dying_scenes();
+
         if self.pause {
             return;
         }
@@ -1239,11 +1246,10 @@ impl SceneManager {
         //     tracing::info!("next_update: {next_update_vec:#?}");
         // }
 
-        let mut current_time_us = (std::time::Instant::now() - self.begin_time).as_micros() as i64;
         for scene_id in self.sorted_scene_ids.iter() {
             let scene: &mut Scene = self.scenes.get_mut(scene_id).unwrap();
 
-            current_time_us = (std::time::Instant::now() - self.begin_time).as_micros() as i64;
+            let current_time_us = (std::time::Instant::now() - self.begin_time).as_micros() as i64;
             if scene.next_tick_us > current_time_us {
                 break;
             }
@@ -1306,6 +1312,33 @@ impl SceneManager {
 
         // Process loading session updates from all scenes
         self.update_loading_session_from_scenes();
+
+        // Explicitly-killed scenes are advanced by reap_dying_scenes() at the top
+        // of this function (so they tear down even while paused). Here we only
+        // collect scenes that exited while still Alive (thread finished without a
+        // kill signal); they are freed by the drain loop below.
+
+        // Periodic pool health check and stats logging (handled by PoolManager)
+        self.pool_manager.borrow_mut().tick();
+
+        for scene_id in scene_to_remove.iter() {
+            self.finalize_scene_removal(scene_id);
+        }
+    }
+
+    /// Advance the kill state machine for every dying scene and free those that
+    /// have finished. Runs every frame from the top of `scene_runner_update`,
+    /// unconditionally — before the `pause` / avatar-validity early-returns — so
+    /// scenes killed on sign-out or realm change are guaranteed to be torn down
+    /// (V8/Deno threads joined, Godot nodes freed) even after the lobby pauses the
+    /// runner. Without this, killed scenes would linger forever as ToKill.
+    fn reap_dying_scenes(&mut self) {
+        if self.dying_scene_ids.is_empty() {
+            return;
+        }
+
+        let current_time_us = (std::time::Instant::now() - self.begin_time).as_micros() as i64;
+        let mut scene_to_remove: HashSet<SceneId> = HashSet::new();
 
         for scene_id in self.dying_scene_ids.iter() {
             let scene = self.scenes.get_mut(scene_id).unwrap();
@@ -1378,63 +1411,67 @@ impl SceneManager {
             }
         }
 
-        // Periodic pool health check and stats logging (handled by PoolManager)
-        self.pool_manager.borrow_mut().tick();
-
         for scene_id in scene_to_remove.iter() {
-            let mut scene = self.scenes.remove(scene_id).unwrap();
-            let signal_data = (*scene_id, scene.scene_entity_definition.id.clone());
+            self.finalize_scene_removal(scene_id);
+        }
+    }
 
-            // Cleanup trigger areas and release RIDs back to pool
-            scene
-                .trigger_areas
-                .cleanup(self.pool_manager.borrow_mut().physics_area());
+    /// Remove a single dead scene: free its Godot nodes, drop bookkeeping, join the
+    /// thread and emit scene_killed / scene_crashed. Shared by the normal update
+    /// path (scenes that exited while Alive) and reap_dying_scenes().
+    fn finalize_scene_removal(&mut self, scene_id: &SceneId) {
+        let mut scene = self.scenes.remove(scene_id).unwrap();
+        let signal_data = (*scene_id, scene.scene_entity_definition.id.clone());
 
-            // Cleanup Rust references first (doesn't free nodes yet)
-            scene.cleanup();
+        // Cleanup trigger areas and release RIDs back to pool
+        scene
+            .trigger_areas
+            .cleanup(self.pool_manager.borrow_mut().physics_area());
 
-            // Free root nodes - queue_free handles both removal from tree and freeing
-            // This is safer than manually calling remove_child + queue_free separately
-            // because queue_free schedules everything atomically for end of frame
-            scene.godot_dcl_scene.free_root_nodes();
+        // Cleanup Rust references first (doesn't free nodes yet)
+        scene.cleanup();
 
-            self.sorted_scene_ids.retain(|x| x != scene_id);
-            self.dying_scene_ids.retain(|x| x != scene_id);
-            self.global_scene_ids.retain(|x| x != scene_id);
+        // Free root nodes - queue_free handles both removal from tree and freeing
+        // This is safer than manually calling remove_child + queue_free separately
+        // because queue_free schedules everything atomically for end of frame
+        scene.godot_dcl_scene.free_root_nodes();
 
-            // Clean up VM_HANDLES entry
-            #[cfg(feature = "use_deno")]
-            {
-                if let Ok(mut handles) = crate::dcl::js::VM_HANDLES.lock() {
-                    handles.remove(scene_id);
-                }
+        self.sorted_scene_ids.retain(|x| x != scene_id);
+        self.dying_scene_ids.retain(|x| x != scene_id);
+        self.global_scene_ids.retain(|x| x != scene_id);
+
+        // Clean up VM_HANDLES entry
+        #[cfg(feature = "use_deno")]
+        {
+            if let Ok(mut handles) = crate::dcl::js::VM_HANDLES.lock() {
+                handles.remove(scene_id);
             }
+        }
 
-            if scene.dcl_scene.thread_join_handle.is_finished() {
-                if let Err(err) = scene.dcl_scene.thread_join_handle.join() {
-                    let msg = if let Some(panic_info) = err.downcast_ref::<&str>() {
-                        format!("Thread panicked with: {}", panic_info)
-                    } else if let Some(panic_info) = err.downcast_ref::<String>() {
-                        format!("Thread panicked with: {}", panic_info)
-                    } else {
-                        "Thread panicked with an unknown payload".to_string()
-                    };
-                    tracing::error!("scene {} thread result: {:?}", scene_id.0, msg);
-                }
+        if scene.dcl_scene.thread_join_handle.is_finished() {
+            if let Err(err) = scene.dcl_scene.thread_join_handle.join() {
+                let msg = if let Some(panic_info) = err.downcast_ref::<&str>() {
+                    format!("Thread panicked with: {}", panic_info)
+                } else if let Some(panic_info) = err.downcast_ref::<String>() {
+                    format!("Thread panicked with: {}", panic_info)
+                } else {
+                    "Thread panicked with an unknown payload".to_string()
+                };
+                tracing::error!("scene {} thread result: {:?}", scene_id.0, msg);
             }
+        }
 
+        self.base_mut().emit_signal(
+            "scene_killed",
+            &[signal_data.0 .0.to_variant(), signal_data.1.to_variant()],
+        );
+
+        if self.crashed_scene_ids.contains(scene_id) {
+            self.crashed_scene_ids.retain(|x| x != scene_id);
             self.base_mut().emit_signal(
-                "scene_killed",
+                "scene_crashed",
                 &[signal_data.0 .0.to_variant(), signal_data.1.to_variant()],
             );
-
-            if self.crashed_scene_ids.contains(scene_id) {
-                self.crashed_scene_ids.retain(|x| x != scene_id);
-                self.base_mut().emit_signal(
-                    "scene_crashed",
-                    &[signal_data.0 .0.to_variant(), signal_data.1.to_variant()],
-                );
-            }
         }
     }
 

--- a/lib/src/scene_runner/scene_manager.rs
+++ b/lib/src/scene_runner/scene_manager.rs
@@ -1367,9 +1367,16 @@ impl SceneManager {
 
         let current_time_us = (std::time::Instant::now() - self.begin_time).as_micros() as i64;
         let mut scene_to_remove: HashSet<SceneId> = HashSet::new();
+        let mut stale_scene_ids: Vec<SceneId> = Vec::new();
 
         for scene_id in self.dying_scene_ids.iter() {
-            let scene = self.scenes.get_mut(scene_id).unwrap();
+            let Some(scene) = self.scenes.get_mut(scene_id) else {
+                // The scene was already removed from the map (e.g. its nodes were
+                // freed with the Explorer during sign-out before we reaped it).
+                // Drop the dangling id below instead of unwrap()-panicking on it.
+                stale_scene_ids.push(*scene_id);
+                continue;
+            };
             match scene.state {
                 SceneState::ToKill => {
                     match scene
@@ -1439,6 +1446,17 @@ impl SceneManager {
             }
         }
 
+        // Drop any dangling ids whose scenes are already gone, so we don't retry
+        // (and re-panic) on them every frame.
+        if !stale_scene_ids.is_empty() {
+            self.sorted_scene_ids
+                .retain(|x| !stale_scene_ids.contains(x));
+            self.dying_scene_ids
+                .retain(|x| !stale_scene_ids.contains(x));
+            self.global_scene_ids
+                .retain(|x| !stale_scene_ids.contains(x));
+        }
+
         for scene_id in scene_to_remove.iter() {
             self.finalize_scene_removal(scene_id);
         }
@@ -1448,7 +1466,16 @@ impl SceneManager {
     /// thread and emit scene_killed / scene_crashed. Shared by the normal update
     /// path (scenes that exited while Alive) and reap_dying_scenes().
     fn finalize_scene_removal(&mut self, scene_id: &SceneId) {
-        let mut scene = self.scenes.remove(scene_id).unwrap();
+        // Prune bookkeeping FIRST so that even if a later step (e.g. freeing an
+        // already-freed Godot node) were to fail, the id can't get stuck in
+        // dying_scene_ids and spam reap_dying_scenes() every frame.
+        self.sorted_scene_ids.retain(|x| x != scene_id);
+        self.dying_scene_ids.retain(|x| x != scene_id);
+        self.global_scene_ids.retain(|x| x != scene_id);
+
+        let Some(mut scene) = self.scenes.remove(scene_id) else {
+            return;
+        };
         let signal_data = (*scene_id, scene.scene_entity_definition.id.clone());
 
         // Cleanup trigger areas and release RIDs back to pool
@@ -1463,10 +1490,6 @@ impl SceneManager {
         // This is safer than manually calling remove_child + queue_free separately
         // because queue_free schedules everything atomically for end of frame
         scene.godot_dcl_scene.free_root_nodes();
-
-        self.sorted_scene_ids.retain(|x| x != scene_id);
-        self.dying_scene_ids.retain(|x| x != scene_id);
-        self.global_scene_ids.retain(|x| x != scene_id);
 
         // Clean up VM_HANDLES entry
         #[cfg(feature = "use_deno")]


### PR DESCRIPTION
## Problem

After signing out, the previous session kept running. **All the heavy subsystems are added to `/root` as siblings of the active scene, not children of `explorer.tscn`** (`global.gd:398-411`), so `change_scene_to_file("lobby.tscn")` freed the explorer UI but left `scene_runner`, `comms`, `realm`, `player_identity`, `avatars` and `scene_fetcher` fully alive with the old user's state.

Concretely, `sign_out()`:
- never killed the running DCL scenes (`kill_all_scenes()` was only reached on a realm change),
- never disconnected comms (MainRoom/SceneRoom/LiveKit stayed open),
- never cleared the Rust player identity (wallet + ephemeral keys persisted in memory; only the on-disk `session_account` dict was cleared).

On top of that, the **Profile** and **Backpack** logout buttons bypassed `sign_out()` and **quit the app** via `comms.disconnect(true)` → `player_identity.logout` → `explorer._on_player_logout()` → `get_tree().quit()` (the "It's crashing" `TODO`).

### The non-obvious trap
Even calling `kill_all_scenes()` right before the swap was **not enough**: it only *marks* scenes `ToKill`. The reaping loop in `scene_runner_update` sits behind two early-returns — `if self.pause` and `if !player_avatar_node.is_instance_valid()` — and **both trip the moment the lobby loads** (`lobby._ready` pauses the runner; the freed explorer invalidates the avatar). So killed scenes would have lingered forever with live V8/Deno threads.

## Fix

**Rust — `scene_manager.rs`:** Extracted the kill state machine into `reap_dying_scenes()` and call it at the **top** of `scene_runner_update`, *before* the `pause`/avatar early-returns, so killed scenes tear down in the background even while the lobby pauses the runner. Shared the node-freeing tail into `finalize_scene_removal()`.

**`global.gd`:** Rewrote `sign_out()` into the single canonical, re-entrancy-guarded teardown:
1. `explorer.prepare_for_logout()` (disconnect persistent-emitter signals + stop timers while still in tree)
2. stop notifications polling + social streams + clear blacklist
3. `scene_runner.kill_all_scenes()`
4. `realm.async_clear_realm()` + `scene_fetcher.reset_for_logout()`
5. `comms.disconnect(true)` (closes comms **and** clears the Rust wallet/ephemeral identity)
6. `scene_runner.recreate_base_ui()`
7. clear `session_account` + save, portrait orientation
8. **deferred** `change_scene_to_file` to a fresh `lobby.tscn`

**`explorer.gd`:** `_on_player_logout()` now funnels into `Global.sign_out()` instead of quitting; added `prepare_for_logout()` / `_disconnect_persistent_signals()` to sever connections to persistent emitters (including the `profile_changed → avatars.update_primary_player_profile` Global→Global connection that leaked one callback per login).

**`scene_fetcher.gd`:** new `reset_for_logout()` clears `loaded_scenes` + island/wall/floor visuals and resets position/version state.

**`profile_settings.gd` / `backpack.gd`:** logout buttons now call `Global.sign_out()` (no more app-quit). **`lobby.gd`:** clears the re-entrancy guard on entry.

## Deliberate scope
- Trimmed the explorer signal-disconnect set to what genuinely needs manual handling — Godot auto-severs receiver-side connections on free, and the file has a hard 1800-line lint cap. The principle is documented in the code.
- Does **not** clear the disk content cache or other settings — this is a sign-out, not a factory reset.

## Out of scope (follow-up)
- The LiveKit adapter's `_clean()` is a no-op (`livekit.rs:134`), so its worker thread isn't explicitly joined on disconnect. Separate, deeper fix (the obvious snippet doesn't compile against current field types).

## Validation
- `cargo build` ✅ and `cargo clippy` ✅ — no warnings.
- `gdformat` ✅ + `gdlint` ✅ on all changed files.
- `check-gdscript` validates all 6 changed GDScript files **✓ OK**. (The command's overall exit-1 is from **pre-existing** parse errors in generated `android/build/src/instrumented/assets/` artifacts, unrelated to this change.)

## How to test
1. Sign in, walk into a populated scene.
2. Sign out (Settings, Profile, or Backpack logout).
3. You should land on a clean `lobby.tscn` and **not** be auto-logged back in.
4. Query the debug WS `scenes` tree (`ws://127.0.0.1:9230`) — it should report **0 scenes**.