### PR TITLE
fix: scene emotes not playing / never changing on the local player

### DIFF
--- a/godot/src/decentraland_components/avatar/avatar.gd
+++ b/godot/src/decentraland_components/avatar/avatar.gd
@@ -1714,6 +1714,35 @@ func get_scene_emote_info(scene_id: String, glb_hash: String) -> Dictionary:
 	return {"base_url": Global.realm.content_base_url, "audio_hash": ""}
 
 
+## Resolve a scene-emote URN back to its registered (scene_id, glb_hash) and content.
+## The URN format `scene-emote:{scene_id}-{glb_hash}-{loop}` is ambiguous to dash-split
+## when the ids contain '-' — which is exactly the case for preview content, whose hashes
+## look like `b64-<base64-of-path>`. Splitting on '-' then drops the `b64-` prefix from
+## glb_hash and corrupts scene_id, the registry lookup misses, and the emote never loads.
+## Instead we match the URN against the registry that Rust populated via
+## register_scene_emote_content() right before async_play_emote(), which is unambiguous.
+## Returns {scene_id, glb_hash, base_url, audio_hash, looping} or {} when no entry matches.
+func find_scene_emote_by_urn(emote_urn: String) -> Dictionary:
+	for scene_id in _scene_emote_registry:
+		var scene_data = _scene_emote_registry[scene_id]
+		for glb_hash in scene_data["emotes"]:
+			for looping in [false, true]:
+				var loop_str := "true" if looping else "false"
+				var candidate := (
+					"urn:decentraland:off-chain:scene-emote:%s-%s-%s"
+					% [scene_id, glb_hash, loop_str]
+				)
+				if candidate == emote_urn:
+					return {
+						"scene_id": scene_id,
+						"glb_hash": glb_hash,
+						"base_url": scene_data["base_url"],
+						"audio_hash": scene_data["emotes"][glb_hash],
+						"looping": looping,
+					}
+	return {}
+
+
 ## Play emote triggered by AvatarShape's expression_trigger_id field.
 ## Supports: default emotes (e.g. "wave"), URN emotes, and local scene emotes (.glb/.gltf)
 func _async_play_expression_trigger(emote_id: String) -> void:

--- a/godot/src/decentraland_components/avatar/avatar_emote_controller.gd
+++ b/godot/src/decentraland_components/avatar/avatar_emote_controller.gd
@@ -469,20 +469,37 @@ func _async_load_emote(emote_urn: String):
 ## Load a scene emote using the same code path as wearable emotes.
 ## This is the key to unification - scene emotes are stored in loaded_emotes_by_urn just like wearables.
 func _async_load_scene_emote_as_wearable(scene_emote_urn: String):
-	# Parse the URN to extract scene_id, glb_hash, looping
-	var parsed = EmoteSceneUrn.new(scene_emote_urn)
-	if not parsed.is_valid:
-		printerr("Failed to parse scene emote URN: %s" % scene_emote_urn)
-		return
+	# Resolve the URN to its registered content. Match against the registry
+	# (populated by Rust before async_play_emote) rather than dash-splitting the
+	# URN — preview hashes look like `b64-<base64>` and contain '-', which breaks
+	# the split and yields a wrong scene_id/glb_hash, so the emote never loads.
+	var glb_hash: String
+	var base_url: String
+	var audio_hash: String
+	var looping: bool
 
-	# Get content info from registry (registered by Rust before calling async_play_emote)
-	var info = avatar.get_scene_emote_info(parsed.scene_id, parsed.glb_hash)
-	var base_url = info["base_url"]
-	var audio_hash = info["audio_hash"]
+	var resolved = avatar.find_scene_emote_by_urn(scene_emote_urn)
+	if not resolved.is_empty():
+		glb_hash = resolved["glb_hash"]
+		base_url = resolved["base_url"]
+		audio_hash = resolved["audio_hash"]
+		looping = resolved["looping"]
+	else:
+		# Fallback: dash-split parse (correct for dashless CID hashes, e.g. deployed
+		# content) and the realm-URL fallback for remote players not in the registry.
+		var parsed = EmoteSceneUrn.new(scene_emote_urn)
+		if not parsed.is_valid:
+			printerr("Failed to parse scene emote URN: %s" % scene_emote_urn)
+			return
+		var info = avatar.get_scene_emote_info(parsed.scene_id, parsed.glb_hash)
+		glb_hash = parsed.glb_hash
+		base_url = info["base_url"]
+		audio_hash = info["audio_hash"]
+		looping = parsed.looping
 
 	# Create content mapping (same structure as wearables use)
 	# Note: base_url from scene already includes "contents/" typically
-	var files_dict = {"emote.glb": parsed.glb_hash}
+	var files_dict = {"emote.glb": glb_hash}
 	if not audio_hash.is_empty():
 		files_dict["emote.mp3"] = audio_hash
 
@@ -499,18 +516,18 @@ func _async_load_scene_emote_as_wearable(scene_emote_urn: String):
 		Global.cli.only_no_optimized_scene_emotes or Global.cli.only_no_optimized
 	)
 	var scene_path = await emote_loader.async_load_emote_from_mapping(
-		parsed.glb_hash, "emote.glb", content_mapping, force_runtime_only
+		glb_hash, "emote.glb", content_mapping, force_runtime_only
 	)
 	if scene_path.is_empty():
 		printerr("Failed to load scene emote: %s" % scene_emote_urn)
 		return
 
