### PR TITLE
feat(ios): report StoreKit environment to analytics at startup

### DIFF
--- a/godot/src/global.gd
+++ b/godot/src/global.gd
@@ -437,6 +437,16 @@ func _ready():
 		# spawns a transient Timer under Global only while polling for first_move_in_world.
 		self.analytics_controller = AnalyticsController.new()
 		self.analytics_controller.setup()
+
+		# iOS only: report the StoreKit environment (production/sandbox) to
+		# analytics once at startup. StoreKit's environment is fixed by how the
+		# binary was distributed and can't be chosen by the app, so this is the
+		# ground truth for which IAP backend a device will hit. We ship this
+		# BEFORE any purchase flow to validate in prod that real App Store
+		# installs report `production`. Deferred so it runs after every autoload
+		# (incl. Iap) is in the tree. See docs/iap-zone-submission/.
+		if self.is_ios():
+			Iap.report_environment_to_analytics.call_deferred()
 	# Platform attestation: needs to be a Node (uses timers + native plugin signals). The
 	# service self-gates on EULA acceptance and caches the issued session token on disk.
 	self.attestation = AttestationService.new()

--- a/godot/src/iap/iap_manager.gd
+++ b/godot/src/iap/iap_manager.gd
@@ -78,6 +78,12 @@ var enabled: bool = false
 
 var _store_kit := DclStoreKitPlugin.new()
 var _store_kit_available: bool = false
+# Synchronous receipt-read environment captured at startup, held until the
+# authoritative AppTransaction resolves so both go out in one atomic event.
+var _env_sync_value: String = ""
+# ms-since-startup when the synchronous read above was taken (same clock the
+# `[Startup]` logs use: Time.get_ticks_msec() - Global._startup_time).
+var _env_sync_at_ms: int = 0
 var _products: Array = []
 # In-memory only; resets on relaunch.
 var _balance: int = 0
@@ -99,6 +105,69 @@ func _ready() -> void:
 	# IAP starts disabled. DeepLinkRouter calls enable() when the launch
 	# deeplink carries iap_enabled=true.
 	pass
+
+
+# Reports the StoreKit environment (production / sandbox / xcode) to analytics.
+# Runs unconditionally on iOS at startup — independent of enable() / iap_enabled
+# — so we collect production telemetry from real App Store installs and validate
+# the environment-detection mechanism BEFORE wiring it to backend selection.
+# StoreKit's environment is fixed by how the binary was distributed and can't be
+# chosen by the app (see docs/iap-zone-submission/), so it's the ground truth for
+# which IAP backend a device will hit. No-op on non-iOS.
+func report_environment_to_analytics() -> void:
+	# is_available() lazily instantiates the Swift class; on non-iOS the class
+	# isn't registered so this returns false. Note this does NOT start the
+	# Transaction.updates listener (that only happens in enable()).
+	if not _store_kit.is_available():
+		return
+
+	# Capture the synchronous receipt read NOW, but don't emit yet: we send a
+	# single atomic event once the authoritative AppTransaction resolves, so the
+	# two readings can never arrive asymmetrically. The Swift side guarantees the
+	# signal fires exactly once (hard timeout falls back to the receipt read), so
+	# the event is never missing.
+	_env_sync_value = _store_kit.current_environment()
+	_env_sync_at_ms = Time.get_ticks_msec() - Global._startup_time
+
+	if not _store_kit.environment_resolved.is_connected(_on_environment_resolved):
+		_store_kit.environment_resolved.connect(_on_environment_resolved, CONNECT_DEFERRED)
+	_store_kit.resolve_environment()
+
+
+func _on_environment_resolved(environment: String, source: String, resolve_ms: float) -> void:
+	var env_at_ms := Time.get_ticks_msec() - Global._startup_time
+	var matched := environment == _env_sync_value
+	print(
+		(
+			"[IAP] StoreKit env: authoritative=%s (%s) sync=%s match=%s resolve=%dms sync@%dms env@%dms"
+			% [
+				environment,
+				source,
+				_env_sync_value,
+				matched,
+				int(resolve_ms),
+				_env_sync_at_ms,
+				env_at_ms
+			]
+		)
+	)
+	if Global.metrics == null:
+		return
+	# One atomic event with BOTH readings + resolve latency + the startup-relative
+	# times each reading was taken + agreement. flush() ships it immediately so a
+	# short session can't drop it (it respects the EULA consent gate, so
+	# pre-consent it stays queued until consent opens).
+	Global.metrics.track_ios_storekit_environment(
+		environment,
+		_env_sync_value,
+		source,
+		resolve_ms,
+		_env_sync_at_ms,
+		env_at_ms,
+		str(DclGlobal.get_dcl_environment()),
+		_store_kit.can_make_payments()
+	)
+	Global.metrics.flush()
 
 
 # Idempotent. Called by DeepLinkRouter when iap_enabled=true is present in

