### PR TITLE
hotfix: cherry-pick fixes from main to release

### DIFF
--- a/godot/export_presets.cfg
+++ b/godot/export_presets.cfg
@@ -33,7 +33,9 @@ gradle_build/compress_native_libraries=false
 gradle_build/export_format=0
 gradle_build/min_sdk=""
 gradle_build/target_sdk="35"
-gradle_build/custom_theme_attributes={}
+gradle_build/custom_theme_attributes={
+"[splash]windowSplashScreenAnimatedIcon": "@mipmap/icon"
+}
 architectures/armeabi-v7a=false
 architectures/arm64-v8a=true
 architectures/x86=false

--- a/godot/export_presets.cfg
+++ b/godot/export_presets.cfg
@@ -40,7 +40,7 @@ architectures/armeabi-v7a=false
 architectures/arm64-v8a=true
 architectures/x86=false
 architectures/x86_64=true
-version/code=68
+version/code=70
 version/name="1.0"
 package/unique_name="org.decentraland.godotexplorer"
 package/name="Decentraland"
@@ -294,8 +294,8 @@ application/provisioning_profile_specifier_release=""
 application/export_method_release=1
 application/bundle_identifier="org.decentraland.godotexplorer"
 application/signature=""
-application/short_version="1.7"
-application/version="68"
+application/short_version="1.8"
+application/version="70"
 application/additional_plist_content="	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>

--- a/godot/src/decentraland_components/avatar/avatar.gd
+++ b/godot/src/decentraland_components/avatar/avatar.gd
@@ -1714,6 +1714,35 @@ func get_scene_emote_info(scene_id: String, glb_hash: String) -> Dictionary:
 	return {"base_url": Global.realm.content_base_url, "audio_hash": ""}
 
 
+## Resolve a scene-emote URN back to its registered (scene_id, glb_hash) and content.
+## The URN format `scene-emote:{scene_id}-{glb_hash}-{loop}` is ambiguous to dash-split
+## when the ids contain '-' — which is exactly the case for preview content, whose hashes
+## look like `b64-<base64-of-path>`. Splitting on '-' then drops the `b64-` prefix from
+## glb_hash and corrupts scene_id, the registry lookup misses, and the emote never loads.
+## Instead we match the URN against the registry that Rust populated via
+## register_scene_emote_content() right before async_play_emote(), which is unambiguous.
+## Returns {scene_id, glb_hash, base_url, audio_hash, looping} or {} when no entry matches.
+func find_scene_emote_by_urn(emote_urn: String) -> Dictionary:
+	for scene_id in _scene_emote_registry:
+		var scene_data = _scene_emote_registry[scene_id]
+		for glb_hash in scene_data["emotes"]:
+			for looping in [false, true]:
+				var loop_str := "true" if looping else "false"
+				var candidate := (
+					"urn:decentraland:off-chain:scene-emote:%s-%s-%s"
+					% [scene_id, glb_hash, loop_str]
+				)
+				if candidate == emote_urn:
+					return {
+						"scene_id": scene_id,
+						"glb_hash": glb_hash,
+						"base_url": scene_data["base_url"],
+						"audio_hash": scene_data["emotes"][glb_hash],
+						"looping": looping,
+					}
+	return {}
+
+
 ## Play emote triggered by AvatarShape's expression_trigger_id field.
 ## Supports: default emotes (e.g. "wave"), URN emotes, and local scene emotes (.glb/.gltf)
 func _async_play_expression_trigger(emote_id: String) -> void:

--- a/godot/src/decentraland_components/avatar/avatar_emote_controller.gd
+++ b/godot/src/decentraland_components/avatar/avatar_emote_controller.gd
@@ -332,6 +332,24 @@ func _force_play_emote(emote_urn: String):
 	playing_loop = false
 
 
+## Legacy hotfix for emote props baked before the prop-origin fix.
+## Those assets only had their basis flipped 180° (not their translation), so a prop
+## authored at an offset from the avatar root (e.g. a ball ~1.5m in front of the kicker)
+## ends up mirrored through the avatar. Correctly-processed assets carry the
+## `prop_origin_corrected` metadata flag (set in Rust emote.rs); legacy optimized/runtime
+## .scn don't, so complete the flip here — rotate the origin 180° about Y (negate x/z) —
+## once, then stamp the node so it can't be double-corrected. Props anchored at the avatar
+## origin (most emotes) are unaffected since their origin is ~zero.
+func _hotfix_legacy_prop_origin(prop: Node3D) -> void:
+	if prop == null:
+		return
+	if bool(prop.get_meta("prop_origin_corrected", false)):
+		return
+	var p: Vector3 = prop.position
+	prop.position = Vector3(-p.x, p.y, -p.z)
+	prop.set_meta("prop_origin_corrected", true)
+
+
 func _hide_all_props():
 	# Hide all prop armatures to ensure clean state before playing new emote
 	if not is_instance_valid(avatar):
