### PR TITLE
fix: onLeaveScene not triggered when players disconnect

### DIFF
--- a/lib/src/avatars/avatar_scene.rs
+++ b/lib/src/avatars/avatar_scene.rs
@@ -1071,40 +1071,68 @@ impl AvatarScene {
         // maybe it's better to cache the last parcel here instead of using prev_scene_id
         // the state of to what parcel the avatar belongs is stored in the avatar_scene
 
+        // Cached component values for this avatar, used to (re)populate the scene
+        // being entered. `@dcl/sdk/players` derives onEnterScene from an entity having
+        // both PlayerIdentityData and AvatarBase, and onLeaveScene from AvatarBase
+        // being removed — so scene membership must add/remove these components.
+        let avatar_base = SceneCrdtStateProtoComponents::get_avatar_base(&self.crdt_state)
+            .get(&avatar_entity_id)
+            .and_then(|v| v.value.clone());
+        let player_identity_data =
+            SceneCrdtStateProtoComponents::get_player_identity_data(&self.crdt_state)
+                .get(&avatar_entity_id)
+                .and_then(|v| v.value.clone());
+        let avatar_equipped_data =
+            SceneCrdtStateProtoComponents::get_avatar_equipped_data(&self.crdt_state)
+                .get(&avatar_entity_id)
+                .and_then(|v| v.value.clone());
+
         let mut scene_runner = DclGlobal::singleton().bind().scene_runner.clone();
         let mut scene_runner = scene_runner.bind_mut();
+
+        // Leaving the previous scene: clear the avatar's components there so the SDK's
+        // onLeaveScene fires and the player drops from getEntitiesWith(PlayerIdentityData).
+        // Routed through `deleted_entities`, which sets these components to None — the
+        // departure cannot be communicated as an entity death (the renderer→scene path
+        // never carries entity deaths). See `update_avatar_scene_updates`.
         if let Some(prev_scene) = scene_runner.get_scene_mut(&prev_scene_id) {
             prev_scene
                 .avatar_scene_updates
-                .transform
-                .insert(avatar_entity_id, None);
-            prev_scene
-                .avatar_scene_updates
-                .internal_player_data
-                .insert(avatar_entity_id, InternalPlayerData { inside: false });
+                .deleted_entities
+                .insert(avatar_entity_id);
         }
 
+        // Entering the new scene: (re)populate the avatar's components so onEnterScene
+        // fires and the player appears in getEntitiesWith(PlayerIdentityData, AvatarBase).
         if let Some(scene) = scene_runner.get_scene_mut(&scene_id) {
             let dcl_transform = DclTransformAndParent::default(); // TODO: get real transform with scene_offset
-
-            let mut avatar_scene_transform = dcl_transform.clone();
-            avatar_scene_transform.translation.x -=
-                (scene.scene_entity_definition.get_base_parcel().x as f32) * 16.0;
-
-            // TODO: I think this is working fine but
-            //   Should it be added instead of subtracted? (z is inverted in godot and dcl)
-            avatar_scene_transform.translation.z -=
-                (scene.scene_entity_definition.get_base_parcel().y as f32) * 16.0;
 
             scene
                 .avatar_scene_updates
                 .transform
-                .insert(avatar_entity_id, Some(dcl_transform.clone()));
-
+                .insert(avatar_entity_id, Some(dcl_transform));
             scene
                 .avatar_scene_updates
                 .internal_player_data
                 .insert(avatar_entity_id, InternalPlayerData { inside: true });
+            if let Some(avatar_base) = avatar_base {
+                scene
+                    .avatar_scene_updates
+                    .avatar_base
+                    .insert(avatar_entity_id, avatar_base);
+            }
+            if let Some(player_identity_data) = player_identity_data {
+                scene
+                    .avatar_scene_updates
+                    .player_identity_data
+                    .insert(avatar_entity_id, player_identity_data);
+            }
+            if let Some(avatar_equipped_data) = avatar_equipped_data {
+                scene
+                    .avatar_scene_updates
+                    .avatar_equipped_data
+                    .insert(avatar_entity_id, avatar_equipped_data);
+            }
         }
     }
 