--- a/lib/src/analytics/data_definition.rs
+++ b/lib/src/analytics/data_definition.rs
@@ -64,6 +64,7 @@ pub enum SegmentEvent {
     FirebaseInit(SegmentEventFirebaseInit),
     AttestationAttempt(SegmentEventAttestationAttempt),
     AttestationSessionCacheLoaded(SegmentEventAttestationSessionCacheLoaded),
+    IosStoreKitEnvironment(SegmentEventIosStoreKitEnvironment),
 }
 
 /// Cross-system correlation anchor. The ONLY Segment event that carries the Firebase Analytics
@@ -286,6 +287,47 @@ pub struct SegmentEventScreenViewed {
     pub extra_properties: Option<String>,
 }
 
+/// Reports the StoreKit environment detected on iOS at startup. The environment
+/// is fixed by how the binary was distributed (App Store download → production;
+/// TestFlight / App Review build → sandbox) and the app cannot choose it, so
+/// this is the ground truth for which In-App-Purchase backend the device will
+/// hit. Emitted before any IAP flow exists, purely to validate in production
+/// that real App Store installs report `production`. See `docs/iap-zone-submission/`.
+// Single atomic event carrying BOTH readings of the StoreKit environment so they
+// can never arrive asymmetrically: the synchronous receipt read and the
+// authoritative `AppTransaction` value, plus how long the latter took and whether
+// they agree. One payload = the two readings are always present together, which
+// is the whole point (measure the resolve latency, confirm they coincide).
+#[derive(Serialize, Clone)]
+pub struct SegmentEventIosStoreKitEnvironment {
+    // Authoritative environment from AppTransaction (falls back to the receipt
+    // read on timeout/error): "production" | "sandbox" | "xcode" | "unknown".
+    pub environment: String,
+    // Synchronous receipt-URL read taken at startup, for comparison.
+    pub environment_sync: String,
+    // How `environment` was determined: "app_transaction" (authoritative) |
+    // "app_transaction_unverified" | "receipt_fallback" (AppTransaction threw) |
+    // "timeout" (AppTransaction didn't resolve within the hard cap).
+    pub source: String,
+    // Wall-clock milliseconds AppTransaction took to resolve (measured in Swift).
+    pub resolve_ms: f64,
+    // Milliseconds since app startup when the synchronous receipt read was taken.
+    pub environment_sync_at_ms: i64,
+    // Milliseconds since app startup when the authoritative environment was
+    // confirmed and readable. The gap to environment_sync_at_ms is how long the
+    // device went before the authoritative value was available.
+    pub environment_at_ms: i64,
+    // Whether the authoritative and synchronous readings agree.
+    #[serde(rename = "match")]
+    pub matched: bool,
+    // The app's own backend environment at the time: "org" | "zone" | "today".
+    // A mismatch (e.g. StoreKit "sandbox" while app "org") is exactly the
+    // App-Review conflict we're characterising.
+    pub app_environment: String,
+    // StoreKit's AppStore.canMakePayments for this device.
+    pub can_make_payments: bool,
+}
+
 #[derive(Serialize, Clone)]
 pub struct SegmentEventRequestFriend {
     // Wallet address of the user receiving the friend request.
@@ -496,6 +538,11 @@ pub fn build_segment_event_batch_item(
         ),
         SegmentEvent::AttestationSessionCacheLoaded(event) => (
             "Attestation Session Cache Loaded".to_string(),
+            serde_json::to_value(event).unwrap(),
+            None,
+        ),
+        SegmentEvent::IosStoreKitEnvironment(event) => (
+            "iOS StoreKit Environment".to_string(),
             serde_json::to_value(event).unwrap(),
             None,
         ),

--- a/lib/src/analytics/metrics.rs
+++ b/lib/src/analytics/metrics.rs
@@ -21,8 +21,8 @@ use super::{
         SegmentEventAttestationAttempt, SegmentEventAttestationSessionCacheLoaded,
         SegmentEventBlockUser, SegmentEventChatMessageSent, SegmentEventClickButton,
         SegmentEventCommonExplorerFields, SegmentEventExplorerMoveToParcel,
-        SegmentEventFirebaseInit, SegmentEventRequestFriend, SegmentEventScreenViewed,
-        SegmentEventUnfriend,
+        SegmentEventFirebaseInit, SegmentEventIosStoreKitEnvironment, SegmentEventRequestFriend,
+        SegmentEventScreenViewed, SegmentEventUnfriend,
     },
     frame::Frame,
     install_referrer::InstallReferrer,
@@ -341,6 +341,41 @@ impl Metrics {
         });
         self.events.push(event.clone());
         self.debug_print_event("Click Button", &event);