@@ -591,6 +609,7 @@ func _load_emote_from_gltf_internal(
 			if not avatar.has_node(NodePath(prop_name)):
 				armature_prop = obj.armature_prop
 				armature_prop.set_owner(null)
+				_hotfix_legacy_prop_origin(armature_prop)
 
 				var prop_anim_player = armature_prop.get_node_or_null("AnimationPlayer")
 				if prop_anim_player != null:

--- a/godot/src/decentraland_components/avatar/avatar_emote_controller.gd
+++ b/godot/src/decentraland_components/avatar/avatar_emote_controller.gd
@@ -469,20 +469,37 @@ func _async_load_emote(emote_urn: String):
 ## Load a scene emote using the same code path as wearable emotes.
 ## This is the key to unification - scene emotes are stored in loaded_emotes_by_urn just like wearables.
 func _async_load_scene_emote_as_wearable(scene_emote_urn: String):
-	# Parse the URN to extract scene_id, glb_hash, looping
-	var parsed = EmoteSceneUrn.new(scene_emote_urn)
-	if not parsed.is_valid:
-		printerr("Failed to parse scene emote URN: %s" % scene_emote_urn)
-		return
+	# Resolve the URN to its registered content. Match against the registry
+	# (populated by Rust before async_play_emote) rather than dash-splitting the
+	# URN — preview hashes look like `b64-<base64>` and contain '-', which breaks
+	# the split and yields a wrong scene_id/glb_hash, so the emote never loads.
+	var glb_hash: String
+	var base_url: String
+	var audio_hash: String
+	var looping: bool
 
-	# Get content info from registry (registered by Rust before calling async_play_emote)
-	var info = avatar.get_scene_emote_info(parsed.scene_id, parsed.glb_hash)
-	var base_url = info["base_url"]
-	var audio_hash = info["audio_hash"]
+	var resolved = avatar.find_scene_emote_by_urn(scene_emote_urn)
+	if not resolved.is_empty():
+		glb_hash = resolved["glb_hash"]
+		base_url = resolved["base_url"]
+		audio_hash = resolved["audio_hash"]
+		looping = resolved["looping"]
+	else:
+		# Fallback: dash-split parse (correct for dashless CID hashes, e.g. deployed
+		# content) and the realm-URL fallback for remote players not in the registry.
+		var parsed = EmoteSceneUrn.new(scene_emote_urn)
+		if not parsed.is_valid:
+			printerr("Failed to parse scene emote URN: %s" % scene_emote_urn)
+			return
+		var info = avatar.get_scene_emote_info(parsed.scene_id, parsed.glb_hash)
+		glb_hash = parsed.glb_hash
+		base_url = info["base_url"]
+		audio_hash = info["audio_hash"]
+		looping = parsed.looping
 
 	# Create content mapping (same structure as wearables use)
 	# Note: base_url from scene already includes "contents/" typically
-	var files_dict = {"emote.glb": parsed.glb_hash}
+	var files_dict = {"emote.glb": glb_hash}
 	if not audio_hash.is_empty():
 		files_dict["emote.mp3"] = audio_hash
 
@@ -499,18 +516,18 @@ func _async_load_scene_emote_as_wearable(scene_emote_urn: String):
 		Global.cli.only_no_optimized_scene_emotes or Global.cli.only_no_optimized
 	)
 	var scene_path = await emote_loader.async_load_emote_from_mapping(
-		parsed.glb_hash, "emote.glb", content_mapping, force_runtime_only
+		glb_hash, "emote.glb", content_mapping, force_runtime_only
 	)
 	if scene_path.is_empty():
 		printerr("Failed to load scene emote: %s" % scene_emote_urn)
 		return
 
-	var obj = await emote_loader.async_get_emote_gltf(parsed.glb_hash)
+	var obj = await emote_loader.async_get_emote_gltf(glb_hash)
 	if obj == null:
 		printerr(
 			(
 				"Failed to extract emote GLTF for scene emote: %s (hash: %s)"
-				% [scene_emote_urn, parsed.glb_hash]
+				% [scene_emote_urn, glb_hash]
 			)
 		)
 		return
