### PR TITLE
fix: stale profile/wearables leak into new account after sign-out

### DIFF
--- a/godot/src/deep_link_router.gd
+++ b/godot/src/deep_link_router.gd
@@ -34,6 +34,10 @@ func process_deep_link(url: String) -> void:
 		print("[DEEPLINK] Found rust-log param: ", rust_log_value)
 		DclGlobal.set_rust_log_filter(rust_log_value)
 
+	# Toggle the loopback debug WS server from the deeplink. Lets it be enabled
+	# before reaching Settings (e.g. on the login/lobby screens).
+	apply_debug_ws_param(Global.deep_link_obj.params.get("debug-ws", ""))
+
 	# Genesis Plaza profiling benchmark (issue #1862). The CLI path spawns the
 	# runner from Global._ready, but on mobile the deep link is not parsed by
 	# then — spawn here once the deeplink lands and only if no runner exists.
@@ -154,6 +158,35 @@ func _route_teleport() -> void:
 		Global.async_teleport_to(Global.deep_link_obj.location, realm)
 	elif not realm.is_empty():
 		Global.async_teleport_to(Vector2i.ZERO, realm)
+
+
+## Start/stop the developer debug WS server from a deeplink `debug-ws` param.
+## Mirrors the Settings → Developer → "Debug WS Server" toggle, but reachable
+## before Settings exists (login/lobby). Developer-only: ignored in production,
+## same as the hidden Settings toggle.
+##
+## Accepted values: empty -> no-op; "0"/"false"/"off"/"stop"/"disable" -> stop;
+## a port number (e.g. "9300") -> start on that port; anything else
+## ("1"/"true"/"on") -> start on the default port.
+func apply_debug_ws_param(value: String) -> void:
+	if value.is_empty():
+		return
+	if Global.is_production():
+		print("[DEEPLINK] Ignoring debug-ws param in production build")
+		return
+
+	if value.to_lower() in ["0", "false", "off", "stop", "disable"]:
+		DebugWs.stop()
+		print("[DEEPLINK] Debug WS server stopped")
+		return
+
+	var port: int = DebugWs.DEFAULT_PORT
+	if value.is_valid_int() and int(value) > 1:
+		port = int(value)
+	if DebugWs.start(port):
+		print("[DEEPLINK] Debug WS server listening on port ", DebugWs.get_port())
+	else:
+		printerr("[DEEPLINK] Failed to start debug WS server on port ", port)
 
 
 func _handle_signin_deep_link(identity_id: String) -> void:

--- a/godot/src/global.gd
+++ b/godot/src/global.gd
@@ -249,6 +249,10 @@ func _ready():
 		else:
 			print("[DEEPLINK] No rust-log param in deeplink")
 
+		# Toggle the loopback debug WS server from the fake deeplink (desktop/CLI
+		# testing). Same handling as runtime deeplinks in DeepLinkRouter.
+		deep_link_router.apply_debug_ws_param(deep_link_obj.params.get("debug-ws", ""))
+
 		print("[DEEPLINK] safemargindebug=", deep_link_obj.safe_margin_debug)
 		if deep_link_obj.safe_margin_debug:
 			set_safe_margin_debug_enable(true)
@@ -687,6 +691,12 @@ func sign_out() -> void:
 	social_blacklist.clear_blocked()
 	social_blacklist.clear_muted()
 	get_config().session_account = {}
+	# Forget the previous identity so the next account starts fresh — otherwise
+	# the prior profile/avatar lingers in memory and leaks into the new account's
+	# avatar editor (issue #1658). Also drop the saved guest look on explicit
+	# sign-out to close the guest->guest leak vector.
+	get_config().guest_profile = {}
+	player_identity.reset_identity()
 	get_config().save_to_settings_file()
 	# Lobby/login is portrait-only; reset orientation so logging out from a
 	# landscape screen (e.g. settings panel) doesn't strand the user there.

--- a/godot/src/logic/player/player_identity.gd
+++ b/godot/src/logic/player/player_identity.gd
@@ -123,6 +123,20 @@ func _on_profile_changed(new_profile: DclUserProfile):
 		Global.social_blacklist.append_muted(muted_list)
 
 
+## Fully reset the in-memory identity so the next account starts from a clean
+## slate. Without this, signing out keeps the previous profile/avatar in memory
+## and the next account's avatar editor inherits the old wearables (issue #1658).
+func reset_identity():
+	# clear_identity() is the native logout exposed for GDScript (the bare
+	# `logout` name is the logout *signal*). Clears wallet/ephemeral/profile so
+	# create_guest_account_if_needed() no longer sees the stale web3 wallet and
+	# correctly starts a fresh account.
+	clear_identity()
+	_mutable_profile = DclUserProfile.new()
+	_current_profile = DclUserProfile.new()
+	_mutable_avatar = _mutable_profile.get_avatar()
+
+
 func get_mutable_avatar() -> DclAvatarWireFormat:
 	return _mutable_avatar
 

