### PR TITLE
fix(avatar): render nameplates in a 2D layer, not per-avatar viewports (#2215)

### DIFF
--- a/godot/src/decentraland_components/avatar/avatar.gd
+++ b/godot/src/decentraland_components/avatar/avatar.gd
@@ -163,6 +163,11 @@ var _free_bone_pool: Array[int] = []
 var _stale_bone_counter: int = 0
 
 var _lod_state: int = LODState.FULL
+# 2D screen-space nameplate (non-XR) vs legacy viewport quad (XR). Runtime lives in
+# NameplateLayer; these cache the hide-flag/FAR gate and the depth-occlusion result.
+var _use_2d_nameplate: bool = false
+var _nametag_gate_visible: bool = true
+var _nameplate_occluded: bool = false
 var _impostor_layer: int = -1
 var _lod_phase: int = 0
 var _mesh_lod_visibility_captured: bool = false
@@ -269,6 +274,9 @@ func _ready():
 	# Hide mic when the avatar is spawned
 	nickname_ui.mic_enabled = false
 	Global.on_chat_message.connect(on_chat_message)
+	_use_2d_nameplate = not Global.is_xr()
+	if _use_2d_nameplate:
+		NameplateLayer.attach(self)
 	_apply_nickname_visibility()
 
 	_lod_phase = int(self.unique_id) % AvatarImpostorConfig.DISTANCE_CHECK_PERIOD_FRAMES
@@ -282,6 +290,11 @@ func _ready():
 
 func _exit_tree() -> void:
 	AvatarLODCoordinator.unregister(self)
+
+	# The 2D nameplate lives in the shared layer, not under this avatar, so it
+	# won't be auto-freed — free it explicitly.
+	if _use_2d_nameplate:
+		NameplateLayer.detach(self)
 
 	# For local player and remote avatars, trigger detection is setup later via setup_trigger_detection()
 	# For AvatarShapes (scene NPCs), remove_trigger_detection() is called from avatar_shape.rs
@@ -590,17 +603,11 @@ func set_force_hide_name(value: bool) -> void:
 		_apply_nickname_visibility()
 
 
-## Bump the nickname SubViewport to redraw exactly one frame. UPDATE_ONCE
-## auto-resets to UPDATE_DISABLED after rendering, so callers must invoke
-## this every time something nickname-related changes — `_apply_nickname_visibility`
-## bumps once on show, individual setters (chat message, mic, etc.) bump as
-## state changes, and `_process` bumps after the viewport resizes.
-##
-## Gate on `nickname_quad.visible` (the source of truth for "is this nickname
-## actually being shown") rather than `render_target_update_mode == UPDATE_DISABLED`
-## — the latter is also the post-render state after UPDATE_ONCE auto-resets, so
-## it can't distinguish "explicitly hidden" from "just finished rendering one frame".
+## Legacy XR-only: bump the nickname SubViewport to redraw one frame (UPDATE_ONCE
+## auto-resets). 2D nameplates are live Controls so content setters suffice.
 func _request_nickname_redraw() -> void:
+	if _use_2d_nameplate:
+		return
 	if nickname_viewport == null or nickname_quad == null:
 		return
 	if not nickname_quad.visible:
@@ -622,6 +629,12 @@ func _apply_nickname_visibility() -> void:
 	var should_hide := (
 		avatar_shape_has_no_name or hide_name or _force_hide_name or far_lod or nametag_hidden
 	)
+	if _use_2d_nameplate:
+		# _update_nameplate_2d() positions/shows when allowed; hide now if gated off.
+		_nametag_gate_visible = not should_hide
+		if should_hide and nickname_ui != null:
+			nickname_ui.hide()
+		return
 	if should_hide:
 		nickname_quad.hide()
 		if nickname_viewport != null:
@@ -1382,11 +1395,20 @@ func _tick_animation_throttle(delta: float) -> void:
 		_anim_throttle_counter = 0
 
 
+func _physics_process(_delta):
+	# Occlusion raycast must run here, not in _process — direct_space_state crashes
+	# when queried from an idle frame.
+	if _use_2d_nameplate:
+		NameplateLayer.update_occlusion(self)
+
+
 func _process(delta):
 	# TODO: maybe a gdext crate bug? when process implement the INode3D, super(delta) doesn't work :/
 	self.process(delta)
 
-	if nickname_viewport.size != Vector2i(nickname_ui.size):
+	if _use_2d_nameplate:
+		NameplateLayer.update(self)
+	elif nickname_viewport != null and nickname_viewport.size != Vector2i(nickname_ui.size):
 		nickname_viewport.size = Vector2i(nickname_ui.size)
 		_request_nickname_redraw()
 

--- a/godot/src/decentraland_components/avatar/nameplate_layer.gd
+++ b/godot/src/decentraland_components/avatar/nameplate_layer.gd
@@ -1,0 +1,136 @@
+class_name NameplateLayer
+extends RefCounted
+
+## Shared screen-space layer + runtime for all avatar nameplates (#2215). Avatars
+## add their NicknameUI Control here instead of rendering it into a per-avatar
+## SubViewport texture (which showed uninitialized-VRAM garbage on mobile). The
+## Control is projected onto the head anchor each frame, distance-faded, depth-
+## occluded against world geometry by a throttled raycast, and depth-sorted.
+## `layer = -1` draws above the 3D world but below the default-layer HUD.
+
+# On-screen size (matches the prior fixed_size Sprite3D) and distance fade
+# (full < FADE_START, fade to FADE_END), per nickname_quad.gd.
+const SCALE := 0.25
+const FADE_START := 10.0
+const FADE_END := 15.0
+# Alpha units/sec for smooth occlusion fade in/out.
+const FADE_SPEED := 6.0
+# Occlude against solid world geometry (CL_PHYSICS) and avatar bodies (CL_AVATAR /
+# layer 30, the remote click_areas, an Area3D — hence collide_with_areas). The own
+# click_area is excluded per-ray so a tag never self-occludes. NOTE: the local player
+# frees its click_area, so its own body does not occlude others yet (follow-up).
+const CL_PHYSICS := 2
+const CL_AVATAR := 536870912
+const OCCLUSION_MASK := CL_PHYSICS | CL_AVATAR
+# Frames between occlusion raycasts per avatar (staggered) — not every frame.
+const OCCLUSION_PERIOD := 6
+
+static var _root: Control = null
+
+
+## The Control to parent nameplates under (screen-space). Created on first use.
+static func get_root() -> Control:
+	if is_instance_valid(_root):
+		return _root
+	var layer := CanvasLayer.new()
+	layer.name = "NameplateLayer"
+	layer.layer = -1
+	_root = Control.new()
+	_root.name = "Root"
+	_root.set_anchors_preset(Control.PRESET_FULL_RECT)
+	_root.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	layer.add_child(_root)
+	var explorer := Global.get_explorer()
+	if explorer != null:
+		explorer.add_child(layer)
+	else:
+		Global.add_child(layer)
+	return _root
+
+
+## Move the avatar's NicknameUI out of its per-avatar SubViewport into the shared
+## layer and drop the render target. nickname_quad stays as an invisible head
+## anchor (still drives the SDK NAME_TAG attach point + the screen projection).
+static func attach(avatar) -> void:
+	var ui = avatar.nickname_ui
+	if avatar.nickname_viewport != null:
+		avatar.nickname_viewport.remove_child(ui)
+		avatar.nickname_viewport.queue_free()
+		avatar.nickname_viewport = null
+	avatar.nickname_quad.texture = null
+	avatar.nickname_quad.visible = false
+	ui.set_anchors_preset(Control.PRESET_TOP_LEFT)
+	ui.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	ui.hide()
+	get_root().add_child(ui)
+
+
+## Free the reparented NicknameUI (it lives in the shared layer, not under the avatar).
+static func detach(avatar) -> void:
+	if is_instance_valid(avatar.nickname_ui):
+		avatar.nickname_ui.queue_free()
+
+
+## Per-frame: project the head anchor to screen, place/scale/sort the Control, and
+## drive its alpha toward a target (smooth fade in/out). The target is 0 unless the
+## tag is gated-visible, in front of the camera, within FADE_END, inside the viewport
+## (frustum) and not depth-occluded — so anything off-screen/behind/occluded fades
+## out and fades back in when it re-enters, instead of popping.
+static func update(avatar) -> void:
+	var ui = avatar.nickname_ui
+	if ui == null:
+		return
+	var target_a := 0.0
+	var cam = avatar.get_viewport().get_camera_3d()
+	if cam != null and avatar._nametag_gate_visible:
+		var anchor: Vector3 = avatar.nickname_quad.global_transform.origin
+		var dist: float = cam.global_position.distance_to(anchor)
+		if dist <= FADE_END and not cam.is_position_behind(anchor):
+			ui.size = ui.get_combined_minimum_size()
+			ui.scale = Vector2(SCALE, SCALE)
+			var screen_size: Vector2 = ui.size * SCALE
+			var pos: Vector2 = (
+				cam.unproject_position(anchor) - Vector2(screen_size.x * 0.5, screen_size.y)
+			)
+			ui.position = pos
+			# Closer avatars draw on top.
+			ui.z_index = clampi(-int(dist * 100.0), -4000, 4000)
+			var view_rect := Rect2(Vector2.ZERO, avatar.get_viewport().get_visible_rect().size)
+			var on_screen := view_rect.intersects(Rect2(pos, screen_size))
+			if on_screen and not avatar._nameplate_occluded:
+				target_a = clampf((FADE_END - dist) / (FADE_END - FADE_START), 0.0, 1.0)
+	ui.modulate.a = move_toward(
+		ui.modulate.a, target_a, avatar.get_process_delta_time() * FADE_SPEED
+	)
+	ui.visible = ui.modulate.a > 0.01
+
+
+## Throttled occlusion raycast. MUST run from _physics_process — direct_space_state
+## crashes when queried from _process (idle frame).
+static func update_occlusion(avatar) -> void:
+	if not avatar._nametag_gate_visible:
+		return
+	if (Engine.get_physics_frames() + int(avatar.unique_id)) % OCCLUSION_PERIOD != 0:
+		return
+	var cam = avatar.get_viewport().get_camera_3d()
+	if cam == null:
+		return
+	var anchor: Vector3 = avatar.nickname_quad.global_transform.origin
+	if cam.global_position.distance_to(anchor) > FADE_END:
+		return
+	avatar._nameplate_occluded = _occluded(avatar, cam.global_position, anchor)
+
+
+## True if solid world geometry or another avatar's body sits between camera and anchor.
+static func _occluded(avatar, from: Vector3, to: Vector3) -> bool:
+	var space = avatar.get_world_3d().direct_space_state
+	if space == null:
+		return false
+	var query := PhysicsRayQueryParameters3D.create(from, to)
+	query.collision_mask = OCCLUSION_MASK
+	# Avatar bodies (click_area) are Area3D; exclude this avatar's own so it never
+	# occludes its own tag (in first person the ray starts inside it → no hit).
+	query.collide_with_areas = true
+	if is_instance_valid(avatar.click_area):
+		query.exclude = [avatar.click_area.get_rid()]
+	return not space.intersect_ray(query).is_empty()

--- a/godot/src/decentraland_components/avatar/nameplate_layer.gd
+++ b/godot/src/decentraland_components/avatar/nameplate_layer.gd
@@ -15,17 +15,21 @@ const FADE_START := 10.0
 const FADE_END := 15.0
 # Alpha units/sec for smooth occlusion fade in/out.
 const FADE_SPEED := 6.0
-# Occlude against solid world geometry (CL_PHYSICS) and avatar bodies (CL_AVATAR /
-# layer 30, the remote click_areas, an Area3D — hence collide_with_areas). The own
-# click_area is excluded per-ray so a tag never self-occludes. NOTE: the local player
-# frees its click_area, so its own body does not occlude others yet (follow-up).
+# Occlude against solid world geometry (CL_PHYSICS), avatar bodies (CL_AVATAR / layer
+# 30 — remote click_areas) and the body/trigger layer (4 — avatar TriggerDetectors +
+# the local player's CharacterBody, which frees its click_area so this is its only
+# occluder). Own colliders + the camera-mode area (also on layer 4, wraps the camera
+# and would otherwise occlude everything past the player) are excluded per-ray.
 const CL_PHYSICS := 2
+const CL_BODY := 4
 const CL_AVATAR := 536870912
-const OCCLUSION_MASK := CL_PHYSICS | CL_AVATAR
+const OCCLUSION_MASK := CL_PHYSICS | CL_BODY | CL_AVATAR
 # Frames between occlusion raycasts per avatar (staggered) — not every frame.
 const OCCLUSION_PERIOD := 6
 
 static var _root: Control = null
+# Cached camera-mode area (player child) — excluded from every occlusion ray.
+static var _camera_area: Node = null
 
 
 ## The Control to parent nameplates under (screen-space). Created on first use.
@@ -128,9 +132,32 @@ static func _occluded(avatar, from: Vector3, to: Vector3) -> bool:
 		return false
 	var query := PhysicsRayQueryParameters3D.create(from, to)
 	query.collision_mask = OCCLUSION_MASK
-	# Avatar bodies (click_area) are Area3D; exclude this avatar's own so it never
-	# occludes its own tag (in first person the ray starts inside it → no hit).
+	# click_area is an Area3D, so areas too; bodies (TriggerDetector / player) are on by default.
 	query.collide_with_areas = true
+	# Exclude this avatar's own colliders (so it never occludes its own tag) and the
+	# camera-mode area that wraps the camera.
+	var excludes: Array = []
 	if is_instance_valid(avatar.click_area):
-		query.exclude = [avatar.click_area.get_rid()]
+		excludes.append(avatar.click_area.get_rid())
+	if is_instance_valid(avatar.trigger_detector):
+		excludes.append(avatar.trigger_detector.get_rid())
+	if avatar.is_local_player:
+		var body = avatar.get_parent()
+		if body is CollisionObject3D:
+			excludes.append(body.get_rid())
+	var cam_area := _get_camera_area()
+	if cam_area != null:
+		excludes.append(cam_area.get_rid())
+	query.exclude = excludes
 	return not space.intersect_ray(query).is_empty()
+
+
+## The player's camera-mode area detector (cached). It sits on the occlusion layer
+## and wraps the camera, so it must be excluded or it occludes everything beyond the
+## player.
+static func _get_camera_area() -> CollisionObject3D:
+	if not is_instance_valid(_camera_area):
+		var explorer := Global.get_explorer()
+		if explorer != null and is_instance_valid(explorer.player):
+			_camera_area = explorer.player.get_node_or_null("camera_mode_area_detector")
+	return _camera_area as CollisionObject3D

--- a/godot/src/decentraland_components/avatar/nameplate_layer.gd.uid
+++ b/godot/src/decentraland_components/avatar/nameplate_layer.gd.uid
@@ -1,0 +1,1 @@
+uid://cpxemftrw7sh0


### PR DESCRIPTION
## Problem (#2215)

Avatar nametags showed **uninitialized-VRAM garbage** on mobile (noise / partial text / color artifacts). Each avatar rendered its `NicknameUI` into a **per-avatar `NicknameViewport` (SubViewport)**, sampled live by a `Sprite3D` `ViewportTexture` and bumped with `UPDATE_ONCE`. On mobile tile GPUs that single-shot render can be dropped/not-cleared, freezing the texture on uninitialized memory. This is the **2nd** bug from this architecture (see #2039, the "garbled pixels" / freeze fix).

Repro note: the bug is driver-specific — the A54 (Mali) clears its render targets, so it does **not** reproduce there; it manifests on the reporter's device (Motorola Edge Fusion). The fix is therefore **structural**, not a tweak to the viewport heuristics.

## Fix: render nameplates in a shared 2D screen-space layer

Stop using viewport textures entirely. Each avatar's `NicknameUI` (already a pure `Control` tree) is **reparented out of its SubViewport into a shared `CanvasLayer`** (`NameplateLayer`, `layer = -1` → above the 3D world, below the HUD) and **projected onto the head anchor every frame**. The per-avatar `SubViewport` + `ViewportTexture` are dropped; the `Sprite3D` is kept (invisible) only as the head anchor for the SDK `NAME_TAG` attach point.

This **eliminates the whole bug class** — no render targets → no uninitialized VRAM — and as a side effect also removes the chat-bubble freeze and the resize race that #2039 was patching around.

### Behaviour
- **Distance fade**: full < 10 m → faded out and hidden by 15 m; depth-sorted by distance (closer draws on top).
- **Smooth fade in/out**: off-frustum, behind-camera, far and occluded all drive the alpha toward 0 (and back), so tags fade instead of popping when they enter/leave the screen.
- **Depth occlusion**: a throttled raycast (every 6 physics frames, staggered per avatar, in `_physics_process`) hides tags behind solid world geometry (`CL_PHYSICS`) and remote avatar bodies (`CL_AVATAR`), excluding the avatar's own collider.
- **XR** keeps the legacy viewport path (screen-space 2D doesn't apply in VR).

## Files
- `godot/src/decentraland_components/avatar/nameplate_layer.gd` (new): owns the shared layer + per-frame projection/fade/occlusion runtime.
- `godot/src/decentraland_components/avatar/avatar.gd`: branch to the 2D path (non-XR), reparent on `_ready`, drive it from `_process` / `_physics_process`, free it on `_exit_tree`; `_request_nickname_redraw` becomes XR-only.

## Verification
- Runs clean on desktop (Forward Mobile / Vulkan) with `--spawn-avatars`: nameplates project, scale, fade, sort and occlude against geometry + remote bodies; chat bubbles animate natively.
- gdformat / gdlint / Godot script validation / cargo check / clippy / rust+integration tests all pass (pre-commit).
- On-device validation of the original VRAM artifact must happen on an affected device (not the A54).

## Known follow-up
- The **local player's own body** does not occlude others' tags yet: the local player frees its `click_area`, so its only collider is the `CharacterBody` on a broad layer (4) that, when added to the occlusion mask, over-occludes (catches every avatar's TriggerDetector + the camera-mode area). A targeted fix (re-layering the kept click_area, mindful of the ground raycast) is left as a follow-up.