-	var obj = await emote_loader.async_get_emote_gltf(parsed.glb_hash)
+	var obj = await emote_loader.async_get_emote_gltf(glb_hash)
 	if obj == null:
 		printerr(
 			(
 				"Failed to extract emote GLTF for scene emote: %s (hash: %s)"
-				% [scene_emote_urn, parsed.glb_hash]
+				% [scene_emote_urn, glb_hash]
 			)
 		)
 		return
@@ -523,7 +540,7 @@ func _async_load_scene_emote_as_wearable(scene_emote_urn: String):
 		)
 		return
 	# Use the unified storage function with scene-specific flags
-	_load_emote_from_gltf_internal(scene_emote_urn, obj, parsed.glb_hash, true, parsed.looping)
+	_load_emote_from_gltf_internal(scene_emote_urn, obj, glb_hash, true, looping)
 
 
 func _has_emote(emote_urn: String) -> bool:
@@ -593,12 +610,17 @@ func _load_emote_from_gltf_internal(
 	emote_item_data.looping = looping
 
 	if obj.default_animation != null:
-		var anim_name = obj.default_animation.get_name()
-		if anim_name.is_empty():
-			if from_scene:
-				anim_name = "scene_emote_" + file_hash.substr(0, 8)
-			else:
-				anim_name = "emote_" + file_hash.substr(0, 8)
+		# The emotes library is shared across ALL of an avatar's emotes, but
+		# independent emote GLBs frequently ship the same internal animation name
+		# (e.g. every clip in this scene is named "Armature" or "Animation").
+		# Keying the library by that raw name collides, so the 2nd emote silently
+		# reuses the 1st emote's clip — the emote "never changes". Namespace the
+		# key by the per-GLB content hash so every emote stays distinct, and so
+		# cleaning up one emote can't remove a clip another emote still references.
+		var raw_anim_name = obj.default_animation.get_name()
+		if raw_anim_name.is_empty():
+			raw_anim_name = "scene_emote" if from_scene else "emote"
+		var anim_name = (file_hash + "_" + raw_anim_name).replace("/", "_").replace(":", "_")
 
 		# If we have both avatar and prop animations, merge them into one
 		# Always duplicate the animation to avoid sharing references between avatar instances


### PR DESCRIPTION
Closes #2219

## Summary

Scene-triggered avatar emotes (`triggerSceneEmote`) did not play on the **local/main player**, while the very same clips animated correctly on scene-spawned avatars and `GltfContainer`s (the NPC / training bot). Reproduced in the **Goal Legends Arena** scene: the kicker/goalkeeper (you) stayed frozen while the bot played its animations.

Root cause was **two** independent bugs in the local-player scene-emote path. The NPC/bot dodges both because it uses the `Animator` component on a single GLB with distinctly-named clips, not the avatar emote pipeline.

### Bug 1 — scene emote never loads when a content hash contains `-`
The scene-emote URN is `urn:decentraland:off-chain:scene-emote:{scene_id}-{glb_hash}-{loop}`. `EmoteSceneUrn` parsed it by splitting on `-`, but **preview** content hashes are `b64-<base64-of-path>` and contain a dash. The split dropped the `b64-` prefix from `glb_hash` and corrupted `scene_id`, so the content-registry lookup missed and the GLB never loaded:

```
Failed to load scene emote: urn:...:scene-emote:b64-...=-b64-...K_intro_emote.glb...-false
Emote urn:...K_intro_emote...-false not found from player
```

Deployed CID hashes (`bafkrei...`) have no dashes, so this only surfaced in preview.

**Fix:** resolve the URN against the registry that Rust populates via `register_scene_emote_content()` immediately before `async_play_emote()` — an exact, unambiguous match regardless of dashes. The old dash-split parse is kept as a fallback for dashless CID hashes / remote players.

### Bug 2 — every scene emote plays the first-loaded clip ("animation never changes")
Independent emote GLBs frequently ship the **same internal animation name**. In this scene every clip is named either `Armature` (K_intro, GK_shoot_L/C/R) or `Animation` (GK_intro, K_shoot). They all share one `AnimationLibrary` on the avatar, keyed by that raw name, so after the first `Armature`/`Animation` is added, every later emote with the same name hit `has_animation()` and silently reused the first clip.

**Fix:** namespace the library key by the per-GLB content hash, so every emote is distinct. This also fixes a latent cleanup bug where removing one emote could delete a clip another emote still referenced.

## Verification (desktop, `--emulate-ios`, preview)
Reproduced live against the hosted scene. Captured the restricted-action + emote-load logs before/after:

| | triggers | "Failed to load scene emote" | "not found from player" |
|---|---|---|---|
| before | 4 | 4 | 4 |
| after  | 7 | **0** | **0** |

With temporary instrumentation, distinct scene emotes now register under distinct library keys (e.g. `…GK_intro_emote.glb…_…` vs `…GK_shoot_L_emote.glb…_…`) and play distinct animations. Confirmed working in-game.

## Scope / risk
- GDScript only (no Rust rebuild). `gdformat` + `gdlint` clean.
- `default_anim_name` is only used internally (store / play / cleanup), so re-keying the shared library is contained to the emote controller.