### PR TITLE
fix: cinematic camera stuck after teleporting

### DIFF
--- a/godot/src/decentraland_components/dcl_global_camera_controller.gd
+++ b/godot/src/decentraland_components/dcl_global_camera_controller.gd
@@ -18,6 +18,12 @@ func _ready():
 	global_virtual_camera.clear_current()
 	global_virtual_camera.cull_mask = 0x7fff
 
+	# A scene always starts non-cinematic. Reset the cinematic/virtual-camera state
+	# whenever the current parcel scene changes so the latch can't survive a teleport
+	# (mirrors how Rust resets input modifiers/skybox time on the same event).
+	if is_instance_valid(Global.scene_runner):
+		Global.scene_runner.on_change_scene_id.connect(_on_parcel_scene_changed)
+
 
 # in the process fn, this node has the responsibility of transitioning the camera between player one and virtual one
 #  virtuals can change between scenes or in the same scene, computed as desired_target
@@ -153,12 +159,7 @@ func _process(delta: float) -> void:
 			Global.scene_runner.raycast_use_cursor_position = false
 
 			# When coming back from virtual camera, we always show outline system and set the first/third person camera behaviour
-			var explorer = Global.get_explorer()
-			if is_instance_valid(explorer):
-				explorer.reset_cursor_position()
-				explorer.player.outline_system.show()
-				if explorer.player.camera.get_camera_mode() == Global.CameraMode.FIRST_PERSON:
-					explorer.player.avatar.set_hidden(true)
+			_restore_player_camera_visibility()
 	else:
 		# Transitioning to virtual camera target
 		var target_transform = desired_target.global_transform
@@ -177,3 +178,45 @@ func _process(delta: float) -> void:
 		# when desired_target != null and look_at_entity_node != null, compute the rotation (looking at)
 		if is_instance_valid(look_at_entity_node):
 			global_virtual_camera.look_at(look_at_entity_node.global_position)
+
+
+func _on_parcel_scene_changed(_scene_id: int) -> void:
+	# A teleport can free the virtual camera's target entity (and the camera reparented
+	# under it), latching this controller in its _process re-init branch and leaving
+	# raycast_use_cursor_position / CINEMATIC stuck — which freezes camera rotation.
+	# Only reset when actually latched, so normal scene crossings don't re-tween/replay
+	# the camera-mode fade. If the new scene is itself cinematic, _process re-enters it
+	# on the next tick (its virtual-camera component is only applied then).
+	var latched := (
+		Global.current_camera_mode == Global.CameraMode.CINEMATIC
+		or Global.scene_runner.raycast_use_cursor_position
+	)
+	if latched:
+		_force_return_to_player_camera()
+
+
+func _force_return_to_player_camera() -> void:
+	# Keep the persistent camera alive (it may be parented to a now-freed scene entity)
+	# and detach it from any virtual-camera target.
+	if is_instance_valid(global_virtual_camera):
+		if global_virtual_camera.get_parent() != self:
+			global_virtual_camera.reparent(self)
+		global_virtual_camera.clear_current()
+	last_virtual_camera_entity_node = null
+	last_camera_reached = true
+	transition_time_counter = 0.0
+	Global.scene_runner.raycast_use_cursor_position = false
+	Global.player_camera_node.make_current()
+	Global.set_camera_mode(Global.player_camera_node.get_camera_mode() as Global.CameraMode)
+	_restore_player_camera_visibility()
+
+
+func _restore_player_camera_visibility() -> void:
+	# When coming back from virtual camera, always show outline system and set the
+	# first/third person camera behaviour.
+	var explorer = Global.get_explorer()
+	if is_instance_valid(explorer):
+		explorer.reset_cursor_position()
+		explorer.player.outline_system.show()
+		if explorer.player.camera.get_camera_mode() == Global.CameraMode.FIRST_PERSON:
+			explorer.player.avatar.set_hidden(true)


### PR DESCRIPTION
## Problem

  Entering a scene's cinematic (virtual) camera, then teleporting (or walking) to another
  scene, left the camera frozen — on mobile you could still move but not rotate the camera.

  Closes #2160

  ## Root cause

  In `dcl_global_camera_controller.gd`, once the virtual camera reaches its target it is
  reparented onto a scene entity. A scene change frees that entity (and the camera under it);
  `_process`'s re-init branch then recreates the camera with `last_camera_reached = true` /
  `last_virtual_camera_entity_node = null`, so every subsequent frame hits the
  `elif last_camera_reached: return` early-out. The only site that resets
  `raycast_use_cursor_position` and the camera mode never runs, so both stay latched
  (`raycast_use_cursor_position = true`, `current_camera_mode = CINEMATIC`).
  `mobile_camera_input.gd` then routes every touch to the cinematic cursor handler instead of
  camera rotation. Confirmed live on-device via the debug WS (port 9230).

  ## Fix

  A scene should always start non-cinematic. The controller now listens to
  `SceneManager::on_change_scene_id` and, **only when actually latched in cinematic state**,
  forces a clean return to the player camera (clears the cursor flag, restores the real
  camera mode, makes the player camera current, resets tracking vars). This mirrors the
  existing pattern where Rust already resets input modifiers / skybox time on the same
  signal (`scene_manager.rs:1768-1772`). GDScript-only — no Rust change. The shared
  visibility/cursor cleanup is extracted into a helper reused by both the transition-complete
  and reset paths.

  ## Verification

  Reproduced the teleport-out-of-cinematic flow on Android and confirmed over the debug WS:

  | Signal | Before | After |
  |---|---|---|
  | `raycast_use_cursor_position` | `true` | `false` |
  | `current_camera_mode` | `2` (CINEMATIC) | `1` (FIRST_PERSON) |
  | `Player/Mount/Camera3D.current` | `true` | `true` |
  | controller `transition_time_counter` | `0.89` (stale) | `0.0` |

  Camera rotation works again. Guard prevents any reset (no fade sound / re-tween) on normal
  non-cinematic parcel crossings.