@@ -523,7 +540,7 @@ func _async_load_scene_emote_as_wearable(scene_emote_urn: String):
 		)
 		return
 	# Use the unified storage function with scene-specific flags
-	_load_emote_from_gltf_internal(scene_emote_urn, obj, parsed.glb_hash, true, parsed.looping)
+	_load_emote_from_gltf_internal(scene_emote_urn, obj, glb_hash, true, looping)
 
 
 func _has_emote(emote_urn: String) -> bool:
@@ -593,12 +610,17 @@ func _load_emote_from_gltf_internal(
 	emote_item_data.looping = looping
 
 	if obj.default_animation != null:
-		var anim_name = obj.default_animation.get_name()
-		if anim_name.is_empty():
-			if from_scene:
-				anim_name = "scene_emote_" + file_hash.substr(0, 8)
-			else:
-				anim_name = "emote_" + file_hash.substr(0, 8)
+		# The emotes library is shared across ALL of an avatar's emotes, but
+		# independent emote GLBs frequently ship the same internal animation name
+		# (e.g. every clip in this scene is named "Armature" or "Animation").
+		# Keying the library by that raw name collides, so the 2nd emote silently
+		# reuses the 1st emote's clip — the emote "never changes". Namespace the
+		# key by the per-GLB content hash so every emote stays distinct, and so
+		# cleaning up one emote can't remove a clip another emote still references.
+		var raw_anim_name = obj.default_animation.get_name()
+		if raw_anim_name.is_empty():
+			raw_anim_name = "scene_emote" if from_scene else "emote"
+		var anim_name = (file_hash + "_" + raw_anim_name).replace("/", "_").replace(":", "_")
 
 		# If we have both avatar and prop animations, merge them into one
 		# Always duplicate the animation to avoid sharing references between avatar instances

--- a/godot/src/global.gd
+++ b/godot/src/global.gd
@@ -716,6 +716,15 @@ func sign_out() -> void:
 
 	# 2. Stop session pollers and tear down the social gRPC streams.
 	NotificationsManager.stop_polling()
+	# Wipe the previous account's in-memory notification history so it can't leak
+	# into the next session's panel/bell badge (issue #2104).
+	NotificationsManager.clear_notification_history()
+	# Drop the previous account's event reminders so they can't fire on the
+	# device after sign-out. Only "event_" entries (per-account attended-event
+	# reminders) are cleared; the per-install day1 welcome is preserved. The
+	# sync-on-next-login REMOVE pass only runs for an authenticated account, so
+	# without this a signed-out/guest session keeps the old reminders scheduled.
+	NotificationsManager.clear_event_local_notifications()
 	# The analytics first-move poll (a Timer under this autoload) reads
 	# scene_runner.player_body_node; left running it would poll the freed Player
 	# after the swap, panicking the #[var] getter. It restarts on the next login.

--- a/godot/src/notifications_manager.gd
+++ b/godot/src/notifications_manager.gd
@@ -147,6 +147,18 @@ func stop_polling() -> void:
 		_poll_timer.stop()
 
 
+## Clear the in-memory server notification history and pending toast queue.
+## Used on sign-out so a previous account's notifications don't leak into the
+## next session (issue #2104). NotificationsManager is an autoload that survives
+## the lobby scene swap, so without this the cached list persists across accounts.
+## Emitting notifications_updated refreshes the open panel and the bell badge.
+func clear_notification_history() -> void:
+	_notifications.clear()
+	_notification_queue.clear()
+	_previous_notification_ids.clear()
+	notifications_updated.emit()
+
+
 ## Get currently cached notifications sorted by timestamp descending (newest first)
 func get_notifications() -> Array:
 	var sorted = _notifications.duplicate()
@@ -829,6 +841,21 @@ func force_queue_sync() -> void:
 	_sync_notification_queue()
 
 
+## Clear account-scoped event reminder notifications (used on sign-out).
+##
+## Only removes "event_"-prefixed entries — the per-account attended-event
+## reminders, which are derived from whoever was signed in. The per-install
+## "day1_welcome" notification is intentionally preserved (it belongs to the
+## device/install, not the session). This both cancels the pending OS
+## notification and deletes the database row, so a signed-out account's
+## reminders can no longer fire on the device.
+func clear_event_local_notifications() -> void:
+	for notif in get_queued_local_notifications():
+		var notif_id: String = notif.get("id", "")
+		if notif_id.begins_with("event_"):
+			cancel_queued_local_notification(notif_id)
+
+
 ## Check if local notifications version has changed and clear all if needed
 ## Returns true if notifications were cleared due to version mismatch
 func _check_and_handle_version_change() -> bool:
@@ -899,7 +926,12 @@ func async_sync_attended_events() -> void:
 	# _on_permission_changed. Trigger day1 here instead — its own guards handle dedup.
 	async_schedule_day1_notification.call_deferred()
 
-	var url = DclUrls.mobile_events_api() + "/?only_attendee=true"
+	# Use the canonical events service (events.decentraland.org/api/events): when
+	# signed it reports a correct per-user `attending` flag on each event — the same
+	# source the REMIND ME button reads/writes. The mobile-bff `?only_attendee=true`
+	# endpoint ignores the param and always returns `attending=false`, so the sync
+	# never restored reminders.
+	var url = DclUrls.events_api()
 	var response = await Global.async_signed_fetch(url, HTTPClient.METHOD_GET, "")
 
 	if response is PromiseError:
@@ -913,8 +945,9 @@ func async_sync_attended_events() -> void:
 
 	var all_events: Array = json.get("data", [])
 
-	# Filter locally to only use events where attending=true
-	# This is a workaround until the API's only_attendee parameter is fixed
+	# Keep only events the signed user is attending. events_api() populates a correct
+	# per-user `attending` flag when the request is signed (unlike the mobile-bff
+	# `only_attendee` endpoint, which always returns false).
 	var events: Array = []
 	for event_data in all_events:
 		if event_data.get("attending", false) == true:

--- a/godot/src/ui/explorer.tscn
+++ b/godot/src/ui/explorer.tscn
@@ -111,6 +111,76 @@ grow_horizontal = 2
 grow_vertical = 2
 script = ExtResource("1_mcinput")
 
+[node name="LeftRightSafeContainerMobile" type="MarginContainer" parent="UI" unique_id=1539864391]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+mouse_filter = 2
+theme_override_constants/margin_top = 0
+script = ExtResource("5_c8ksg")
+use_top = false
+use_bottom = false
+
+[node name="MobileUI" type="Control" parent="UI/LeftRightSafeContainerMobile" unique_id=1539864390]
+unique_name_in_owner = true
+layout_mode = 2
+mouse_filter = 2
+
+[node name="Joypad" parent="UI/LeftRightSafeContainerMobile/MobileUI" unique_id=275799521 instance=ExtResource("7_admxk")]
+unique_name_in_owner = true
+editor_description = "Action buttons, to jump and interact."
+layout_mode = 1
+
+[node name="VirtualJoystick_Left" parent="UI/LeftRightSafeContainerMobile/MobileUI" unique_id=858042680 node_paths=PackedStringArray("margin_control") instance=ExtResource("9_lxw33")]
+unique_name_in_owner = true
+editor_description = "Virtual joystick to control avatar movement."
+layout_mode = 1
+deadzone_size = 0.0
+margin_control = NodePath("../..")
+
+[node name="Label_Crosshair" type="Label" parent="UI" unique_id=2000293560]
+unique_name_in_owner = true
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -13.0
+offset_top = -14.0
+offset_right = 13.0
+offset_bottom = 12.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_colors/font_color = Color(1, 1, 1, 1)
+theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
+theme_override_constants/outline_size = 1
+theme_override_fonts/font = ExtResource("16_karsc")
+theme_override_font_sizes/font_size = 20
+text = "+"
+horizontal_alignment = 1
+vertical_alignment = 1
+
+[node name="Control_PointerTooltip" parent="UI" unique_id=944970499 instance=ExtResource("11_qjs00")]
+unique_name_in_owner = true
+z_index = -4096
+layout_mode = 1
+metadata/_edit_lock_ = true
+
+[node name="SceneUIContainer" type="Control" parent="UI" unique_id=1950684600]
+unique_name_in_owner = true
+editor_description = "Single container for all per-scene SDK UI (built at runtime under 'scenes_ui'). INPUT LAYERING: Godot picks GUI input by tree order and IGNORES z_index — scanning siblings from last child to first, the first mouse_filter=STOP control under the point wins. So UI siblings AFTER this node (shown BELOW it in the Scene tree) receive input before scene UI, while siblings BEFORE it (shown ABOVE) are blocked by scene UI wherever it has a STOP control. Keep movement/camera catch-areas (joystick, MobileCameraInput) before this node, and interactive app UI (HUD panels, navbar, menus) after it."
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+mouse_filter = 2
+
 [node name="MarginContainer_ShowUI" type="MarginContainer" parent="UI" unique_id=1783716233]
 unique_name_in_owner = true
 visible = false
@@ -152,35 +222,6 @@ icon = ExtResource("27_u4dfr")
 icon_alignment = 1
 expand_icon = true
 
-[node name="Label_Crosshair" type="Label" parent="UI" unique_id=2000293560]
-unique_name_in_owner = true
-layout_mode = 1
-anchors_preset = 8
-anchor_left = 0.5
-anchor_top = 0.5
-anchor_right = 0.5
-anchor_bottom = 0.5
-offset_left = -13.0
-offset_top = -14.0
-offset_right = 13.0
-offset_bottom = 12.0
-grow_horizontal = 2
-grow_vertical = 2
-theme_override_colors/font_color = Color(1, 1, 1, 1)
-theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
-theme_override_constants/outline_size = 1
-theme_override_fonts/font = ExtResource("16_karsc")
-theme_override_font_sizes/font_size = 20
-text = "+"
-horizontal_alignment = 1
-vertical_alignment = 1
-
-[node name="Control_PointerTooltip" parent="UI" unique_id=944970499 instance=ExtResource("11_qjs00")]
-unique_name_in_owner = true
-z_index = -4096
-layout_mode = 1
-metadata/_edit_lock_ = true
-
 [node name="LeftRightSafeContainer" type="MarginContainer" parent="UI" unique_id=1210894567]
 unique_name_in_owner = true
 layout_mode = 1
@@ -198,28 +239,6 @@ use_bottom = false
 [node name="InteractableHUD" type="Control" parent="UI/LeftRightSafeContainer" unique_id=1898741314]
 layout_mode = 2
 mouse_filter = 2
-
-[node name="MobileUI" type="Control" parent="UI/LeftRightSafeContainer/InteractableHUD" unique_id=1539864390]
-unique_name_in_owner = true
-layout_mode = 1
-anchors_preset = 15
-anchor_right = 1.0
-anchor_bottom = 1.0
-grow_horizontal = 2
-grow_vertical = 2
-mouse_filter = 2
-
-[node name="Joypad" parent="UI/LeftRightSafeContainer/InteractableHUD/MobileUI" unique_id=275799521 instance=ExtResource("7_admxk")]
-unique_name_in_owner = true
-editor_description = "Action buttons, to jump and interact."
-layout_mode = 1
-
-[node name="VirtualJoystick_Left" parent="UI/LeftRightSafeContainer/InteractableHUD/MobileUI" unique_id=858042680 node_paths=PackedStringArray("margin_control") instance=ExtResource("9_lxw33")]
-unique_name_in_owner = true
-editor_description = "Virtual joystick to control avatar movement."
-layout_mode = 1
-deadzone_size = 0.0
-margin_control = NodePath("../../..")
 
 [node name="TopBottomSafeContainer" type="MarginContainer" parent="UI/LeftRightSafeContainer/InteractableHUD" unique_id=1437253374]
 layout_mode = 1
@@ -351,16 +370,6 @@ vertical_alignment = 1
 [node name="EmoteWheel" parent="UI/LeftRightSafeContainer/InteractableHUD" unique_id=228992295 instance=ExtResource("21_pows0")]
 unique_name_in_owner = true
 layout_mode = 1
-
-[node name="SceneUIContainer" type="Control" parent="UI" unique_id=1950684600]
-unique_name_in_owner = true
-layout_mode = 1
-anchors_preset = 15
-anchor_right = 1.0
-anchor_bottom = 1.0
-grow_horizontal = 2
-grow_vertical = 2
-mouse_filter = 2
 
 [node name="Timer_FPSLabel" type="Timer" parent="UI" unique_id=926156601]
 autostart = true

--- a/godot/src/ui/pages/discover/discover.gd
+++ b/godot/src/ui/pages/discover/discover.gd
@@ -197,7 +197,7 @@ func set_search_filter_text(new_text: String) -> void:
 		friends_online.visible = friends_online.has_items()
 		last_visited.visible = last_visited.has_items()
 		places_featured.show()
-		places_favorites.show()
+		places_favorites.visible = places_favorites.has_items()
 		places_my_places.visible = places_my_places.has_items()
 		places_most_active.title = "Most Actives"
 	else:
@@ -335,6 +335,10 @@ func _on_error_loading_notification() -> void:
 
 func _on_report_loading_status(status: CarrouselGenerator.LoadingStatus, container) -> void:
 	_generator_statuses[container] = status
+	# Re-hide carousels that the search filter turned off — the carousel's own
+	# _on_report_loading_status may have called show() on itself after we hid it.
+	if not search_text.is_empty() and container not in _get_active_carousels():
+		container.hide()
 	_update_global_messages()
 
 

--- a/lib/Cargo.lock
+++ b/lib/Cargo.lock
@@ -861,7 +861,7 @@ dependencies = [
 
 [[package]]
 name = "dclgodot"
-version = "0.68.0"
+version = "0.70.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dclgodot"
-version = "0.68.0"
+version = "0.70.0"
 edition = "2021"
 publish = false
 

--- a/lib/src/content/gltf/emote.rs
+++ b/lib/src/content/gltf/emote.rs
@@ -1,7 +1,7 @@
 //! Emote GLTF loading (for ContentProvider emote loading).
 
 use godot::{
-    builtin::{Quaternion, VarArray},
+    builtin::{Basis, Quaternion, VarArray, Vector3},
     classes::{animation::TrackType, Animation, AnimationLibrary, AnimationPlayer, Node, Node3D},
     meta::ToGodot,
     obj::{Gd, NewAlloc},
@@ -86,7 +86,29 @@ pub fn process_emote_animations(
         .and_then(|v| v.clone().try_cast::<Node3D>().ok())
         .map(|mut node| {
             node.set_name(&format!("Armature_Prop_{}", anim_sufix_from_hash));
-            node.rotate_y(std::f32::consts::PI);
+            // The avatar body is rendered 180° flipped relative to the emote GLB's
+            // authoring frame (the flip is baked into avatar.tscn's Skeleton3D). The prop
+            // armature is a sibling of the avatar armature in the GLB, so it needs the SAME
+            // 180° flip about the avatar's vertical axis to stay aligned with the body.
+            //
+            // `rotate_y()` only rotates the basis and leaves the node's translation
+            // untouched, so a prop authored at an offset from the avatar root (e.g. a soccer
+            // ball sitting 1.5m in front of the kicker) keeps that offset un-flipped and ends
+            // up behind the avatar / on the wrong side. Rotate the *whole* transform (origin
+            // included) so the offset pivots about the avatar root. Props anchored at the
+            // root (offset ≈ 0) are unaffected, which is why this only ever mis-placed props
+            // authored away from the avatar origin.
+            let rot = Basis::from_axis_angle(Vector3::UP, std::f32::consts::PI);
+            let mut t = node.get_transform();
+            t.basis = rot * t.basis;
+            t.origin = rot * t.origin;
+            node.set_transform(t);
+            // Stamp the prop so the client can tell a correctly-processed asset from a legacy
+            // one. Assets baked before this fix only had their basis flipped (not their
+            // origin); they lack this flag, so the client applies a load-time hotfix that
+            // completes the flip. This flag (serialized into the .scn) prevents double-fixing
+            // an already-correct asset. See avatar_emote_controller.gd::_load_emote_from_gltf_internal.
+            node.set_meta("prop_origin_corrected", &true.to_variant());
             node
         });
 


### PR DESCRIPTION
## Release Hotfix

Cherry-picks the following fixes from `main` onto `release` (chronological order), plus a version bump to **v70**.

| Commit (main) | PR | Description |
|---|---|---|
| `71729f16` | #2223 | dirty notifications on logout |
| `e072665c` | #2226 | set windowSplashScreenAnimatedIcon |
| `9796bf1c` | #2232 | fix: scene emotes not playing / never changing on the local player |
| `feb66394` | #2246 | fix: emote prop mis-positioned on the avatar |
| `50f44459` | #2235 | fix: hide non-search carousels during discover search |
| `820f0b79` | #2247 | fix: scene UI no longer blocks app UI input on mobile |

All commits cherry-picked cleanly with no conflicts. Each carries a `(cherry picked from commit ...)` reference for traceability.

### Version bump
Release was at **v68**; this PR bumps to **v70** to match `main`:
- `version/code` 68 → 70
- iOS `short_version` 1.7 → 1.8, `version` 68 → 70
- Cargo `0.68.0` → `0.70.0`

(The v70 bump on `main` — #2222 — bumps 69→70 in-file, so it couldn't be cherry-picked cleanly onto release at 68; the bump is reproduced here as a fresh commit.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