+    }
+
+    /// Reports the iOS StoreKit environment to Segment. Fired once at startup
+    /// (and again when the authoritative `AppTransaction` resolves) so we can
+    /// validate in production that real App Store installs report `production`
+    /// — before any IAP purchase flow exists. Platform-agnostic on the Rust
+    /// side: callers gate to iOS. Subject to the EULA consent gate like every
+    /// other event.
+    #[allow(clippy::too_many_arguments)]
+    #[func]
+    pub fn track_ios_storekit_environment(
+        &mut self,
+        environment: String,
+        environment_sync: String,
+        source: String,
+        resolve_ms: f64,
+        environment_sync_at_ms: i64,
+        environment_at_ms: i64,
+        app_environment: String,
+        can_make_payments: bool,
+    ) {
+        let matched = environment == environment_sync;
+        let event = SegmentEvent::IosStoreKitEnvironment(SegmentEventIosStoreKitEnvironment {
+            environment,
+            environment_sync,
+            source,
+            resolve_ms,
+            environment_sync_at_ms,
+            environment_at_ms,
+            matched,
+            app_environment,
+            can_make_payments,
+        });
+        self.events.push(event.clone());
+        self.debug_print_event("iOS StoreKit Environment", &event);
     }
 
     #[func]

--- a/lib/src/godot_classes/dcl_swift_lib.rs
+++ b/lib/src/godot_classes/dcl_swift_lib.rs
@@ -110,6 +110,13 @@ impl DclStoreKitPlugin {
     #[signal]
     fn transaction_updated(json: GString);
 
+    /// `(environment, source, resolve_ms)` — emitted exactly once after
+    /// `resolve_environment()`, guaranteed even on timeout. `environment` is
+    /// `"production"` | `"sandbox"` | `"xcode"` | `"unknown"`; `source` tells how
+    /// it was determined; `resolve_ms` is how long `AppTransaction` took.
+    #[signal]
+    fn environment_resolved(environment: GString, source: GString, resolve_ms: f64);
+
     fn ensure_inner(&mut self) -> bool {
         if self.inner.is_some() {
             return true;
@@ -139,6 +146,7 @@ impl DclStoreKitPlugin {
         let cb_purchase_cancelled = self.base().callable("_on_purchase_cancelled");
         let cb_purchase_pending = self.base().callable("_on_purchase_pending");
         let cb_transaction_updated = self.base().callable("_on_transaction_updated");
+        let cb_environment_resolved = self.base().callable("_on_environment_resolved");
 
         // The Swift signals are emitted from background `Task`s (StoreKit runs
         // its async work off the main thread). Connect DEFERRED so the forwarders
@@ -153,6 +161,7 @@ impl DclStoreKitPlugin {
         inner.connect_flags("purchase_cancelled", &cb_purchase_cancelled, deferred);
         inner.connect_flags("purchase_pending", &cb_purchase_pending, deferred);
         inner.connect_flags("transaction_updated", &cb_transaction_updated, deferred);
+        inner.connect_flags("environment_resolved", &cb_environment_resolved, deferred);
         self.wired = true;
     }
 
@@ -174,6 +183,38 @@ impl DclStoreKitPlugin {
             .call("can_make_payments", &[])
             .try_to::<bool>()
             .unwrap_or(false)
+    }
+
+    /// Synchronous best-effort StoreKit environment: `"sandbox"`,
+    /// `"production"` or `"unknown"`, read instantly from the receipt URL.
+    /// Safe to call at startup before picking the credits backend. Empty
+    /// string on non-iOS. For the authoritative value (and to distinguish the
+    /// Xcode StoreKit-config environment) use [`Self::resolve_environment`].
+    #[func]
+    fn current_environment(&mut self) -> GString {
+        if !self.ensure_inner() {
+            return GString::new();
+        }
+        self.inner
+            .as_mut()
+            .unwrap()
+            .call("current_environment", &[])
+            .try_to::<GString>()
+            .unwrap_or_default()
+    }
+
+    /// Authoritative StoreKit environment via `AppTransaction.shared`. Resolves
+    /// asynchronously; connect to the `environment_resolved(environment,
+    /// source)` signal for the result. No-op on non-iOS.
+    #[func]
+    fn resolve_environment(&mut self) {
+        if !self.ensure_inner() {
+            return;
+        }
+        self.inner
+            .as_mut()
+            .unwrap()
+            .call("resolve_environment", &[]);
     }
 
     #[func]
@@ -261,5 +302,17 @@ impl DclStoreKitPlugin {
     fn _on_transaction_updated(&mut self, json: GString) {
         self.base_mut()
             .emit_signal("transaction_updated", &[json.to_variant()]);
+    }
+
+    #[func]
+    fn _on_environment_resolved(&mut self, environment: GString, source: GString, resolve_ms: f64) {
+        self.base_mut().emit_signal(
+            "environment_resolved",
+            &[
+                environment.to_variant(),
+                source.to_variant(),
+                resolve_ms.to_variant(),
+            ],
+        );
     }
 }

--- a/plugins/dcl-swift-lib/Sources/DclSwiftLib/StoreKitManager.swift
+++ b/plugins/dcl-swift-lib/Sources/DclSwiftLib/StoreKitManager.swift
@@ -49,6 +49,17 @@ class DclStoreKit: RefCounted, @unchecked Sendable {
     /// purchases from another device, etc.). Argument: JSON of the transaction.
     @Signal var transactionUpdated: SignalWithArguments<String>
 
+    /// Emitted EXACTLY ONCE by `resolve_environment()` — guaranteed, even if
+    /// `AppTransaction.shared` hangs (a hard timeout falls back to the receipt
+    /// read). `(environment, source, resolveMs)`:
+    /// - `environment`: `"production"` | `"sandbox"` | `"xcode"` | `"unknown"`.
+    /// - `source`: `"app_transaction"` (authoritative) |
+    ///   `"app_transaction_unverified"` | `"receipt_fallback"` (AppTransaction
+    ///   threw) | `"timeout"` (AppTransaction didn't resolve in time).
+    /// - `resolveMs`: wall-clock ms `AppTransaction` took to resolve — the value
+    ///   we want to measure.
+    @Signal var environmentResolved: SignalWithArguments<String, String, Double>
+
     // MARK: - State
 
     // `loadedProducts` is written from the `loadProducts` background Task and
@@ -80,6 +91,97 @@ class DclStoreKit: RefCounted, @unchecked Sendable {
     @Callable(autoSnakeCase: true)
     func canMakePayments() -> Bool {
         return AppStore.canMakePayments
+    }
+
+    // MARK: - Environment
+
+    /// Synchronous, best-effort StoreKit environment. Returns `"sandbox"`,
+    /// `"production"` or `"unknown"` immediately from the app-receipt URL —
+    /// no network, no `await` — so it's safe to call at startup *before*
+    /// deciding which credits backend (.zone vs .org) to talk to.
+    ///
+    /// The environment is fixed by how the binary was distributed and the app
+    /// cannot choose it: App Store download → production; TestFlight and the
+    /// App Review build → sandbox (see `docs/iap-zone-submission/`). This getter
+    /// can't see the Xcode StoreKit-config environment (it has no receipt) and
+    /// may read `"unknown"` on a brand-new install before the receipt exists —
+    /// for the authoritative value use `resolve_environment()`.
+    @Callable(autoSnakeCase: true)
+    func currentEnvironment() -> String {
+        guard let url = Bundle.main.appStoreReceiptURL else { return "unknown" }
+        switch url.lastPathComponent {
+        case "sandboxReceipt": return "sandbox"
+        case "receipt": return "production"
+        default: return "unknown"
+        }
+    }
+
+    /// Authoritative StoreKit environment via `AppTransaction.shared` — the
+    /// app's own signed "download" receipt, available even before any purchase.
+    /// Resolves asynchronously and emits `environment_resolved(environment,
+    /// source)`. This is the same signal Apple uses to route App Review's
+    /// sandbox purchases, so it's the reliable input for picking the backend.
+    /// Falls back to `current_environment()` if `AppTransaction` can't be
+    /// fetched (e.g. no network on a fresh sandbox install).
+    @Callable(autoSnakeCase: true)
+    func resolveEnvironment() {
+        Task { [weak self] in
+            guard let self = self else { return }
+            let start = DispatchTime.now()
+            let (env, source) = await self.computeEnvironment()
+            let elapsedMs =
+                Double(DispatchTime.now().uptimeNanoseconds &- start.uptimeNanoseconds) / 1_000_000.0
+            gdLog("[DclStoreKit] resolveEnvironment: \(env) (\(source)) in \(Int(elapsedMs))ms")
+            self.environmentResolved.emit(env, source, elapsedMs)
+        }
+    }
+
+    /// Resolves the authoritative environment, ALWAYS returning within the hard
+    /// timeout and NEVER throwing — on error or timeout it falls back to the
+    /// synchronous receipt read. This is what lets `resolve_environment()`
+    /// guarantee its signal fires exactly once, so the analytics event is never
+    /// missing.
+    private func computeEnvironment() async -> (String, String) {
+        let timeoutNs: UInt64 = 10_000_000_000  // 10s hard cap
+        return await withTaskGroup(of: (String, String)?.self) { group in
+            group.addTask { [weak self] in
+                guard let self = self else { return nil }
+                do {
+                    let result = try await AppTransaction.shared
+                    switch result {
+                    case .verified(let appTx):
+                        return (Self.environmentString(appTx.environment), "app_transaction")
+                    case .unverified(let appTx, _):
+                        return (
+                            Self.environmentString(appTx.environment), "app_transaction_unverified"
+                        )
+                    }
+                } catch {
+                    return (self.currentEnvironment(), "receipt_fallback")
+                }
+            }
+            group.addTask {
+                try? await Task.sleep(nanoseconds: timeoutNs)
+                return nil  // timeout sentinel
+            }
+            defer { group.cancelAll() }
+            for await first in group {
+                if let value = first {
+                    return value
+                }
+                break  // sentinel reached first → timeout
+            }
+            return (self.currentEnvironment(), "timeout")
+        }
+    }
+
+    /// Normalises `AppStore.Environment` (a RawRepresentable struct, not an
+    /// enum) to a stable lowercase string for GDScript.
+    private static func environmentString(_ env: AppStore.Environment) -> String {
+        if env == .production { return "production" }
+        if env == .sandbox { return "sandbox" }
+        if env == .xcode { return "xcode" }
+        return env.rawValue
     }
 
     /// Start observing `Transaction.updates`. Idempotent. Call this early in


### PR DESCRIPTION
iOS-only, append-only startup probe: reads the StoreKit environment (the ground truth for which IAP backend a device hits — fixed by how the binary was distributed) and ships it to Segment as a single atomic event, before any purchase flow exists. Validates in prod that App Store installs report `production`.

- Swift currentEnvironment() (sync receipt) + resolveEnvironment() (authoritative AppTransaction.shared) with a 10s timeout guaranteeing exactly one emission, so the event is never missing.
- One atomic event: both readings + resolve_ms + startup-relative read times + match. Deferred, iOS-only, fails silently, no blocking time.
- Does not touch the purchase path (each Transaction carries its own signed environment, validated by the backend).