### PR TITLE
fix: emote prop (e.g. ball) mis-positioned on the avatar

### DIFF
--- a/godot/src/decentraland_components/avatar/avatar_emote_controller.gd
+++ b/godot/src/decentraland_components/avatar/avatar_emote_controller.gd
@@ -332,6 +332,24 @@ func _force_play_emote(emote_urn: String):
 	playing_loop = false
 
 
+## Legacy hotfix for emote props baked before the prop-origin fix.
+## Those assets only had their basis flipped 180° (not their translation), so a prop
+## authored at an offset from the avatar root (e.g. a ball ~1.5m in front of the kicker)
+## ends up mirrored through the avatar. Correctly-processed assets carry the
+## `prop_origin_corrected` metadata flag (set in Rust emote.rs); legacy optimized/runtime
+## .scn don't, so complete the flip here — rotate the origin 180° about Y (negate x/z) —
+## once, then stamp the node so it can't be double-corrected. Props anchored at the avatar
+## origin (most emotes) are unaffected since their origin is ~zero.
+func _hotfix_legacy_prop_origin(prop: Node3D) -> void:
+	if prop == null:
+		return
+	if bool(prop.get_meta("prop_origin_corrected", false)):
+		return
+	var p: Vector3 = prop.position
+	prop.position = Vector3(-p.x, p.y, -p.z)
+	prop.set_meta("prop_origin_corrected", true)
+
+
 func _hide_all_props():
 	# Hide all prop armatures to ensure clean state before playing new emote
 	if not is_instance_valid(avatar):
@@ -591,6 +609,7 @@ func _load_emote_from_gltf_internal(
 			if not avatar.has_node(NodePath(prop_name)):
 				armature_prop = obj.armature_prop
 				armature_prop.set_owner(null)
+				_hotfix_legacy_prop_origin(armature_prop)
 
 				var prop_anim_player = armature_prop.get_node_or_null("AnimationPlayer")
 				if prop_anim_player != null:

--- a/lib/src/content/gltf/emote.rs
+++ b/lib/src/content/gltf/emote.rs
@@ -1,7 +1,7 @@
 //! Emote GLTF loading (for ContentProvider emote loading).
 
 use godot::{
-    builtin::{Quaternion, VarArray},
+    builtin::{Basis, Quaternion, VarArray, Vector3},
     classes::{animation::TrackType, Animation, AnimationLibrary, AnimationPlayer, Node, Node3D},
     meta::ToGodot,
     obj::{Gd, NewAlloc},
@@ -86,7 +86,29 @@ pub fn process_emote_animations(
         .and_then(|v| v.clone().try_cast::<Node3D>().ok())
         .map(|mut node| {
             node.set_name(&format!("Armature_Prop_{}", anim_sufix_from_hash));
-            node.rotate_y(std::f32::consts::PI);
+            // The avatar body is rendered 180° flipped relative to the emote GLB's
+            // authoring frame (the flip is baked into avatar.tscn's Skeleton3D). The prop
+            // armature is a sibling of the avatar armature in the GLB, so it needs the SAME
+            // 180° flip about the avatar's vertical axis to stay aligned with the body.
+            //
+            // `rotate_y()` only rotates the basis and leaves the node's translation
+            // untouched, so a prop authored at an offset from the avatar root (e.g. a soccer
+            // ball sitting 1.5m in front of the kicker) keeps that offset un-flipped and ends
+            // up behind the avatar / on the wrong side. Rotate the *whole* transform (origin
+            // included) so the offset pivots about the avatar root. Props anchored at the
+            // root (offset ≈ 0) are unaffected, which is why this only ever mis-placed props
+            // authored away from the avatar origin.
+            let rot = Basis::from_axis_angle(Vector3::UP, std::f32::consts::PI);
+            let mut t = node.get_transform();
+            t.basis = rot * t.basis;
+            t.origin = rot * t.origin;
+            node.set_transform(t);
+            // Stamp the prop so the client can tell a correctly-processed asset from a legacy
+            // one. Assets baked before this fix only had their basis flipped (not their
+            // origin); they lack this flag, so the client applies a load-time hotfix that
+            // completes the flip. This flag (serialized into the .scn) prevents double-fixing
+            // an already-correct asset. See avatar_emote_controller.gd::_load_emote_from_gltf_internal.
+            node.set_meta("prop_origin_corrected", &true.to_variant());
             node
         });
 


### PR DESCRIPTION
## Problem

Emote props baked into an emote GLB — an `Armature_Prop` sibling of the avatar armature, e.g. the soccer **ball** in `goal-legends-arena` — were rendered in the wrong place. During the held pose the ball had a large constant offset (it sat **behind** the kicker, on the wrong side); the offset became less obvious during the multi-meter kick travel.

The bot's ball looked fine because the bot uses a **separate scene `ball.glb`** the scene positions directly — not an emote prop — so it was never a like-for-like comparison.

## Root cause

When the explorer attaches an emote prop it flips it 180° to match the avatar's in-engine orientation, but `process_emote_animations` used `node.rotate_y(PI)`, which rotates **only the basis** and leaves the translation untouched. Decoding `avatar.tscn`'s `Skeleton3D` transform shows the avatar→GLB flip is exactly **180° about Y**, so the prop's *offset* must pivot about the avatar root too. A prop authored ~1.5 m in front of the kicker therefore got mirrored to ~1.5 m **behind** it (and the side flipped).

Props anchored at the avatar origin (most emotes — props held in hand at the root) were unaffected, which is why nobody hit this until a scene placed a prop at an offset. It only became visible at all after #2232 made scene emotes actually play on the local player (before, the local avatar stayed frozen).

## Fix

- **`emote.rs`** — rotate the **whole** prop transform (origin + basis) 180° about Y, and stamp `prop_origin_corrected` metadata on the prop node (serialized into the `.scn`).
- **`avatar_emote_controller.gd`** — legacy load-time hotfix. Assets baked **before** this fix (cached optimized `<hash>-mobile.zip` and on-device runtime `emote_<hash>.scn`) only had their basis flipped and lack the flag, so the client completes the flip on attach (rotate origin 180° about Y) once, then stamps it. Flag-gated + idempotent → an already-correct asset is never double-flipped.

### Why no re-bake / no cache bump
The fix is applied at **processing/bake time** (the same `load_and_save_emote_gltf` runs both on-device and in the offline `asset_server` packer), so existing optimized ZIPs have the bug baked in and a `LOCAL_ASSETS_CACHE_VERSION` wipe would just re-download the same buggy ZIP. The metadata flag + client hotfix repairs **both** legacy optimized assets and legacy runtime caches at load — so this PR needs **no optimized re-bake and no forced full cache wipe**.

## Verification (live, via debug WS `eval`)

| Case | Result |
|---|---|
| New asset (process → save → load) | `local_pos = (0.5, 0, -1.5)`, basis `-180°`, `prop_origin_corrected = true` → hotfix skips it ✓ |
| Legacy asset (no flag) | `(-0.5, 0, 1.5)` → `(0.5, 0, -1.5)`, flag set ✓ |
| Idempotency (run twice) | stays `(0.5, 0, -1.5)` ✓ |

Before the fix the ball measured ~4 m **behind** the foot; after, it sits ~1 m **in front**, tracking the body through the kick.

## Notes
- Adding the `build` label to get an iOS TestFlight + Android build for on-device verification.