### PR TITLE
feat:add CL_MAIN_PLAYER collision layer to distinguish main player from remote players

### DIFF
--- a/godot/src/decentraland_components/avatar/avatar.gd
+++ b/godot/src/decentraland_components/avatar/avatar.gd
@@ -9,6 +9,12 @@ enum LODState { FULL, MID, CROSSFADE, FAR }
 # Debug to store each avatar loaded in user://avatars
 const DEBUG_SAVE_AVATAR_DATA = false
 
+# Collision layers (mirrors decentraland.sdk.components.ColliderLayer)
+# CL_PLAYER (4) is set on every avatar; CL_MAIN_PLAYER (8) is added on top for the
+# local player so scenes can distinguish the main player from remote avatars.
+const CL_PLAYER = 4
+const CL_MAIN_PLAYER = 8
+
 # Useful to filter wearable categories (and distinguish between top_head and head)
 const WEARABLE_NAME_PREFIX = "__"
 
@@ -295,6 +301,11 @@ func setup_trigger_detection(p_entity_id: int) -> void:
 
 	# Set metadata on TriggerDetector so trigger_area.rs can identify this avatar
 	trigger_detector.set_meta("dcl_entity_id", dcl_entity_id)
+
+	# The local (main) player also lives on the CL_MAIN_PLAYER layer so scenes can
+	# tell it apart from remote avatars. Remote avatars stay on CL_PLAYER only.
+	if is_local_player:
+		trigger_detector.collision_layer = CL_PLAYER | CL_MAIN_PLAYER
 
 	# Enable the collision shape
 	trigger_detector.get_node("CollisionShape3D").disabled = false

--- a/lib/src/scene_runner/components/trigger_area.rs
+++ b/lib/src/scene_runner/components/trigger_area.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::sync::Mutex;
 
 use godot::{classes::PhysicsServer3D, obj::Singleton, prelude::*};
@@ -28,7 +28,12 @@ use crate::{
     },
 };
 
+// Collision layers (mirrors decentraland.sdk.components.ColliderLayer).
 const CL_PLAYER: u32 = 4;
+const CL_MAIN_PLAYER: u32 = 8;
+/// Bits used to tag an avatar collider. The local (main) player carries both
+/// CL_PLAYER and CL_MAIN_PLAYER; remote avatars carry only CL_PLAYER.
+const PLAYER_LAYERS: u32 = CL_PLAYER | CL_MAIN_PLAYER;
 
 // ============================================================================
 // Global Monitor Registry for PhysicsServer3D Callbacks
@@ -120,22 +125,25 @@ fn handle_body_monitor_event(
             return;
         }
 
-        // Check if this is an avatar (has CL_PLAYER layer)
-        let is_avatar = object
+        // Read the collider's layer bits. Avatars carry CL_PLAYER (and the local
+        // player additionally CL_MAIN_PLAYER); scene entities do not.
+        let avatar_layers = object
             .clone()
             .try_cast::<godot::classes::CollisionObject3D>()
             .ok()
-            .map(|co| (co.get_collision_layer() & CL_PLAYER) != 0)
-            .unwrap_or(false);
+            .map(|co| co.get_collision_layer() & PLAYER_LAYERS)
+            .unwrap_or(0);
 
