### PR TITLE
fix(android): restore gradient background on pre-splash icon

### DIFF
--- a/godot/export_presets.cfg
+++ b/godot/export_presets.cfg
@@ -33,7 +33,9 @@ gradle_build/compress_native_libraries=false
 gradle_build/export_format=0
 gradle_build/min_sdk=""
 gradle_build/target_sdk="35"
-gradle_build/custom_theme_attributes={}
+gradle_build/custom_theme_attributes={
+"[splash]windowSplashScreenAnimatedIcon": "@mipmap/icon"
+}
 architectures/armeabi-v7a=false
 architectures/arm64-v8a=true
 architectures/x86=false


### PR DESCRIPTION
## What
  Points the Android 12+ system pre-splash icon at the full composited adaptive icon (`@mipmap/icon`) instead of the foreground-only layer, so the orange→pink gradient renders behind the logo again.

**Before**

<img height="500" alt="Image" src="https://github.com/user-attachments/assets/0a93b9f2-3b8c-4955-9a01-50bc34cc44a0" />


**After**

<img height="500" alt="imagen" src="https://github.com/user-attachments/assets/a0b34bbf-c837-4f32-b248-4c9b51bf1c9d" />


  ## Why
  Godot's Android export sets `windowSplashScreenAnimatedIcon = @mipmap/icon_foreground` (the transparent foreground layer only) and tries to supply the gradient via `windowSplashScreenBackground =
  @mipmap/icon_background`. The Android 12 SplashScreen API only reliably honors a *solid color* for the window background, so OEMs like Samsung One UI (Galaxy S25) ignore the bitmap and fall back to their dark
  default — leaving just the logo with no gradient. iOS is unaffected since it uses the fully composited icon.

  ## Fix
  Override the splash animated icon via the export preset's `custom_theme_attributes`, using the full adaptive icon which composes background + foreground:

  gradle_build/custom_theme_attributes={
  "[splash]windowSplashScreenAnimatedIcon": "@mipmap/icon"
  }

  No brand assets changed, no engine change.

  ## Testing
  Built and deployed to an Android device; the pre-splash now shows the gradient + logo. Confirmed via a differential test (temporary `windowSplashScreenIconBackgroundColor` showed the OS does render the
  adaptive background layer).

  Closes #1843