--- a/lib/src/scene_runner/components/avatar_data.rs
+++ b/lib/src/scene_runner/components/avatar_data.rs
@@ -9,7 +9,28 @@ use crate::{
 
 pub fn update_avatar_scene_updates(scene: &mut Scene, crdt_state: &mut SceneCrdtState) {
     for entity_id in scene.avatar_scene_updates.deleted_entities.drain() {
-        crdt_state.entities.kill(entity_id);
+        // Issue #1818: a departing player (disconnect or walk-out) must be communicated
+        // to the scene's V8 CRDT so `@dcl/sdk/players` onLeaveScene fires and iterating
+        // entities with PlayerIdentityData drops the peer.
+        //
+        // We must NOT do this with an entity death: the renderer→scene path never
+        // carries entity deaths (they're stripped from the dirty set, and #1444 stops
+        // them reaching the SDK). Instead we mirror the enter path — which works by
+        // PUT-ing components — and set the player components to None. A None value is a
+        // dirty component DELETE that propagates to V8 exactly like a PUT does.
+        //
+        // The entity is left alive (component-less) in the scene CRDT; avatar entity
+        // slots are recycled from `AvatarScene::crdt_state`, which is killed separately
+        // in `AvatarScene::remove_avatar`, so no scene-side kill is needed here.
+        SceneCrdtStateProtoComponents::get_player_identity_data_mut(crdt_state)
+            .put(entity_id, None);
+        SceneCrdtStateProtoComponents::get_avatar_base_mut(crdt_state).put(entity_id, None);
+        SceneCrdtStateProtoComponents::get_avatar_equipped_data_mut(crdt_state)
+            .put(entity_id, None);
+        crdt_state
+            .get_internal_player_data_mut()
+            .put(entity_id, None);
+        crdt_state.get_transform_mut().put(entity_id, None);
     }
 
     {


### PR DESCRIPTION
## What

  `@dcl/sdk/players` `onLeaveScene` (and `onEnterScene`) never fired for remote players. The renderer signalled a player leaving by **killing the avatar entity**, but entity deaths never reach the scene's JS
  (they're stripped from the dirty set, and #1444 deliberately stops them reaching the SDK). The SDK detects presence purely from components — `onEnterScene` when an entity gains `PlayerIdentityData` +
  `AvatarBase`, `onLeaveScene` when `AvatarBase` is removed — so the entity-kill was invisible to it.

  ## Fix

  Communicate departure as **component deletions** (set the player components to `None`), which propagate to the scene exactly like the component PUTs the enter path already uses.

  - **`avatar_data.rs`** — on avatar removal (disconnect), clear the player components instead of `entities.kill`. Entity-slot recycling still happens via `AvatarScene`'s own CRDT in `remove_avatar`.
  - **`avatar_scene.rs` (`on_avatar_changed_scene`)** — on walk-out, clear the components for the scene being left; on walk-in, repopulate them from the cached avatar data. This makes scene-boundary crossings 
  fire `onLeaveScene`/`onEnterScene` too.

  Grounded in the proto contract (`PlayerIdentityData` is "written by the engine using the communications transports' data") and the SDK's actual detection logic in `@dcl/sdk/src/players`.

  ## Testing

  Requires two players in the same realm (a second desktop/Bevy/Unity client, or two instances).

  1. Build & run: `cargo run -- run`.
  2. Go to parcel **`-31,19`** and select the **"Avatars"** test block. It shows live counters: `Connected Avatars`, `onEnterScene`, `onLeaveScene`, and `PlayerIdentityData entities`.
  3. Bring a **second player into the scene**. Confirm every counter reads the full count (e.g. `(2)`, `onEnterScene: 2`).
  4. **Walk the second player out** of the parcel (stays connected): `onLeaveScene` increments and `PlayerIdentityData entities` decrements; "Recent leaves" records the address.
  5. **Walk back in**: `onEnterScene` increments and the counts restore.
  6. **Fully disconnect** the second player: `onLeaveScene` increments, `PlayerIdentityData entities` decrements, and the avatar is removed — with no double-firing.

  > Note: restart the client between full test runs — the SDK's player-tracking map can retain stale entries from a prior session, which masks subsequent events.

  Closes #1818