### PR TITLE
fix: clear notifications on sign-out + repair attended-events sync

### DIFF
--- a/godot/src/global.gd
+++ b/godot/src/global.gd
@@ -711,6 +711,15 @@ func sign_out() -> void:
 
 	# 2. Stop session pollers and tear down the social gRPC streams.
 	NotificationsManager.stop_polling()
+	# Wipe the previous account's in-memory notification history so it can't leak
+	# into the next session's panel/bell badge (issue #2104).
+	NotificationsManager.clear_notification_history()
+	# Drop the previous account's event reminders so they can't fire on the
+	# device after sign-out. Only "event_" entries (per-account attended-event
+	# reminders) are cleared; the per-install day1 welcome is preserved. The
+	# sync-on-next-login REMOVE pass only runs for an authenticated account, so
+	# without this a signed-out/guest session keeps the old reminders scheduled.
+	NotificationsManager.clear_event_local_notifications()
 	# The analytics first-move poll (a Timer under this autoload) reads
 	# scene_runner.player_body_node; left running it would poll the freed Player
 	# after the swap, panicking the #[var] getter. It restarts on the next login.

--- a/godot/src/notifications_manager.gd
+++ b/godot/src/notifications_manager.gd
@@ -147,6 +147,18 @@ func stop_polling() -> void:
 		_poll_timer.stop()
 
 
+## Clear the in-memory server notification history and pending toast queue.
+## Used on sign-out so a previous account's notifications don't leak into the
+## next session (issue #2104). NotificationsManager is an autoload that survives
+## the lobby scene swap, so without this the cached list persists across accounts.
+## Emitting notifications_updated refreshes the open panel and the bell badge.
+func clear_notification_history() -> void:
+	_notifications.clear()
+	_notification_queue.clear()
+	_previous_notification_ids.clear()
+	notifications_updated.emit()
+
+
 ## Get currently cached notifications sorted by timestamp descending (newest first)
 func get_notifications() -> Array:
 	var sorted = _notifications.duplicate()
@@ -829,6 +841,21 @@ func force_queue_sync() -> void:
 	_sync_notification_queue()
 
 
+## Clear account-scoped event reminder notifications (used on sign-out).
+##
+## Only removes "event_"-prefixed entries — the per-account attended-event
+## reminders, which are derived from whoever was signed in. The per-install
+## "day1_welcome" notification is intentionally preserved (it belongs to the
+## device/install, not the session). This both cancels the pending OS
+## notification and deletes the database row, so a signed-out account's
+## reminders can no longer fire on the device.
+func clear_event_local_notifications() -> void:
+	for notif in get_queued_local_notifications():
+		var notif_id: String = notif.get("id", "")
+		if notif_id.begins_with("event_"):
+			cancel_queued_local_notification(notif_id)
+
+
 ## Check if local notifications version has changed and clear all if needed
 ## Returns true if notifications were cleared due to version mismatch
 func _check_and_handle_version_change() -> bool:
@@ -899,7 +926,12 @@ func async_sync_attended_events() -> void:
 	# _on_permission_changed. Trigger day1 here instead — its own guards handle dedup.
 	async_schedule_day1_notification.call_deferred()
 
-	var url = DclUrls.mobile_events_api() + "/?only_attendee=true"
+	# Use the canonical events service (events.decentraland.org/api/events): when
+	# signed it reports a correct per-user `attending` flag on each event — the same
+	# source the REMIND ME button reads/writes. The mobile-bff `?only_attendee=true`
+	# endpoint ignores the param and always returns `attending=false`, so the sync
+	# never restored reminders.
+	var url = DclUrls.events_api()
 	var response = await Global.async_signed_fetch(url, HTTPClient.METHOD_GET, "")
 
 	if response is PromiseError:
@@ -913,8 +945,9 @@ func async_sync_attended_events() -> void:
 
 	var all_events: Array = json.get("data", [])
 
-	# Filter locally to only use events where attending=true
-	# This is a workaround until the API's only_attendee parameter is fixed
+	# Keep only events the signed user is attending. events_api() populates a correct
+	# per-user `attending` flag when the request is signed (unlike the mobile-bff
+	# `only_attendee` endpoint, which always returns false).
 	var events: Array = []
 	for event_data in all_events:
 		if event_data.get("attending", false) == true:


### PR DESCRIPTION
## Summary

  Three related notification fixes, surfaced while investigating #2104:

  1. **Clear in-memory notification history on sign-out (closes #2104).**
     `NotificationsManager` is an autoload that survives the lobby scene swap, and
     `sign_out()` only stopped the poll timer — the cached `_notifications` array (and the
     bell badge count) leaked into the next account. New `clear_notification_history()`
     wipes the in-memory history/queue and refreshes the panel + bell via
     `notifications_updated`.

  2. **Drop the previous account's local event reminders on sign-out.**
     New `clear_event_local_notifications()` cancels the OS notifications and deletes the
     `event_`-prefixed rows from the local SQLite queue, so a signed-out/guest session can't
     fire a previous account's reminders. The per-install `day1_welcome` is preserved.

  3. **Repair the attended-events re-sync (prerequisite for #2 not regressing).**
     `async_sync_attended_events()` was fetching `mobile_events_api()` (mobile-bff)
     `?only_attendee=true`, which ignores the param and returns `attending=false` for every
     event — so the sync never scheduled anything. Re-pointed it at `events_api()`
     (events.decentraland.org), the canonical service that reports a correct per-user
     `attending` flag (the same source the REMIND ME button reads/writes). This was a
     regression from #1424, which moved the sync onto mobile-bff in the same PR that
     documented mobile-bff "doesn't return per-user attending state."

  ## Verified on-device (Android)
  
  Via debug-WS (in-memory) and `adb run-as` sqlite snapshots of `dcl_notifications.db`:

  - Sign-out clears in-memory history (33 → 0) and `event_` rows (1 → 0), `day1_welcome` preserved.
  - After fix, logout → login → enter world restores attended/future reminders automatically
    (4 attending detected; 3 scheduled, 1 correctly skipped as already-started) — no manual re-set.

  ## Files

  - `godot/src/notifications_manager.gd` — `clear_notification_history()`,
    `clear_event_local_notifications()`, `async_sync_attended_events()` URL fix.
  - `godot/src/global.gd` — both clears wired into `sign_out()`.

  Closes #2104