### PR TITLE
feat: bake textures at multiple resolutions for runtime quality selection

### DIFF
--- a/godot/src/connection_quality_monitor.gd
+++ b/godot/src/connection_quality_monitor.gd
@@ -86,6 +86,13 @@ func _ready() -> void:
 
 
 func _connect_signals() -> void:
+	# Headless/server runs (e.g. script validation) boot autoloads but never
+	# initialize the UI, so modal_manager stays null forever and the retry below
+	# would re-defer itself every frame until the message queue OOMs. Nothing to
+	# monitor without a UI, so bail out.
+	if OS.has_feature("Server") or DisplayServer.get_name() == "headless":
+		return
+
 	if Global.modal_manager == null:
 		# modal_manager not ready yet; retry next frame
 		_connect_signals.call_deferred()

--- a/godot/src/logic/scene_fetcher.gd
+++ b/godot/src/logic/scene_fetcher.gd
@@ -948,9 +948,6 @@ func async_load_scene(
 			return PromiseUtils.resolved(false)
 
 	var scene_hash_zip: String = "%s-mobile.zip" % scene_entity_id
-	var asset_url: String = (
-		"%s/%s-mobile.zip" % [Global.content_provider.get_optimized_base_url(), scene_entity_id]
-	)
 
 	# Skip optimized zip download when:
 	# - XR mode (handled separately)
@@ -969,15 +966,17 @@ func async_load_scene(
 		if FileAccess.file_exists(zip_file_path):
 			download_success = true
 		else:
-			# First check if the file exists remotely (HEAD request)
-			# This avoids treating 404s as errors - scenes without optimized versions are expected
-			var exists_promise = Global.content_provider.check_remote_file_exists(asset_url)
-			var exists_res = await PromiseUtils.async_awaiter(exists_promise)
+			# Try each versioned bucket (newest first) until one has the zip
+			for base_url in Global.content_provider.get_optimized_base_urls():
+				var asset_url: String = "%s/%s" % [base_url, scene_hash_zip]
+				# First check if the file exists remotely (HEAD request)
+				# This avoids treating 404s as errors - scenes without optimized versions are expected
+				var exists_promise = Global.content_provider.check_remote_file_exists(asset_url)
+				var exists_res = await PromiseUtils.async_awaiter(exists_promise)
 
-			if exists_res is PromiseError or exists_res == false:
-				# File doesn't exist remotely or check failed - this is expected for non-optimized scenes
-				file_not_found_remotely = true
-			else:
+				if exists_res is PromiseError or exists_res == false:
+					continue
+
 				# File exists remotely, proceed with download
 				var download_promise: Promise = Global.content_provider.fetch_file_by_url(
 					scene_hash_zip, asset_url
@@ -987,6 +986,10 @@ func async_load_scene(
 					download_error = download_res
 				else:
 					download_success = true
+				break
+
+			# Not found in any bucket - expected for non-optimized scenes
+			file_not_found_remotely = not download_success and download_error == null
 
 	if skip_optimized:
 		pass  # Scene optimization skipped (XR, testing, or --only-no-optimized)
@@ -1000,9 +1003,7 @@ func async_load_scene(
 			loaded_scenes.erase(scene_entity_id)
 			return PromiseUtils.resolved(false)
 	elif download_error != null or not download_success:
-		printerr(
-			"Scene ", scene_entity_id, " failed to download optimized zip asset_url=", asset_url
-		)
+		printerr("Scene ", scene_entity_id, " failed to download optimized zip ", scene_hash_zip)
 
 		send_scene_failed_metrics(scene_entity_id, "zip_download_failed")
 

--- a/lib/src/asset_server/handlers.rs
+++ b/lib/src/asset_server/handlers.rs
@@ -545,8 +545,8 @@ async fn watch_and_pack_scene_batch(
     let _permit = ctx.godot_single_thread.acquire().await;
 
     // Create individual ZIPs for each completed asset
-    for (hash, path, asset_type) in &results {
-        match pack_single_asset_to_zip(hash, path, *asset_type, &ctx.output_folder) {
+    for (hash, paths, asset_type) in &results {
+        match pack_single_asset_to_zip(hash, paths, *asset_type, &ctx.output_folder) {
             Ok(zip_path) => {
                 job_manager
                     .add_individual_zip(&batch_id, hash.clone(), zip_path)

--- a/lib/src/asset_server/job_manager.rs
+++ b/lib/src/asset_server/job_manager.rs
@@ -8,6 +8,7 @@ use uuid::Uuid;
 
 use super::types::{
     AssetType, Batch, BatchStatus, Job, JobStatus, SceneOptimizationMetadata, TextureSize,
+    TextureVariant,
 };
 
 /// Maximum number of concurrent processing jobs.
@@ -129,6 +130,15 @@ impl JobManager {
         }
     }
 
+    /// Set the baked quality variants for a texture job.
+    pub async fn set_texture_variants(&self, job_id: &str, variants: Vec<TextureVariant>) {
+        let mut jobs = self.jobs.write().await;
+        if let Some(job) = jobs.get_mut(job_id) {
+            job.texture_variants = Some(variants);
+            job.updated_at = Instant::now();
+        }
+    }
+
     /// Acquire a permit to process a job.
     /// This limits the number of concurrent jobs.
     pub async fn acquire_permit(&self) -> tokio::sync::OwnedSemaphorePermit {
@@ -208,11 +218,12 @@ impl JobManager {
     }
 
     /// Get all completed job results for a batch.
-    /// Returns (hash, optimized_path, asset_type) for each completed job.
+    /// Returns (hash, file_paths, asset_type) for each completed job.
+    /// GLTF jobs have a single path; texture jobs have one path per baked variant.
     pub async fn get_batch_results(
         &self,
         batch_id: &str,
-    ) -> Vec<(String, String, super::types::AssetType)> {
+    ) -> Vec<(String, Vec<String>, super::types::AssetType)> {
         let batches = self.batches.read().await;
         let batch = match batches.get(batch_id) {
             Some(b) => b,
@@ -232,7 +243,11 @@ impl JobManager {
             if let Some(job) = jobs.get(job_id) {
                 if job.status == JobStatus::Completed {
                     if let Some(ref path) = job.optimized_path {
-                        results.push((job.hash.clone(), path.clone(), job.asset_type));
+                        let paths = match job.texture_variants {
+                            Some(ref variants) => variants.iter().map(|v| v.path.clone()).collect(),
+                            None => vec![path.clone()],
+                        };
+                        results.push((job.hash.clone(), paths, job.asset_type));
                     } else {
                         completed_no_path += 1;
                         if completed_no_path <= 3 {
@@ -300,6 +315,7 @@ impl JobManager {
                     external_scene_dependencies: HashMap::new(),
                     original_sizes: HashMap::new(),
                     hash_size_map: HashMap::new(),
+                    texture_qualities: HashMap::new(),
                 }
             }
         };
@@ -309,6 +325,7 @@ impl JobManager {
         let mut external_scene_dependencies = HashMap::new();
         let mut original_sizes = HashMap::new();
         let mut hash_size_map = HashMap::new();
+        let mut texture_qualities = HashMap::new();
 
         for job_id in &batch.job_ids {
             if let Some(job) = jobs.get(job_id) {
@@ -323,8 +340,15 @@ impl JobManager {
                     original_sizes.insert(job.hash.clone(), size.clone());
                 }
 
-                // Add optimized file size
-                if let Some(size) = job.optimized_file_size {
+                // Add optimized file size; textures report the sum of all
+                // baked variant sizes (the per-hash ZIP contains every variant)
+                if let Some(ref variants) = job.texture_variants {
+                    let mut qualities: Vec<i32> = variants.iter().map(|v| v.quality).collect();
+                    qualities.sort_unstable();
+                    texture_qualities.insert(job.hash.clone(), qualities);
+                    hash_size_map
+                        .insert(job.hash.clone(), variants.iter().map(|v| v.file_size).sum());
+                } else if let Some(size) = job.optimized_file_size {
                     hash_size_map.insert(job.hash.clone(), size);
                 }
 
@@ -340,6 +364,7 @@ impl JobManager {
             external_scene_dependencies,
             original_sizes,
             hash_size_map,
+            texture_qualities,
         }
     }
 

--- a/lib/src/asset_server/packer.rs
+++ b/lib/src/asset_server/packer.rs
@@ -12,18 +12,83 @@ use godot::prelude::*;
 
 use super::types::{AssetType, SceneOptimizationMetadata};
 
+/// Compute the path of a file inside the ZIP.
+/// No res:// prefix - Godot adds it when loading the resource pack.
+/// GLTFs go to glbs/, textures go to content/ keeping their on-disk file name
+/// (`{hash}_q{N}.res` for quality variants).
+fn zip_internal_path(hash: &str, path: &str, asset_type: AssetType) -> String {
+    match asset_type {
+        AssetType::Texture => {
+            let basename = path.rsplit('/').next().unwrap_or(path);
+            format!("content/{}", basename)
+        }
+        _ => format!("glbs/{}.scn", hash), // Scene, Wearable, Emote
+    }
+}
+
+/// Add a single file to an open ZIP, logging and skipping on failure.
+fn add_file_to_zip(packer: &mut Gd<ZipPacker>, hash: &str, path: &str, asset_type: AssetType) {
+    // Read the file contents
+    let file_access = FileAccess::open(&GString::from(path), ModeFlags::READ);
+    let Some(mut file) = file_access else {
+        tracing::warn!("Failed to open file for packing: {}", path);
+        return;
+    };
+
+    let data = file.get_buffer(file.get_length() as i64);
+    file.close();
+
+    let zip_internal_path = zip_internal_path(hash, path, asset_type);
+
+    tracing::debug!("Adding to ZIP: {} -> {}", path, zip_internal_path);
+
+    // Start file entry in ZIP
+    let err = packer.start_file(&GString::from(&zip_internal_path));
+    if err != godot::global::Error::OK {
+        tracing::warn!(
+            "Failed to start file entry in ZIP for {}: {:?}",
+            zip_internal_path,
+            err
+        );
+        return;
+    }
+
+    // Write file data
+    let err = packer.write_file(&data);
+    if err != godot::global::Error::OK {
+        tracing::warn!(
+            "Failed to write file data to ZIP for {}: {:?}",
+            zip_internal_path,
+            err
+        );
+        // Try to close the file entry anyway
+        let _ = packer.close_file();
+        return;
+    }
+
+    // Close file entry
+    let err = packer.close_file();
+    if err != godot::global::Error::OK {
+        tracing::warn!(
+            "Failed to close file entry in ZIP for {}: {:?}",
+            zip_internal_path,
+            err
+        );
+    }
+}
+
 /// Pack processed assets into a ZIP file.
 ///
 /// Creates a ZIP file at `{output_folder}{output_hash}-mobile.zip` containing
 /// all processed assets. The paths inside the ZIP are structured as:
 /// - `glbs/{hash}.scn` for GLTF assets (scene/wearable/emote)
-/// - `content/{hash}.res` for texture files
+/// - `content/{hash}_q{N}.res` for texture quality variants
 ///
 /// After `load_resource_pack()`, files become accessible at `res://glbs/...` and `res://content/...`
 ///
 /// # Arguments
 /// * `output_hash` - The hash to use for the ZIP filename
-/// * `asset_paths` - List of (hash, optimized_path, asset_type) for each completed job
+/// * `asset_paths` - List of (hash, file_paths, asset_type) for each completed job
 /// * `output_folder` - The output folder path for ZIP files (e.g., `./output/`)
 ///
 /// # Returns
@@ -31,7 +96,7 @@ use super::types::{AssetType, SceneOptimizationMetadata};
 /// * `Err(anyhow::Error)` - If packing fails
 pub fn pack_assets_to_zip(
     output_hash: &str,
-    asset_paths: Vec<(String, String, AssetType)>,
+    asset_paths: Vec<(String, Vec<String>, AssetType)>,
     output_folder: &str,
 ) -> Result<String, anyhow::Error> {
     let zip_path = format!("{}{}-mobile.zip", output_folder, output_hash);
@@ -52,59 +117,9 @@ pub fn pack_assets_to_zip(
         ));
     }
 
-    for (hash, path, asset_type) in asset_paths {
-        // Read the file contents
-        let file_access = FileAccess::open(&GString::from(&path), ModeFlags::READ);
-        let Some(mut file) = file_access else {
-            tracing::warn!("Failed to open file for packing: {}", path);
-            continue;
-        };
-
-        let data = file.get_buffer(file.get_length() as i64);
-        file.close();
-
-        // Determine the path inside the ZIP
-        // No res:// prefix - Godot adds it when loading the resource pack
-        // GLTFs go to glbs/, textures go to content/
-        let zip_internal_path = match asset_type {
-            AssetType::Texture => format!("content/{}.res", hash),
-            _ => format!("glbs/{}.scn", hash), // Scene, Wearable, Emote
-        };
-
-        tracing::debug!("Adding to ZIP: {} -> {}", path, zip_internal_path);
-
-        // Start file entry in ZIP
-        let err = packer.start_file(&GString::from(&zip_internal_path));
-        if err != godot::global::Error::OK {
-            tracing::warn!(
-                "Failed to start file entry in ZIP for {}: {:?}",
-                zip_internal_path,
-                err
-            );
-            continue;
-        }
-
-        // Write file data
-        let err = packer.write_file(&data);
-        if err != godot::global::Error::OK {
-            tracing::warn!(
-                "Failed to write file data to ZIP for {}: {:?}",
-                zip_internal_path,
-                err
-            );
-            // Try to close the file entry anyway
-            let _ = packer.close_file();
-            continue;
-        }
-
-        // Close file entry
-        let err = packer.close_file();
-        if err != godot::global::Error::OK {
-            tracing::warn!(
-                "Failed to close file entry in ZIP for {}: {:?}",
-                zip_internal_path,
-                err
-            );
+    for (hash, paths, asset_type) in asset_paths {
+        for path in &paths {
+            add_file_to_zip(&mut packer, &hash, path, asset_type);
         }
     }
 
@@ -119,10 +134,11 @@ pub fn pack_assets_to_zip(
 
 /// Pack a single asset into its own ZIP file.
 ///
-/// Creates `{output_folder}{hash}-mobile.zip` containing a single `.scn` or `.res` file.
+/// Creates `{output_folder}{hash}-mobile.zip` containing the asset's files:
+/// a single `.scn` for GLTFs, or one `.res` per quality variant for textures.
 pub fn pack_single_asset_to_zip(
     hash: &str,
-    optimized_path: &str,
+    file_paths: &[String],
     asset_type: AssetType,
     output_folder: &str,
 ) -> Result<String, anyhow::Error> {
@@ -143,43 +159,39 @@ pub fn pack_single_asset_to_zip(
         ));
     }
 
-    let file_access = FileAccess::open(&GString::from(optimized_path), ModeFlags::READ);
-    let Some(mut file) = file_access else {
-        packer.close();
-        return Err(anyhow::anyhow!(
-            "Failed to open file for packing: {}",
-            optimized_path
-        ));
-    };
+    for path in file_paths {
+        let file_access = FileAccess::open(&GString::from(path), ModeFlags::READ);
+        let Some(mut file) = file_access else {
+            packer.close();
+            return Err(anyhow::anyhow!("Failed to open file for packing: {}", path));
+        };
 
-    let data = file.get_buffer(file.get_length() as i64);
-    file.close();
+        let data = file.get_buffer(file.get_length() as i64);
+        file.close();
 
-    let zip_internal_path = match asset_type {
-        AssetType::Texture => format!("content/{}.res", hash),
-        _ => format!("glbs/{}.scn", hash),
-    };
+        let internal_path = zip_internal_path(hash, path, asset_type);
 
-    let err = packer.start_file(&GString::from(&zip_internal_path));
-    if err != godot::global::Error::OK {
-        packer.close();
-        return Err(anyhow::anyhow!(
-            "Failed to start file entry in ZIP: {:?}",
-            err
-        ));
-    }
+        let err = packer.start_file(&GString::from(&internal_path));
+        if err != godot::global::Error::OK {
+            packer.close();
+            return Err(anyhow::anyhow!(
+                "Failed to start file entry in ZIP: {:?}",
+                err
+            ));
+        }
 
-    let err = packer.write_file(&data);
-    if err != godot::global::Error::OK {
+        let err = packer.write_file(&data);
+        if err != godot::global::Error::OK {
+            let _ = packer.close_file();
+            packer.close();
+            return Err(anyhow::anyhow!(
+                "Failed to write file data to ZIP: {:?}",
+                err
+            ));
+        }
+
         let _ = packer.close_file();
-        packer.close();
-        return Err(anyhow::anyhow!(
-            "Failed to write file data to ZIP: {:?}",
-            err
-        ));
     }
-
-    let _ = packer.close_file();
 
     let err = packer.close();
     if err != godot::global::Error::OK {
@@ -197,13 +209,13 @@ pub fn pack_single_asset_to_zip(
 ///
 /// # Arguments
 /// * `output_hash` - The hash to use for the ZIP filename
-/// * `asset_paths` - List of (hash, optimized_path, asset_type) for each completed job
+/// * `asset_paths` - List of (hash, file_paths, asset_type) for each completed job
 /// * `preloaded_hashes` - Optional set of hashes to include alongside metadata
 /// * `metadata` - Scene optimization metadata to include in the ZIP
 /// * `output_folder` - The output folder path for ZIP files (e.g., `./output/`)
 pub fn pack_scene_assets_to_zip(
     output_hash: &str,
-    asset_paths: Vec<(String, String, AssetType)>,
+    asset_paths: Vec<(String, Vec<String>, AssetType)>,
     preloaded_hashes: Option<&HashSet<String>>,
     metadata: SceneOptimizationMetadata,
     output_folder: &str,
@@ -271,57 +283,9 @@ pub fn pack_scene_assets_to_zip(
     }
 
     // Add asset files
-    for (hash, path, asset_type) in assets_to_pack {
-        // Read the file contents
-        let file_access = FileAccess::open(&GString::from(&path), ModeFlags::READ);
-        let Some(mut file) = file_access else {
-            tracing::warn!("Failed to open file for packing: {}", path);
-            continue;
-        };
-
-        let data = file.get_buffer(file.get_length() as i64);
-        file.close();
-
-        // Determine the path inside the ZIP
-        // GLTFs go to glbs/, textures go to content/
-        let zip_internal_path = match asset_type {
-            AssetType::Texture => format!("content/{}.res", hash),
-            _ => format!("glbs/{}.scn", hash),
-        };
-
-        tracing::debug!("Adding to ZIP: {} -> {}", path, zip_internal_path);
-
-        // Start file entry in ZIP
-        let err = packer.start_file(&GString::from(&zip_internal_path));
-        if err != godot::global::Error::OK {
-            tracing::warn!(
-                "Failed to start file entry in ZIP for {}: {:?}",
-                zip_internal_path,
-                err
-            );
-            continue;
-        }
-
-        // Write file data
-        let err = packer.write_file(&data);
-        if err != godot::global::Error::OK {
-            tracing::warn!(
-                "Failed to write file data to ZIP for {}: {:?}",
-                zip_internal_path,
-                err
-            );
-            let _ = packer.close_file();
-            continue;
-        }
-
-        // Close file entry
-        let err = packer.close_file();
-        if err != godot::global::Error::OK {
-            tracing::warn!(
-                "Failed to close file entry in ZIP for {}: {:?}",
-                zip_internal_path,
-                err
-            );
+    for (hash, paths, asset_type) in assets_to_pack {
+        for path in &paths {
+            add_file_to_zip(&mut packer, &hash, path, asset_type);
         }
     }
 

--- a/lib/src/asset_server/processor.rs
+++ b/lib/src/asset_server/processor.rs
@@ -18,12 +18,13 @@ use crate::content::gltf::{
 };
 use crate::content::packed_array::PackedByteArrayFromVec;
 use crate::content::resource_provider::ResourceProvider;
+use crate::content::texture::MAX_TEXTURE_DIMENSION;
 use crate::content::thread_safety::GodotSingleThreadSafety;
 use crate::godot_classes::dcl_config::TextureQuality;
 use crate::utils::infer_mime;
 
 use super::job_manager::JobManager;
-use super::types::{AssetRequest, AssetType, JobStatus};
+use super::types::{AssetRequest, AssetType, JobStatus, TextureVariant};
 
 /// Context for asset processing, similar to ContentProviderContext but standalone.
 #[derive(Clone)]
@@ -89,6 +90,8 @@ pub struct ProcessResult {
     pub optimized_file_size: Option<u64>,
     /// GLTF dependencies - texture hashes (for GLTFs only)
     pub gltf_dependencies: Option<Vec<String>>,
+    /// Baked quality variants (for textures only)
+    pub texture_variants: Option<Vec<TextureVariant>>,
 }
 
 /// Process an asset request.
@@ -139,6 +142,9 @@ pub async fn process_asset(
             }
             if let Some(deps) = process_result.gltf_dependencies {
                 job_manager.set_gltf_dependencies(&job_id, deps).await;
+            }
+            if let Some(variants) = process_result.texture_variants {
+                job_manager.set_texture_variants(&job_id, variants).await;
             }
 
             job_manager
@@ -250,6 +256,7 @@ async fn process_scene_gltf(
         original_size: None,
         optimized_file_size,
         gltf_dependencies: Some(gltf_dependencies),
+        texture_variants: None,
     })
 }
 
@@ -305,6 +312,7 @@ async fn process_wearable_gltf(
         original_size: None,
         optimized_file_size,
         gltf_dependencies: Some(gltf_dependencies),
+        texture_variants: None,
     })
 }
 
@@ -360,6 +368,7 @@ async fn process_emote_gltf(
         original_size: None,
         optimized_file_size,
         gltf_dependencies: Some(gltf_dependencies),
+        texture_variants: None,
     })
 }
 
@@ -374,8 +383,6 @@ async fn process_texture(
     tracing::debug!("Processing texture: {}", request.hash);
 
     let raw_file_path = format!("{}{}", ctx.content_folder, request.hash);
-    // Use .res extension for compressed ImageTexture (Godot binary resource format)
-    let res_file_path = format!("{}{}.res", ctx.content_folder, request.hash);
 
     // Download the raw image file (or read from cache if cache_only)
     let bytes_vec = if request.cache_only {
@@ -476,10 +483,86 @@ async fn process_texture(
         image_format
     );
 
-    // Resize if needed based on texture quality
-    let max_size = ctx.texture_quality.to_max_size();
-    resize_image_if_needed(&mut image, max_size);
+    // Bake one variant per quality tier. Each variant is resized from a fresh
+    // duplicate of the pristine decoded image to avoid lossy resize cascades.
+    //
+    // Tiers whose max size covers the original resolution all produce identical
+    // pixels, so when the original fits within High (1024) the top variant is
+    // baked once and named at the Source ordinal: a High request then selects
+    // the q3 file via the "smallest variant >= requested" rule and gets exactly
+    // the pixels a dedicated High bake would have produced.
+    let original_max = original_width.max(original_height) as i32;
+    let mut texture_variants: Vec<TextureVariant> = Vec::new();
 
+    for quality in [
+        TextureQuality::Low,
+        TextureQuality::Medium,
+        TextureQuality::High,
+        TextureQuality::Source,
+    ] {
+        if quality == TextureQuality::High && original_max <= TextureQuality::High.to_max_size() {
+            continue; // identical to the Source variant, which is always baked
+        }
+        let max_size = quality.to_max_size().min(MAX_TEXTURE_DIMENSION);
+
+        let mut variant_image = image
+            .duplicate()
+            .ok_or_else(|| anyhow::anyhow!("Failed to duplicate image for variant"))?
+            .cast::<Image>();
+        resize_image_if_needed(&mut variant_image, max_size);
+
+        let variant_path = format!(
+            "{}{}_q{}.res",
+            ctx.content_folder,
+            request.hash,
+            quality.to_i32()
+        );
+        let file_size = compress_and_save_variant(variant_image, &variant_path)?;
+
+        tracing::debug!(
+            "Texture variant saved: {} q{} -> {} ({} bytes)",
+            request.hash,
+            quality.to_i32(),
+            variant_path,
+            file_size
+        );
+
+        texture_variants.push(TextureVariant {
+            quality: quality.to_i32(),
+            path: variant_path,
+            file_size,
+        });
+    }
+
+    let top_variant = texture_variants
+        .last()
+        .ok_or_else(|| anyhow::anyhow!("No texture variants baked"))?;
+    let optimized_path = top_variant.path.clone();
+    let optimized_file_size = Some(top_variant.file_size);
+
+    tracing::debug!(
+        "Texture {} baked ({}x{}, {} variants)",
+        request.hash,
+        original_width,
+        original_height,
+        texture_variants.len()
+    );
+
+    Ok(ProcessResult {
+        optimized_path,
+        original_size: Some((original_width, original_height)),
+        optimized_file_size,
+        gltf_dependencies: None,
+        texture_variants: Some(texture_variants),
+    })
+}
+
+/// Pad to ETC2 block size, compress, and save an image as a `.res` ImageTexture.
+/// Returns the saved file size in bytes.
+fn compress_and_save_variant(
+    mut image: Gd<Image>,
+    res_file_path: &str,
+) -> Result<u64, anyhow::Error> {
     // Compress the image using ETC2 (mobile-optimized format)
     // Pad dimensions to multiples of 4 (ETC2 operates on 4x4 blocks)
     if !image.is_compressed() {
@@ -507,7 +590,6 @@ async fn process_texture(
         }
     }
 
-    // Create ImageTexture from the compressed image
     let texture = ImageTexture::create_from_image(&image).ok_or_else(|| {
         anyhow::anyhow!(
             "Failed to create ImageTexture from compressed image ({}x{})",
@@ -516,16 +598,7 @@ async fn process_texture(
         )
     })?;
 
-    let texture_width = texture.get_width();
-    let texture_height = texture.get_height();
-    tracing::debug!(
-        "Created compressed texture: {}x{}",
-        texture_width,
-        texture_height
-    );
-
-    // Verify compression succeeded
-    if texture_width == 0 || texture_height == 0 {
+    if texture.get_width() == 0 || texture.get_height() == 0 {
         return Err(anyhow::anyhow!(
             "Texture compression failed - resulting texture has no dimensions"
         ));
@@ -535,7 +608,7 @@ async fn process_texture(
     // We use .res instead of .ctex because ImageTexture doesn't support .ctex
     let err = ResourceSaver::singleton()
         .save_ex(&texture.upcast::<Resource>())
-        .path(&res_file_path)
+        .path(res_file_path)
         .flags(SaverFlags::COMPRESS)
         .done();
 
@@ -547,24 +620,9 @@ async fn process_texture(
         ));
     }
 
-    // Get optimized file size
-    let optimized_file_size = std::fs::metadata(&res_file_path).ok().map(|m| m.len());
-
-    tracing::debug!(
-        "Texture saved: {} -> {} ({}x{}, {:?} bytes)",
-        request.hash,
-        res_file_path,
-        original_width,
-        original_height,
-        optimized_file_size
-    );
-
-    Ok(ProcessResult {
-        optimized_path: res_file_path,
-        original_size: Some((original_width, original_height)),
-        optimized_file_size,
-        gltf_dependencies: None,
-    })
+    std::fs::metadata(res_file_path)
+        .map(|m| m.len())
+        .map_err(|e| anyhow::anyhow!("Failed to stat saved texture '{}': {}", res_file_path, e))
 }
 
 /// Resize image if it exceeds max size while maintaining aspect ratio.

--- a/lib/src/asset_server/types.rs
+++ b/lib/src/asset_server/types.rs
@@ -161,6 +161,17 @@ pub struct TextureSize {
     pub height: u32,
 }
 
+/// A baked texture variant at a specific quality tier.
+#[derive(Debug, Clone)]
+pub struct TextureVariant {
+    /// TextureQuality ordinal (0=Low, 1=Medium, 2=High, 3=Source)
+    pub quality: i32,
+    /// Path to the baked `.res` file
+    pub path: String,
+    /// File size in bytes
+    pub file_size: u64,
+}
+
 /// A processing job.
 #[derive(Debug, Clone)]
 pub struct Job {
@@ -188,6 +199,8 @@ pub struct Job {
     pub optimized_file_size: Option<u64>,
     /// GLTF texture dependencies (for GLTF jobs)
     pub gltf_dependencies: Option<Vec<String>>,
+    /// Baked quality variants (for texture jobs)
+    pub texture_variants: Option<Vec<TextureVariant>>,
 }
 
 impl Job {
@@ -206,6 +219,7 @@ impl Job {
             original_size: None,
             optimized_file_size: None,
             gltf_dependencies: None,
+            texture_variants: None,
         }
     }
 }
@@ -360,5 +374,50 @@ pub struct SceneOptimizationMetadata {
     /// Map of texture hash -> original dimensions
     pub original_sizes: HashMap<String, TextureSize>,
     /// Map of hash -> optimized file size in bytes
+    /// (for textures: sum of all baked variant sizes)
     pub hash_size_map: HashMap<String, u64>,
+    /// Map of texture hash -> baked quality ordinals (ascending).
+    /// Ordinals follow TextureQuality: 0=Low, 1=Medium, 2=High, 3=Source.
+    #[serde(default)]
+    pub texture_qualities: HashMap<String, Vec<i32>>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_scene_optimization_metadata_serializes_camel_case() {
+        let metadata = SceneOptimizationMetadata {
+            optimized_content: vec!["hashA".to_string()],
+            external_scene_dependencies: HashMap::new(),
+            original_sizes: HashMap::new(),
+            hash_size_map: HashMap::from([("hashA".to_string(), 1500)]),
+            texture_qualities: HashMap::from([("hashA".to_string(), vec![0, 1, 3])]),
+        };
+
+        let json = serde_json::to_value(&metadata).expect("serializes");
+        assert_eq!(
+            json["textureQualities"]["hashA"],
+            serde_json::json!([0, 1, 3])
+        );
+        assert_eq!(json["hashSizeMap"]["hashA"], 1500);
+
+        let roundtrip: SceneOptimizationMetadata =
+            serde_json::from_value(json).expect("deserializes");
+        assert_eq!(roundtrip.texture_qualities["hashA"], vec![0, 1, 3]);
+    }
+
+    #[test]
+    fn test_scene_optimization_metadata_texture_qualities_optional_on_read() {
+        let json = r#"{
+            "optimizedContent": [],
+            "externalSceneDependencies": {},
+            "originalSizes": {},
+            "hashSizeMap": {}
+        }"#;
+        let metadata: SceneOptimizationMetadata =
+            serde_json::from_str(json).expect("legacy metadata");
+        assert!(metadata.texture_qualities.is_empty());
+    }
 }

--- a/lib/src/content/content_provider.rs
+++ b/lib/src/content/content_provider.rs
@@ -1372,11 +1372,34 @@ impl ContentProvider {
             return promise;
         }
 
+        // Resolve which pre-baked artifact (if any) serves this request:
+        // - a v4 quality variant (`content/{hash}_q{N}.res`) when one satisfies
+        //   the requested quality;
+        // - the v3 legacy single bake (`content/{hash}.res`) when the hash is
+        //   optimized but the manifest carries no per-quality info (legacy
+        //   manifests have `optimizedContent` but no `textureQualities`). This
+        //   keeps serving the GPU-ready ETC2 `.res` instead of regressing to a
+        //   raw download + on-device recompress during the v3→v4 rollout.
         let selected_variant = self.select_texture_variant(&file_hash, &quality);
-        let variant_key = selected_variant.map(|v| format!("{}_v{}", file_hash, v));
+        let optimized_godot_path = match selected_variant {
+            Some(v) => Some(format!("res://content/{}_q{}.res", file_hash, v)),
+            None if self.optimized_asset_exists(file_hash_godot.clone()) => {
+                Some(format!("res://content/{}.res", file_hash))
+            }
+            None => None,
+        };
 
-        if let Some(ref variant_key) = variant_key {
-            if let Some(promise) = self.get_cached_promise(variant_key) {
+        // Promises resolving to the same baked artifact share a cache slot, so
+        // the default-quality and explicit-quality entry points don't load it
+        // twice. The legacy single bake is quality-independent → one slot.
+        let shared_key = match selected_variant {
+            Some(v) => Some(format!("{}_v{}", file_hash, v)),
+            None if optimized_godot_path.is_some() => Some(format!("{}_legacy", file_hash)),
+            None => None,
+        };
+
+        if let Some(ref shared_key) = shared_key {
+            if let Some(promise) = self.get_cached_promise(shared_key) {
                 self.cache_promise(primary_key, &promise);
                 return promise;
             }
@@ -1395,7 +1418,7 @@ impl ContentProvider {
 
         let hash_id = file_hash.clone();
 
-        if let Some(variant) = selected_variant {
+        if let Some(godot_path) = optimized_godot_path {
             let optimized_data = self.optimized_data.clone();
             let original_size = self.optimized_original_size.get(&hash_id).copied();
 
@@ -1408,17 +1431,15 @@ impl ContentProvider {
                 )
                 .await;
 
-                let godot_path = format!("res://content/{}_q{}.res", hash_id, variant);
-
                 if let Some(entry_variant) = load_baked_texture_entry(&godot_path, original_size) {
                     then_promise(get_promise, Ok(Some(entry_variant)));
                     return;
                 }
 
-                // Baked variant missing or unreadable (e.g. a stale pre-v4 ZIP
-                // in the local cache): fall back to download + decode.
+                // Baked artifact missing or unreadable (e.g. a stale ZIP in the
+                // local cache): fall back to download + decode.
                 tracing::warn!(
-                    "Failed to load baked texture variant {}, falling back to runtime decode",
+                    "Failed to load baked texture {}, falling back to runtime decode",
                     godot_path
                 );
                 let result = load_image_texture(url, hash_id.clone(), ctx).await;
@@ -1450,8 +1471,8 @@ impl ContentProvider {
         }
 
         self.cache_promise(primary_key, &promise);
-        if let Some(variant_key) = variant_key {
-            self.cache_promise(variant_key, &promise);
+        if let Some(shared_key) = shared_key {
+            self.cache_promise(shared_key, &promise);
         }
 
         promise

--- a/lib/src/content/content_provider.rs
+++ b/lib/src/content/content_provider.rs
@@ -72,6 +72,10 @@ struct ContentData {
     external_scene_dependencies: HashMap<String, HashSet<String>>,
     original_sizes: HashMap<String, ImageSize>,
     hash_size_map: HashMap<String, u64>,
+    /// Texture hash -> baked quality ordinals (TextureQuality: 0=Low .. 3=Source).
+    /// Optional: manifests baked before quality variants existed lack it.
+    #[serde(default)]
+    texture_qualities: HashMap<String, Vec<i32>>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Copy)]
@@ -111,8 +115,11 @@ pub struct ContentProvider {
     // Set of optimized hashes that we know that exists...
     optimized_assets: HashSet<String>,
     optimized_original_size: HashMap<String, ImageSize>,
-    // URL base for optimized wearable/emote assets (e.g., "http://127.0.0.1:9090/")
-    optimized_wearable_base_url: Option<String>,
+    // Texture hash -> baked quality ordinals, sorted ascending
+    optimized_texture_qualities: HashMap<String, Vec<i32>>,
+    // URL bases for optimized wearable/emote assets, tried in order
+    // (e.g., ["http://127.0.0.1:9090/"])
+    optimized_wearable_base_urls: Option<Vec<String>>,
 }
 
 #[derive(Clone)]
@@ -139,7 +146,41 @@ pub struct SceneGltfContext {
 
 unsafe impl Send for SceneGltfContext {}
 
-const ASSET_OPTIMIZED_BASE_URL: &str = "https://optimized-assets.dclexplorer.com/v3";
+/// Versioned optimized-assets buckets, newest first. The runtime tries each in
+/// order, so clients keep serving older-format content until the newest bucket
+/// is fully populated. Remove old entries once their content is migrated.
+const ASSET_OPTIMIZED_BASE_URLS: &[&str] = &[
+    "https://optimized-assets.dclexplorer.com/v4",
+    "https://optimized-assets.dclexplorer.com/v3",
+];
+
+/// Smallest quality ordinal in `qualities` (sorted ascending) that is >= `requested`.
+fn select_variant_from(qualities: &[i32], requested: i32) -> Option<i32> {
+    qualities.iter().copied().find(|&q| q >= requested)
+}
+
+/// Load a baked texture variant from a mounted resource pack and build a
+/// TextureEntry variant. Returns None if the resource is missing or invalid.
+/// Synchronous on purpose: the non-Send Godot objects must not live across an
+/// await in the calling async block.
+fn load_baked_texture_entry(godot_path: &str, original_size: Option<ImageSize>) -> Option<Variant> {
+    let texture = ResourceLoader::singleton()
+        .load(&GString::from(godot_path))
+        .and_then(|res| res.try_cast::<godot::classes::Texture2D>().ok())?;
+    let image = texture.get_image()?;
+    let original_size = if let Some(original_size) = original_size {
+        Vector2i::new(original_size.width, original_size.height)
+    } else {
+        image.get_size()
+    };
+    let texture_entry = Gd::from_init_fn(|_base| TextureEntry {
+        original_size,
+        image,
+        texture,
+        failed: false,
+    });
+    Some(texture_entry.to_variant())
+}
 
 #[godot_api]
 impl INode for ContentProvider {
@@ -187,8 +228,14 @@ impl INode for ContentProvider {
             }),
             optimized_assets: HashSet::default(),
             optimized_original_size: HashMap::default(),
-            // Default to the same URL used for scene optimized assets
-            optimized_wearable_base_url: Some(format!("{}/", ASSET_OPTIMIZED_BASE_URL)),
+            optimized_texture_qualities: HashMap::default(),
+            // Default to the same URLs used for scene optimized assets
+            optimized_wearable_base_urls: Some(
+                ASSET_OPTIMIZED_BASE_URLS
+                    .iter()
+                    .map(|url| format!("{}/", url))
+                    .collect(),
+            ),
         }
     }
     fn ready(&mut self) {}
@@ -461,7 +508,7 @@ impl ContentProvider {
         };
 
         let file_hash_clone = file_hash.clone();
-        let optimized_base_url = self.optimized_wearable_base_url.clone();
+        let optimized_base_urls = self.optimized_wearable_base_urls.clone();
         let opt_wearable_counter = self.optimized_wearable_count.clone();
         let rt_wearable_counter = self.runtime_wearable_count.clone();
 
@@ -472,7 +519,7 @@ impl ContentProvider {
                 file_path_str,
                 content_mapping_ref,
                 ctx,
-                optimized_base_url,
+                optimized_base_urls,
                 false, // is_emote = false
                 opt_wearable_counter,
                 rt_wearable_counter,
@@ -607,7 +654,7 @@ impl ContentProvider {
         };
 
         let file_hash_clone = file_hash.clone();
-        let optimized_base_url = self.optimized_wearable_base_url.clone();
+        let optimized_base_urls = self.optimized_wearable_base_urls.clone();
         let opt_wearable_counter = self.optimized_wearable_count.clone();
         let rt_wearable_counter = self.runtime_wearable_count.clone();
 
@@ -618,7 +665,7 @@ impl ContentProvider {
                 file_path_str,
                 content_mapping_ref,
                 ctx,
-                optimized_base_url,
+                optimized_base_urls,
                 true, // is_emote = true
                 opt_wearable_counter,
                 rt_wearable_counter,
@@ -1046,6 +1093,16 @@ impl ContentProvider {
             self.optimized_assets
                 .extend(content_data.optimized_content.clone());
 
+            self.optimized_texture_qualities.extend(
+                content_data
+                    .texture_qualities
+                    .into_iter()
+                    .map(|(hash, mut qualities)| {
+                        qualities.sort_unstable();
+                        (hash, qualities)
+                    }),
+            );
+
             let optimized_data = self.optimized_data.clone();
 
             TokioRuntime::spawn(async move {
@@ -1240,6 +1297,48 @@ impl ContentProvider {
         file_hash_godot: GString,
         content_mapping: Gd<DclContentMappingAndUrl>,
     ) -> Gd<Promise> {
+        let quality = self.texture_quality.clone();
+        self.fetch_texture_by_hash_internal(file_hash_godot, content_mapping, quality, true)
+    }
+
+    /// Fetches a texture by hash with an explicit quality. Serves a baked variant
+    /// from the optimized pipeline when one satisfies the requested quality;
+    /// otherwise downloads and decodes at that quality.
+    /// Cache key: `{hash}_q{N}` — shared with `fetch_texture_by_url_with_quality`.
+    pub fn fetch_texture_by_hash_with_quality(
+        &mut self,
+        file_hash_godot: GString,
+        content_mapping: Gd<DclContentMappingAndUrl>,
+        quality: TextureQuality,
+    ) -> Gd<Promise> {
+        self.fetch_texture_by_hash_internal(file_hash_godot, content_mapping, quality, false)
+    }
+
+    /// Smallest baked variant whose quality satisfies (>=) the requested one.
+    /// `None` means no baked variant can serve the request without degrading it,
+    /// and the caller must fall back to download + decode.
+    fn select_texture_variant(&self, hash: &str, requested: &TextureQuality) -> Option<i32> {
+        select_variant_from(
+            self.optimized_texture_qualities.get(hash)?,
+            requested.to_i32(),
+        )
+    }
+
+    /// Shared implementation for hash-based texture fetching.
+    ///
+    /// Cache keys: each entry point keeps its historical primary key (plain
+    /// `{hash}` for the default-quality path, `{hash}_q{N}` for explicit
+    /// quality) since callers like `get_texture_from_hash` look promises up by
+    /// those. When a baked variant is selected, the promise is also cached
+    /// under `{hash}_v{N}` so both entry points resolving to the same variant
+    /// share a single load.
+    fn fetch_texture_by_hash_internal(
+        &mut self,
+        file_hash_godot: GString,
+        content_mapping: Gd<DclContentMappingAndUrl>,
+        quality: TextureQuality,
+        use_plain_cache_key: bool,
+    ) -> Gd<Promise> {
         let file_hash = file_hash_godot.to_string();
 
         // Validate file_hash is not empty to prevent "Is a directory" errors
@@ -1248,7 +1347,13 @@ impl ContentProvider {
             return Promise::from_rejected("Empty texture hash".to_string());
         }
 
-        if let Some(promise) = self.get_cached_promise(&file_hash) {
+        let primary_key = if use_plain_cache_key {
+            file_hash.clone()
+        } else {
+            format!("{}_q{}", file_hash, quality.to_i32())
+        };
+
+        if let Some(promise) = self.get_cached_promise(&primary_key) {
             return promise;
         }
 
@@ -1258,85 +1363,71 @@ impl ContentProvider {
         if file_hash.starts_with("http") {
             // get file_hash from url
             let new_file_hash = format!("hashed_{:x}", file_hash_godot.hash_u32());
-            let promise = self.fetch_texture_by_url(GString::from(&new_file_hash), file_hash_godot);
-            self.cache_promise(file_hash, &promise);
+            let promise = self.fetch_texture_by_url_with_quality(
+                GString::from(&new_file_hash),
+                file_hash_godot,
+                quality,
+            );
+            self.cache_promise(primary_key, &promise);
             return promise;
         }
 
+        let selected_variant = self.select_texture_variant(&file_hash, &quality);
+        let variant_key = selected_variant.map(|v| format!("{}_v{}", file_hash, v));
+
+        if let Some(ref variant_key) = variant_key {
+            if let Some(promise) = self.get_cached_promise(variant_key) {
+                self.cache_promise(primary_key, &promise);
+                return promise;
+            }
+        }
+
         let (promise, get_promise) = Promise::make_to_async();
-        let ctx = self.get_context();
 
-        if self.optimized_asset_exists(file_hash_godot.clone()) {
-            let hash_id = file_hash.clone();
+        let mut ctx = self.get_context();
+        ctx.texture_quality = quality;
+
+        let url = format!(
+            "{}{}",
+            content_mapping.bind().get_base_url(),
+            file_hash.clone()
+        );
+
+        let hash_id = file_hash.clone();
+
+        if let Some(variant) = selected_variant {
             let optimized_data = self.optimized_data.clone();
-
             let original_size = self.optimized_original_size.get(&hash_id).copied();
 
             TokioRuntime::spawn(async move {
                 let _ = ContentProvider::async_fetch_optimized_asset(
                     hash_id.clone(),
-                    ctx,
+                    ctx.clone(),
                     optimized_data,
                     false,
                 )
                 .await;
 
-                let godot_path = format!("res://content/{}.res", hash_id);
+                let godot_path = format!("res://content/{}_q{}.res", hash_id, variant);
 
-                let resource =
-                    match ResourceLoader::singleton().load(&GString::from(godot_path.as_str())) {
-                        Some(res) => res,
-                        None => {
-                            tracing::error!(
-                                "Failed to load optimized texture resource: {}",
-                                godot_path
-                            );
-                            then_promise(
-                                get_promise,
-                                Err(anyhow::anyhow!("Failed to load texture: {}", godot_path)),
-                            );
-                            return;
-                        }
-                    };
+                if let Some(entry_variant) = load_baked_texture_entry(&godot_path, original_size) {
+                    then_promise(get_promise, Ok(Some(entry_variant)));
+                    return;
+                }
 
-                let texture = resource.cast::<godot::classes::Texture2D>();
-                let image = match texture.get_image() {
-                    Some(img) => img,
-                    None => {
-                        tracing::error!("Failed to get image from texture: {}", godot_path);
-                        then_promise(
-                            get_promise,
-                            Err(anyhow::anyhow!("Failed to get image from: {}", godot_path)),
-                        );
-                        return;
-                    }
-                };
-
-                let original_size = if let Some(original_size) = original_size {
-                    Vector2i::new(original_size.width, original_size.height)
-                } else {
-                    image.get_size()
-                };
-
-                let texture_entry = Gd::from_init_fn(|_base| TextureEntry {
-                    original_size,
-                    image,
-                    texture,
-                    failed: false,
-                });
-
-                then_promise(get_promise, Ok(Some(texture_entry.to_variant())));
+                // Baked variant missing or unreadable (e.g. a stale pre-v4 ZIP
+                // in the local cache): fall back to download + decode.
+                tracing::warn!(
+                    "Failed to load baked texture variant {}, falling back to runtime decode",
+                    godot_path
+                );
+                let result = load_image_texture(url, hash_id.clone(), ctx).await;
+                then_promise(get_promise, result);
             });
         } else {
-            let url = format!(
-                "{}{}",
-                content_mapping.bind().get_base_url(),
-                file_hash.clone()
-            );
-
             let loading_resources = self.loading_resources.clone();
             let loaded_resources = self.loaded_resources.clone();
-            let hash_id = file_hash.clone();
+
             TokioRuntime::spawn(async move {
                 #[cfg(feature = "use_resource_tracking")]
                 report_resource_start(&hash_id, "texture");
@@ -1358,84 +1449,10 @@ impl ContentProvider {
             });
         }
 
-        self.cache_promise(file_hash, &promise);
-
-        promise
-    }
-
-    /// Fetches a texture by hash with an explicit quality, bypassing the optimization
-    /// pipeline. Useful for UI textures that need a specific (usually Source) quality.
-    /// Cache key: `{hash}_q{N}` — shared with `fetch_texture_by_url_with_quality`.
-    pub fn fetch_texture_by_hash_with_quality(
-        &mut self,
-        file_hash_godot: GString,
-        content_mapping: Gd<DclContentMappingAndUrl>,
-        quality: TextureQuality,
-    ) -> Gd<Promise> {
-        let file_hash = file_hash_godot.to_string();
-
-        // Validate file_hash is not empty to prevent "Is a directory" errors
-        if file_hash.is_empty() {
-            tracing::warn!(
-                "fetch_texture_by_hash_with_quality: empty file_hash, returning rejected promise"
-            );
-            return Promise::from_rejected("Empty texture hash".to_string());
+        self.cache_promise(primary_key, &promise);
+        if let Some(variant_key) = variant_key {
+            self.cache_promise(variant_key, &promise);
         }
-
-        let cache_key = format!("{}_q{}", file_hash, quality.to_i32());
-
-        if let Some(promise) = self.get_cached_promise(&cache_key) {
-            return promise;
-        }
-
-        // Handle URL-based textures
-        if file_hash.starts_with("http") {
-            let new_file_hash = format!("hashed_{:x}", file_hash_godot.hash_u32());
-            let promise = self.fetch_texture_by_url_with_quality(
-                GString::from(&new_file_hash),
-                file_hash_godot,
-                quality,
-            );
-            self.cache_promise(cache_key, &promise);
-            return promise;
-        }
-
-        let (promise, get_promise) = Promise::make_to_async();
-
-        let mut ctx = self.get_context();
-        ctx.texture_quality = quality;
-
-        let url = format!(
-            "{}{}",
-            content_mapping.bind().get_base_url(),
-            file_hash.clone()
-        );
-
-        let loading_resources = self.loading_resources.clone();
-        let loaded_resources = self.loaded_resources.clone();
-        let hash_id = file_hash.clone();
-
-        TokioRuntime::spawn(async move {
-            #[cfg(feature = "use_resource_tracking")]
-            report_resource_start(&hash_id, "texture_with_quality");
-
-            loading_resources.fetch_add(1, Ordering::Relaxed);
-
-            let result = load_image_texture(url, hash_id.clone(), ctx).await;
-
-            #[cfg(feature = "use_resource_tracking")]
-            if let Err(error) = &result {
-                report_resource_error(&hash_id, &error.to_string());
-            } else {
-                report_resource_loaded(&hash_id);
-            }
-
-            then_promise(get_promise, result);
-
-            loaded_resources.fetch_add(1, Ordering::Relaxed);
-        });
-
-        self.cache_promise(cache_key, &promise);
 
         promise
     }
@@ -1807,9 +1824,14 @@ impl ContentProvider {
             .set_max_low_priority_downloads(number as usize)
     }
 
+    /// Versioned optimized-assets base URLs, newest first. Callers should try
+    /// each in order until the content is found.
     #[func]
-    pub fn get_optimized_base_url(&self) -> GString {
-        ASSET_OPTIMIZED_BASE_URL.to_godot()
+    pub fn get_optimized_base_urls(&self) -> PackedStringArray {
+        ASSET_OPTIMIZED_BASE_URLS
+            .iter()
+            .map(|url| GString::from(*url))
+            .collect()
     }
 
     /// Set the base URL for optimized wearable/emote assets.
@@ -1820,7 +1842,7 @@ impl ContentProvider {
     pub fn set_optimized_wearable_base_url(&mut self, url: GString) {
         let url_str = url.to_string();
         if url_str.is_empty() {
-            self.optimized_wearable_base_url = None;
+            self.optimized_wearable_base_urls = None;
             tracing::info!("Optimized wearable base URL cleared");
         } else {
             // Ensure URL ends with slash
@@ -1830,14 +1852,18 @@ impl ContentProvider {
                 format!("{}/", url_str)
             };
             tracing::info!("Optimized wearable base URL set to: {}", url_with_slash);
-            self.optimized_wearable_base_url = Some(url_with_slash);
+            self.optimized_wearable_base_urls = Some(vec![url_with_slash]);
         }
     }
 
-    /// Get the configured optimized wearable base URL, if any.
+    /// Get the first configured optimized wearable base URL, if any.
     #[func]
     pub fn get_optimized_wearable_base_url(&self) -> GString {
-        match &self.optimized_wearable_base_url {
+        match self
+            .optimized_wearable_base_urls
+            .as_ref()
+            .and_then(|urls| urls.first())
+        {
             Some(url) => GString::from(url.as_str()),
             None => GString::new(),
         }
@@ -2364,18 +2390,10 @@ impl ContentProvider {
         let loaded_dependencies = optimized_data.loaded_assets.read().await;
 
         for hash_dependency in &dependencies {
-            let asset_url: String = format!(
-                "{}/{}-mobile.zip",
-                ASSET_OPTIMIZED_BASE_URL, hash_dependency
-            );
             let hash_dependency_zip = format!("{}-mobile.zip", hash_dependency);
             let absolute_file_path = format!("{}{}", ctx.content_folder, hash_dependency_zip);
 
-            tracing::debug!(
-                "Optimized asset dependency: {} -> url: {}",
-                hash_dependency,
-                asset_url
-            );
+            tracing::debug!("Optimized asset dependency: {}", hash_dependency);
 
             if !loaded_dependencies.contains(hash_dependency) {
                 if hash_dependency != &file_hash {
@@ -2392,7 +2410,7 @@ impl ContentProvider {
             }
 
             // Fetch the resource if it's either a new dependency or missing in cache
-            tracing::debug!("Fetching optimized asset: {}", asset_url);
+            tracing::debug!("Fetching optimized asset: {}", hash_dependency_zip);
 
             #[cfg(feature = "use_resource_tracking")]
             report_resource_start(&hash_dependency_zip, "optimized_asset_dep");
@@ -2401,16 +2419,39 @@ impl ContentProvider {
             let hash_for_tracking = hash_dependency_zip.clone();
 
             let ctx_clone = ctx.clone();
-            let url_for_log = asset_url.clone();
             let future = async move {
-                let result = ctx_clone
-                    .resource_provider
-                    .fetch_resource(asset_url, hash_dependency_zip.clone(), absolute_file_path)
-                    .await;
+                // Try each versioned bucket (newest first) until one has the ZIP
+                let mut result = Err(format!(
+                    "No optimized asset bucket served {}",
+                    hash_dependency_zip
+                ));
+                for base_url in ASSET_OPTIMIZED_BASE_URLS {
+                    let asset_url = format!("{}/{}", base_url, hash_dependency_zip);
+                    result = ctx_clone
+                        .resource_provider
+                        .fetch_resource(
+                            asset_url.clone(),
+                            hash_dependency_zip.clone(),
+                            absolute_file_path.clone(),
+                        )
+                        .await;
 
-                match &result {
-                    Ok(_) => tracing::debug!("Downloaded optimized asset: {}", url_for_log),
-                    Err(e) => tracing::error!("Failed to download {}: {}", url_for_log, e),
+                    match &result {
+                        Ok(_) => {
+                            tracing::debug!("Downloaded optimized asset: {}", asset_url);
+                            break;
+                        }
+                        Err(e) => {
+                            tracing::debug!("Failed to download {}: {}", asset_url, e)
+                        }
+                    }
+                }
+                if let Err(e) = &result {
+                    tracing::error!(
+                        "Failed to download {} from all buckets: {}",
+                        hash_dependency_zip,
+                        e
+                    );
                 }
 
                 #[cfg(feature = "use_resource_tracking")]
@@ -2502,7 +2543,7 @@ impl ContentProvider {
         file_path: String,
         content_mapping: super::content_mapping::ContentMappingAndUrlRef,
         ctx: SceneGltfContext,
-        optimized_base_url: Option<String>,
+        optimized_base_urls: Option<Vec<String>>,
         is_emote: bool,
         optimized_wearable_counter: Arc<AtomicU64>,
         runtime_wearable_counter: Arc<AtomicU64>,
@@ -2514,9 +2555,9 @@ impl ContentProvider {
         let local_zip_path = format!("{}{}", ctx.content_folder, zip_name);
 
         // 2. Determine if we should use optimized version
-        // IMPORTANT: Only check for local ZIP if optimized_base_url is Some
+        // IMPORTANT: Only check for local ZIP if optimized_base_urls is Some
         // When None is passed (runtime-only mode), skip optimized assets entirely
-        let use_optimized = if let Some(base_url) = optimized_base_url {
+        let use_optimized = if let Some(base_urls) = optimized_base_urls {
             // Check local cache first
             let local_zip_exists = std::path::Path::new(&local_zip_path).exists();
             if local_zip_exists {
@@ -2528,63 +2569,77 @@ impl ContentProvider {
                 );
                 true
             } else {
-                // Try to check if optimized version exists on remote server
-                let zip_url = format!("{}{}", base_url, zip_name);
-                tracing::debug!("Checking for optimized {} at: {}", asset_type, zip_url);
+                // Try each versioned base URL (newest first) until one has the ZIP
+                let mut downloaded = false;
+                for base_url in &base_urls {
+                    let zip_url = format!("{}{}", base_url, zip_name);
+                    tracing::debug!("Checking for optimized {} at: {}", asset_type, zip_url);
 
-                match ctx
-                    .resource_provider
-                    .check_remote_file_exists(&zip_url)
-                    .await
-                {
-                    Ok(true) => {
-                        // File exists on server - download it
-                        tracing::debug!(
-                            "[OPTIMIZED] Downloading {} ZIP from: {}",
-                            asset_type.to_uppercase(),
-                            zip_url
-                        );
-                        match ctx
-                            .resource_provider
-                            .fetch_resource_low_priority(
-                                zip_url.clone(),
-                                zip_name.clone(),
-                                local_zip_path.clone(),
-                            )
-                            .await
-                        {
-                            Ok(_) => {
-                                tracing::debug!(
-                                    "[OPTIMIZED] Downloaded {} ZIP: {} (hash={})",
-                                    asset_type.to_uppercase(),
-                                    zip_name,
-                                    file_hash
-                                );
-                                true
+                    match ctx
+                        .resource_provider
+                        .check_remote_file_exists(&zip_url)
+                        .await
+                    {
+                        Ok(true) => {
+                            // File exists on server - download it
+                            tracing::debug!(
+                                "[OPTIMIZED] Downloading {} ZIP from: {}",
+                                asset_type.to_uppercase(),
+                                zip_url
+                            );
+                            match ctx
+                                .resource_provider
+                                .fetch_resource_low_priority(
+                                    zip_url.clone(),
+                                    zip_name.clone(),
+                                    local_zip_path.clone(),
+                                )
+                                .await
+                            {
+                                Ok(_) => {
+                                    tracing::debug!(
+                                        "[OPTIMIZED] Downloaded {} ZIP: {} (hash={})",
+                                        asset_type.to_uppercase(),
+                                        zip_name,
+                                        file_hash
+                                    );
+                                    downloaded = true;
+                                }
+                                Err(e) => {
+                                    tracing::warn!(
+                                        "Failed to download optimized {} from {}: {}",
+                                        asset_type,
+                                        zip_url,
+                                        e
+                                    );
+                                }
                             }
-                            Err(e) => {
-                                tracing::warn!(
-                                    "Failed to download optimized {}: {} - falling back to runtime processing",
-                                    asset_type,
-                                    e
-                                );
-                                false
-                            }
+                            break;
+                        }
+                        Ok(false) => {
+                            tracing::debug!(
+                                "No optimized {} available at: {}",
+                                asset_type,
+                                zip_url
+                            );
+                        }
+                        Err(e) => {
+                            tracing::debug!(
+                                "Failed to check optimized {} existence at {}: {}",
+                                asset_type,
+                                zip_url,
+                                e
+                            );
                         }
                     }
-                    Ok(false) => {
-                        tracing::debug!("No optimized {} available at: {}", asset_type, zip_url);
-                        false
-                    }
-                    Err(e) => {
-                        tracing::debug!(
-                            "Failed to check optimized {} existence: {} - falling back to runtime processing",
-                            asset_type,
-                            e
-                        );
-                        false
-                    }
                 }
+                if !downloaded {
+                    tracing::debug!(
+                        "No optimized {} in any bucket - falling back to runtime processing",
+                        asset_type
+                    );
+                }
+                downloaded
             }
         } else {
             // No optimized_base_url provided - use runtime processing only
@@ -2689,5 +2744,63 @@ impl ContentProvider {
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_select_variant_from() {
+        // (baked qualities, requested, expected)
+        let cases: &[(&[i32], i32, Option<i32>)] = &[
+            // full set: exact matches
+            (&[0, 1, 2, 3], 0, Some(0)),
+            (&[0, 1, 2, 3], 2, Some(2)),
+            (&[0, 1, 2, 3], 3, Some(3)),
+            // collapsed High (original <= 1024): High request serves Source
+            (&[0, 1, 3], 2, Some(3)),
+            // only lower variants baked: never degrade, fall back to network
+            (&[0, 1], 2, None),
+            (&[0, 1, 2], 3, None),
+            // no variants known (pre-v4 manifest)
+            (&[], 1, None),
+        ];
+
+        for (qualities, requested, expected) in cases {
+            assert_eq!(
+                select_variant_from(qualities, *requested),
+                *expected,
+                "qualities={:?} requested={}",
+                qualities,
+                requested
+            );
+        }
+    }
+
+    #[test]
+    fn test_content_data_parses_texture_qualities() {
+        let json = r#"{
+            "optimizedContent": ["hashA"],
+            "externalSceneDependencies": {},
+            "originalSizes": {"hashA": {"width": 2048, "height": 1024}},
+            "hashSizeMap": {"hashA": 1000},
+            "textureQualities": {"hashA": [0, 1, 2, 3]}
+        }"#;
+        let data: ContentData = serde_json::from_str(json).expect("valid manifest");
+        assert_eq!(data.texture_qualities["hashA"], vec![0, 1, 2, 3]);
+    }
+
+    #[test]
+    fn test_content_data_parses_legacy_manifest_without_texture_qualities() {
+        let json = r#"{
+            "optimizedContent": ["hashA"],
+            "externalSceneDependencies": {},
+            "originalSizes": {},
+            "hashSizeMap": {}
+        }"#;
+        let data: ContentData = serde_json::from_str(json).expect("legacy manifest");
+        assert!(data.texture_qualities.is_empty());
     }
 }

--- a/lib/src/content/texture.rs
+++ b/lib/src/content/texture.rs
@@ -453,7 +453,7 @@ pub fn create_compressed_texture(image: &mut Gd<Image>, max_size: i32) -> Gd<Tex
 
 /// Hard cap on any single dimension, regardless of pixel budget.
 /// Keeps us safely under common GPU `MAX_TEXTURE_SIZE` limits on mobile / Quest.
-const MAX_TEXTURE_DIMENSION: i32 = 4096;
+pub const MAX_TEXTURE_DIMENSION: i32 = 4096;
 
 /// Downscale `image` (preserving aspect ratio) so that:
 ///   - total pixels <= `max_size * max_size`, AND


### PR DESCRIPTION
Closes #2076

## Problem

The offline asset pipeline baked a single `.res` per texture at one fixed quality (`ctx.texture_quality`, hardcoded Medium). At runtime the optimized fast-path loaded that `.res` blindly, so:

- the user's `TextureQuality` setting was silently ignored (High request → got Medium, no warning);
- `fetch_texture_by_hash_with_quality` / `fetch_texture_by_url_with_quality` could **never** use the fast-path and always paid full network + decode (e.g. every UI image asking for Source).

## What changed

### Bake side (`lib/src/asset_server/`)
- `process_texture` now bakes one variant per quality tier — **Low (256) / Medium (512) / High (1024) / Source** — each resized from a fresh `image.duplicate()` of the pristine decode to avoid lossy resize cascades. Source is capped at `MAX_TEXTURE_DIMENSION` (4096) and collapsed into the top variant when the original already fits in High (identical pixels).
- Variants are saved as `content/{hash}_q{N}.res`. New manifest field `textureQualities: {hash: [ordinals]}` records which variants exist; `hashSizeMap` for textures is the sum of all variant sizes. Packer + job plumbing carry N files per texture.

### Runtime side (`lib/src/content/content_provider.rs`)
- `select_texture_variant` picks the **smallest baked variant ≥ the requested quality**; if only lower variants exist it falls back to network + decode — never silently degrades (the core bug).
- `fetch_texture_by_hash` (uses the runtime setting) and `fetch_texture_by_hash_with_quality` (explicit) are unified on a shared internal that hits the fast-path when a variant satisfies the request, sharing a single load via a `{hash}_v{N}` cache key.

### Versioning / back-compat
- Bumped the optimized bucket to **`/v4`**. The runtime tries versioned buckets **newest-first (v4 → v3)** for scene manifests (`scene_fetcher.gd`), per-hash zips (`async_fetch_optimized_asset`), and wearable/emote zips. So **v4 clients keep serving v3 content until the v4 bucket is populated** — no regression while the re-bake rolls out. Legacy manifests without `textureQualities` parse fine and fall back to network.

## Out of scope (per the issue)
- Exact resolution set, cache eviction / storage budget, CDN-side negotiation.
- GLTF-embedded textures stay single-quality (baked into the `.scn`).
- **Note on packaging:** variants live inside the existing per-hash zip, so a Low client still downloads the Source bytes (disk + bandwidth, not RAM/VRAM). Splitting into per-variant zips is a possible follow-up.

## Testing
- Unit tests: variant selection rule (exact / High→Source collapse / "only lower" → None / empty manifest), and serde round-trip of `textureQualities` (camelCase, optional on read for legacy manifests).
- `cargo fmt`, `clippy`, full Rust unit suite, `gdformat`/`gdlint` pass.
- **Bake e2e**: ran the asset server locally (`--rendering-driver opengl3`), processed 3 textures of different sizes → zip contents verified byte-for-byte (1536px → q0/q1/q2/q3; 936px & 192px → q0/q1/q3 with High collapsed; valid `RSCC` headers).
- `gdformat`/`gdlint` and headless script validation pass (0 errors).
- Not yet exercised live: runtime quality matrix against re-baked v4 content, and the `/process-scene` manifest flow end-to-end.