--- a/godot/src/ui/pages/settings/settings.gd
+++ b/godot/src/ui/pages/settings/settings.gd
@@ -349,6 +349,9 @@ func refresh_values():
 	process_tick_quota.value = Global.get_config().process_tick_quota_ms
 	if is_instance_valid(Global.raycast_debugger):
 		check_button_raycast_debugger.set_pressed_no_signal(true)
+	# Reflect the real server state: it may have been started from a deeplink
+	# (debug-ws param) before Settings was ever opened.
+	check_button_debug_server.set_pressed_no_signal(DebugWs.is_running())
 
 
 func _on_button_connect_preview_pressed():

--- a/lib/src/auth/dcl_player_identity.rs
+++ b/lib/src/auth/dcl_player_identity.rs
@@ -555,6 +555,16 @@ impl DclPlayerIdentity {
         );
     }
 
+    /// GDScript-callable logout used by the sign-out flow to fully forget the
+    /// current identity (issue #1658). A bare `logout()` can't be called from
+    /// GDScript because the name is taken by the `logout` signal, and the
+    /// internal `logout()` fn is comms-only — so expose an explicitly-named
+    /// entry point. Clears wallet/ephemeral/profile and emits `logout`.
+    #[func]
+    pub fn clear_identity(&mut self) {
+        self.logout();
+    }
+
     #[func]
     pub fn get_address_str(&self) -> GString {
         match self.try_get_address() {


### PR DESCRIPTION
## Summary
  - Sign-out never reset the player identity, so the previous account's profile/avatar
    (name + wearables) lingered in memory **and** the native wallet stayed set. The new
    account's avatar editor inherited the old wearables, and `create_guest_account_if_needed`
    saw the still-present web3 wallet and skipped starting a fresh account.
  - `Global.sign_out()` now clears `guest_profile` and calls `player_identity.reset_identity()`,
    which clears the native wallet/ephemeral/profile (via a new GDScript-callable `clear_identity()`)
    and re-inits the cached mutable profile/avatar.
  - Adds a `debug-ws` deeplink param to start/stop the loopback debug WS server before
    Settings is reachable (login/lobby), used to diagnose & verify this fix.


https://github.com/user-attachments/assets/c46da087-b98a-406e-9b75-2597378326a9


  ## Changes
  - `lib/src/auth/dcl_player_identity.rs` — expose `clear_identity()` `#[func]` (the bare
    `logout` name is the logout *signal*; internal `logout()` is comms-only).
  - `godot/src/logic/player/player_identity.gd` — `reset_identity()`.
  - `godot/src/global.gd` — `sign_out()` clears guest profile + resets identity; `--fake-deeplink`
    applies `debug-ws`.
  - `godot/src/deep_link_router.gd` — `apply_debug_ws_param()` + runtime deeplink hook.
  - `godot/src/ui/pages/settings/settings.gd` — sync Debug Server checkbox to running state.

  ## Verification (debug WS server, on device)
  Create-account preview avatar after sign-out:
  - Before: `avatar_name = "EibrielAndroid#0ee8"` (old account leaked)
  - After:  `avatar_name = "#faff"` — fresh address, no leaked name/wearables

  ## Test steps
  1. Sign in with an account that has custom (non-default) wearables and a name.
  2. Open **Settings → Sign out**.
  3. From the lobby, tap **Create account**.
  4. **Expected:** the avatar editor shows the **default** body with **no** wearables
     from the previous account, and no carried-over name.
  5. Regression: confirm a normal guest entry and a normal web3 sign-in still load the
     correct profile (preview reflects the freshly fetched/created profile).

  ### Debug WS deeplink (optional, dev builds only)
  1. Send `decentraland://?debug-ws=1` (mobile) or run
     `cargo run -- run -- --fake-deeplink "decentraland://?debug-ws=1"` (desktop).
  2. `adb forward tcp:9230 tcp:9230`, then
     `.claude/skills/debug-ws-inspector/scripts/debug-ws.sh '{"id":1,"cmd":"ping"}'` → expect `ok:true`.
  3. After sign-out → Create account, probe the preview avatar and confirm
     `avatar_name` no longer carries the previous account's name:
```
.claude/skills/debug-ws-inspector/scripts/debug-ws.sh '{"id":2,"cmd":"app_ui","filters":{"path":"/root/Lobby/Main/BackpackContainer/MarginContainer/VBoxContainer/Backpack/VBoxContainer2/Control/AvatarPrevi
  ew/SubViewport","depth":1,"collect_nodes":{"Avatar":["avatar_name"]}}}'
```

  Closes #1658