-        if is_avatar {
+        if avatar_layers != 0 {
             // Avatar detection (local player or remote avatar)
             // AvatarShapes (scene NPCs) don't have trigger detection enabled, so they can't reach here
             if !object.has_meta("dcl_entity_id") {
                 return;
             }
             let dcl_entity_id = object.get_meta("dcl_entity_id").to::<i32>();
-            (SceneEntityId::from_i32(dcl_entity_id), CL_PLAYER)
+            // Report the avatar's actual layers so scenes can distinguish the main
+            // player (CL_PLAYER | CL_MAIN_PLAYER) from remote avatars (CL_PLAYER).
+            (SceneEntityId::from_i32(dcl_entity_id), avatar_layers)
         } else if object.has_meta("dcl_entity_id") {
             // Regular DCL scene entity (not avatar)
             let dcl_entity_id = object.get_meta("dcl_entity_id").to::<i32>();
@@ -185,8 +193,11 @@ fn handle_body_monitor_event(
 pub struct TriggerAreaInstance {
     pub area_rid: Rid,
     pub shape_rid: Rid,
-    /// Set of entities physically overlapping this trigger area (tracked by physics)
-    pub entities_inside: HashSet<SceneEntityId>,
+    /// Entities physically overlapping this trigger area (tracked by physics),
+    /// mapped to the collider layer bits captured when they entered. Storing the
+    /// layer lets STAY/EXIT events report the same layers as the ENTER event
+    /// (e.g. CL_MAIN_PLAYER for the local player).
+    pub entities_inside: HashMap<SceneEntityId, u32>,
     pub mesh_type: TriggerAreaMeshType,
     pub collision_mask: u32,
     /// Whether this trigger area is active (player is in this scene)
@@ -346,7 +357,7 @@ fn check_scene_active(scene: &mut Scene, current_parcel_scene_id: &SceneId) {
 
         for (trigger_entity, instance) in &mut scene.trigger_areas.instances {
             // Generate EXIT for everyone inside
-            for entity in instance.entities_inside.drain() {
+            for (entity, collider_layer) in instance.entities_inside.drain() {
                 let trigger_transform = scene
                     .godot_dcl_scene
                     .get_node_or_null_3d(trigger_entity)
@@ -358,12 +369,6 @@ fn check_scene_active(scene: &mut Scene, current_parcel_scene_id: &SceneId) {
                     .get_node_or_null_3d(&entity)
                     .map(|n| n.get_global_transform())
                     .unwrap_or(Transform3D::IDENTITY);
-
-                let collider_layer = if entity == SceneEntityId::PLAYER {
-                    CL_PLAYER
-                } else {
-                    instance.collision_mask
-                };
 
                 let result = build_trigger_result(
                     trigger_entity,
@@ -434,7 +439,9 @@ fn process_callback_events(scene: &mut Scene) {
             .unwrap_or(Transform3D::IDENTITY);
 
         if event.is_enter {
-            instance.entities_inside.insert(event.collider_entity);
+            instance
+                .entities_inside
+                .insert(event.collider_entity, event.collider_layer);
 
             let result = build_trigger_result(
                 &event.trigger_entity,
@@ -449,7 +456,11 @@ fn process_callback_events(scene: &mut Scene) {
             scene
                 .trigger_area_results
                 .push((event.trigger_entity, result));
-        } else if instance.entities_inside.remove(&event.collider_entity) {
+        } else if instance
+            .entities_inside
+            .remove(&event.collider_entity)
+            .is_some()
+        {
             let result = build_trigger_result(
                 &event.trigger_entity,
                 &event.collider_entity,
@@ -485,7 +496,7 @@ fn generate_stay_events(scene: &mut Scene) {
             let entities: Vec<_> = instance
                 .entities_inside
                 .iter()
-                .map(|e| (*e, instance.collision_mask))
+                .map(|(entity, layer)| (*entity, *layer))
                 .collect();
 
             let trigger_transform = scene
@@ -500,18 +511,12 @@ fn generate_stay_events(scene: &mut Scene) {
 
     // Generate STAY events
     for (trigger_entity, entities, trigger_transform) in stay_data {
-        for (collider_entity, collision_mask) in entities {
+        for (collider_entity, collider_layer) in entities {
             let collider_transform = scene
                 .godot_dcl_scene
                 .get_node_or_null_3d(&collider_entity)
                 .map(|n| n.get_global_transform())
                 .unwrap_or(Transform3D::IDENTITY);
-
-            let collider_layer = if collider_entity == SceneEntityId::PLAYER {
-                CL_PLAYER
-            } else {
-                collision_mask
-            };
 
             let result = build_trigger_result(
                 &trigger_entity,
@@ -612,7 +617,7 @@ fn create_or_update_trigger_area(
             TriggerAreaInstance {
                 area_rid,
                 shape_rid,
-                entities_inside: HashSet::new(),
+                entities_inside: HashMap::new(),
                 mesh_type,
                 collision_mask,
                 is_active,


### PR DESCRIPTION
## Summary

  Adds support for the new `CL_MAIN_PLAYER` collision layer (protocol PR
  decentraland/protocol#414), letting scenes tell the local (main) player apart
  from remote avatars by bitmask alone — no more filtering by address.

  The local player's avatar collider now carries both `CL_PLAYER (4)` and
  `CL_MAIN_PLAYER (8)`; remote avatars keep `CL_PLAYER (4)` only. Trigger areas
  report the avatar's actual layer bits, so a result's `layers` field is `12`
  for the main player and `4` for remote avatars.

  ## Changes

  - **`mesh_collider.proto`**: rename `CL_RESERVED2 = 8` → `CL_MAIN_PLAYER = 8`,
    clarify `CL_PLAYER` comment.
  - **`avatar.gd`**: tag the local player's `TriggerDetector` with
    `CL_PLAYER | CL_MAIN_PLAYER`; remote avatars unchanged.
  - **`trigger_area.rs`**: report the collider's real layer bits across
    ENTER/STAY/EXIT. `entities_inside` is now a `HashMap<SceneEntityId, u32>`
    storing the layer captured at ENTER, so STAY/EXIT report the same layers as
    ENTER (removes the old `== PLAYER` heuristic that mislabeled remote avatars).

  ## Verification

  A test scene at parcel **-31,19** has two labeled trigger boxes:
  - **Area A** — `collision_mask = CL_PLAYER (4)`
  - **Area B** — `collision_mask = CL_MAIN_PLAYER (8)`

  How to use it: walk in and watch each box's `PBTriggerAreaResult.trigger.layers`.
  Area A fires for any avatar (main reports `12`, remote reports `4`); Area B fires
  **only** for the main player. With a second client in the parcel you can confirm a
  remote avatar reports `4` in Area A and is rejected by Area B even while standing
  inside it. (Live state is easy to read over the debug WS server on `127.0.0.1:9230`,
  querying each box entity's `sdk_gos.TriggerAreaResult`.)

  Built clean (`cargo check`/`clippy`, `gdformat`/`gdlint`) and validated live with
  two connected clients:

  | Case | Expected | Observed |
  |---|---|---|
  | Main player in Area A (`CL_PLAYER`) | `layers=12` | ✅ |
  | Remote avatar in Area A (`CL_PLAYER`) | `layers=4` | ✅ (STAY + EXIT) |
  | Main player in Area B (`CL_MAIN_PLAYER`) | matched | ✅ |
  | Remote avatar standing inside Area B | rejected | ✅ absent |

  Closes #2227