### PR TITLE
fix: scene emotes not playing on remote players (multiplayer)

### DIFF
--- a/godot/src/decentraland_components/avatar/avatar_emote_controller.gd
+++ b/godot/src/decentraland_components/avatar/avatar_emote_controller.gd
@@ -497,14 +497,20 @@ func _async_load_scene_emote_as_wearable(scene_emote_urn: String):
 	var looping: bool
 
 	var resolved = avatar.find_scene_emote_by_urn(scene_emote_urn)
+	if resolved.is_empty():
+		# Remote players and AvatarShape triggers never populate the per-avatar
+		# registry (it's filled by Rust only on the avatar that ran
+		# triggerSceneEmote), so resolve the URN against the loaded scenes —
+		# unambiguous even when ids/hashes contain '-' (preview `b64-` hashes).
+		resolved = Global.scene_runner.resolve_scene_emote_urn(scene_emote_urn)
 	if not resolved.is_empty():
 		glb_hash = resolved["glb_hash"]
 		base_url = resolved["base_url"]
 		audio_hash = resolved["audio_hash"]
 		looping = resolved["looping"]
 	else:
-		# Fallback: dash-split parse (correct for dashless CID hashes, e.g. deployed
-		# content) and the realm-URL fallback for remote players not in the registry.
+		# Last resort: dash-split parse (correct for dashless CID hashes, e.g. deployed
+		# content, when the emote's scene is not loaded locally).
 		var parsed = EmoteSceneUrn.new(scene_emote_urn)
 		if not parsed.is_valid:
 			printerr("Failed to parse scene emote URN: %s" % scene_emote_urn)

--- a/godot/src/tool/debug_server/debug_ws_server.gd
+++ b/godot/src/tool/debug_server/debug_ws_server.gd
@@ -72,7 +72,13 @@ func _ready() -> void:
 	# manual toggle. Release/exported builds stay off until the Settings →
 	# Developer toggle. Never in production.
 	if OS.is_debug_build() and not Global.is_production():
-		start()
+		# DCL_DEBUG_WS_PORT lets a second local instance get its own inspector
+		# (the default port can only be bound by one process).
+		var port := DEFAULT_PORT
+		var env_port := OS.get_environment("DCL_DEBUG_WS_PORT")
+		if env_port.is_valid_int():
+			port = env_port.to_int()
+		start(port)
 
 
 func is_running() -> bool:

--- a/lib/src/content/content_mapping.rs
+++ b/lib/src/content/content_mapping.rs
@@ -221,7 +221,9 @@ mod tests {
     #[test]
     fn scene_emote_by_glb_hash_unknown_hash() {
         let mapping = mapping_with(&[("emote.glb", "bafkreihash")]);
-        assert!(mapping.get_scene_emote_hash_by_glb_hash("missing").is_none());
+        assert!(mapping
+            .get_scene_emote_hash_by_glb_hash("missing")
+            .is_none());
     }
 
     #[test]

--- a/lib/src/content/content_mapping.rs
+++ b/lib/src/content/content_mapping.rs
@@ -62,6 +62,20 @@ impl ContentMappingAndUrl {
         Some(SceneEmoteHash::new(glb_hash, audio_hash))
     }
 
+    /// Get scene emote data when only the GLB *hash* is known — e.g. a scene-emote
+    /// URN received from a remote player, which carries the hash but not the file path.
+    /// Reverse-looks-up the glb/gltf file for that hash, then resolves its sibling audio.
+    pub fn get_scene_emote_hash_by_glb_hash(&self, glb_hash: &str) -> Option<SceneEmoteHash> {
+        let file = self
+            .content
+            .iter()
+            .find(|(file, hash)| {
+                hash.as_str() == glb_hash && (file.ends_with(".glb") || file.ends_with(".gltf"))
+            })
+            .map(|(file, _)| file.clone())?;
+        self.get_scene_emote_hash(&file)
+    }
+
     /// Find audio file hash for a given base name (without extension).
     /// Searches for .mp3 or .ogg files with the same base name.
     fn find_audio_for_base_name(&self, base_name: &str) -> Option<String> {
@@ -159,5 +173,63 @@ impl DclContentMappingAndUrl {
         Gd::from_init_fn(move |_base| DclContentMappingAndUrl {
             inner: Arc::new(ContentMappingAndUrl::new()),
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn mapping_with(files: &[(&str, &str)]) -> ContentMappingAndUrl {
+        ContentMappingAndUrl::from_base_url_and_content(
+            "http://localhost:8001/content/contents/".into(),
+            files
+                .iter()
+                .map(|(file, hash)| TypedIpfsRef {
+                    file: file.to_string(),
+                    hash: hash.to_string(),
+                })
+                .collect(),
+        )
+    }
+
+    #[test]
+    fn scene_emote_by_glb_hash_finds_file_and_audio() {
+        // Preview-style hashes contain '-' — the reverse lookup must be exact.
+        let mapping = mapping_with(&[
+            ("assets/models/animations/k_intro_emote.glb", "b64-aGFzaA=="),
+            ("assets/models/animations/k_intro_emote.mp3", "b64-YXVkaW8="),
+            ("assets/models/other.glb", "b64-b3RoZXI="),
+        ]);
+
+        let hash = mapping
+            .get_scene_emote_hash_by_glb_hash("b64-aGFzaA==")
+            .expect("glb hash should resolve");
+        assert_eq!(hash.glb_hash, "b64-aGFzaA==");
+        assert_eq!(hash.audio_hash.as_deref(), Some("b64-YXVkaW8="));
+    }
+
+    #[test]
+    fn scene_emote_by_glb_hash_without_audio() {
+        let mapping = mapping_with(&[("emote.glb", "bafkreihash")]);
+        let hash = mapping
+            .get_scene_emote_hash_by_glb_hash("bafkreihash")
+            .expect("glb hash should resolve");
+        assert_eq!(hash.audio_hash, None);
+    }
+
+    #[test]
+    fn scene_emote_by_glb_hash_unknown_hash() {
+        let mapping = mapping_with(&[("emote.glb", "bafkreihash")]);
+        assert!(mapping.get_scene_emote_hash_by_glb_hash("missing").is_none());
+    }
+
+    #[test]
+    fn scene_emote_by_glb_hash_ignores_non_gltf_files() {
+        // A hash that belongs to a non-model file must not resolve as an emote.
+        let mapping = mapping_with(&[("emote.mp3", "bafkreiaudio")]);
+        assert!(mapping
+            .get_scene_emote_hash_by_glb_hash("bafkreiaudio")
+            .is_none());
     }
 }

--- a/lib/src/scene_runner/scene_manager.rs
+++ b/lib/src/scene_runner/scene_manager.rs
@@ -828,6 +828,54 @@ impl SceneManager {
         GString::default()
     }
 
+    /// Resolve a scene-emote URN (`urn:decentraland:off-chain:scene-emote:{scene_id}-{glb_hash}-{loop}`)
+    /// against the currently loaded scenes. The URN payload cannot be dash-split:
+    /// preview ids/hashes look like `b64-<base64>` and contain `-` themselves. Matching
+    /// the payload against each loaded scene's entity id (exact prefix) is unambiguous.
+    /// This is the path for emotes that arrive *without* local context — broadcast from
+    /// remote players over comms, or AvatarShape expression triggers — where the
+    /// per-avatar content registry used by triggerSceneEmote was never populated.
+    /// Returns `{scene_id, glb_hash, base_url, audio_hash, looping}` or `{}`.
+    #[func]
+    pub fn resolve_scene_emote_urn(&self, emote_urn: GString) -> VarDictionary {
+        const URN_PREFIX: &str = "urn:decentraland:off-chain:scene-emote:";
+        let urn = emote_urn.to_string();
+        let Some(payload) = urn.strip_prefix(URN_PREFIX) else {
+            return VarDictionary::new();
+        };
+        let (payload, looping) = if let Some(p) = payload.strip_suffix("-true") {
+            (p, true)
+        } else if let Some(p) = payload.strip_suffix("-false") {
+            (p, false)
+        } else {
+            return VarDictionary::new();
+        };
+
+        for scene in self.scenes.values() {
+            let scene_entity_id = scene.scene_entity_definition.id.as_str();
+            let Some(glb_hash) = payload
+                .strip_prefix(scene_entity_id)
+                .and_then(|rest| rest.strip_prefix('-'))
+            else {
+                continue;
+            };
+            let audio_hash = scene
+                .content_mapping
+                .get_scene_emote_hash_by_glb_hash(glb_hash)
+                .and_then(|hash| hash.audio_hash)
+                .unwrap_or_default();
+
+            let mut dict = VarDictionary::new();
+            dict.set("scene_id", scene_entity_id);
+            dict.set("glb_hash", glb_hash);
+            dict.set("base_url", scene.content_mapping.base_url.as_str());
+            dict.set("audio_hash", audio_hash);
+            dict.set("looping", looping);
+            return dict;
+        }
+        VarDictionary::new()
+    }
+
     #[func]
     fn get_scene_is_paused(&self, scene_id: i32) -> bool {
         if let Some(scene) = self.scenes.get(&SceneId(scene_id)) {


### PR DESCRIPTION
Closes #2240 

Follow-up to #2232, which fixed scene emotes for the **local** player. In **multiplayer** the same clips still never played on the *other* clients: in Goal Legends Arena, the opponent (and any spectator) saw the kicker/goalkeeper frozen in Idle for the whole match, while their own avatar animated correctly.

## Root cause

When a scene calls `triggerSceneEmote`, Rust registers the emote content (`register_scene_emote_content`) **only on the triggering player's own avatar** before playing, then broadcasts the URN over comms. On receiving clients that registry is empty, so `_async_load_scene_emote_as_wearable` fell back to dash-splitting the URN payload:

```
urn:decentraland:off-chain:scene-emote:{scene_id}-{glb_hash}-{loop}
```

Preview ids/hashes are `b64-<base64>` and contain `-` (and `=`), so the split stripped the `b64-` prefix off `glb_hash` and corrupted `scene_id`. The content lookup missed and every remote emote failed:

```
Failed to load scene emote: urn:...:scene-emote:b64-...=-b64-...K_intro_emote.glb...-false
Emote urn:... not found from player 'zsDYw8UjVo#6287'
```

The training bot was never affected (it's a `GltfContainer` + `Animator`, not an avatar emote), which is why PvE looked fine on the player's own screen. `AvatarShape` `expressionTriggerId` scene emotes had the same gap (URN built in Rust, never registered).

## Fix

- **`SceneManager::resolve_scene_emote_urn()`** (new `#[func]`): resolves the URN against the **loaded scenes' entity ids** — an exact prefix match, unambiguous no matter how many dashes the ids contain — and returns `{scene_id, glb_hash, base_url, audio_hash, looping}` from that scene's content mapping.
- **`ContentMappingAndUrl::get_scene_emote_hash_by_glb_hash()`**: reverse lookup (hash → glb file → sibling audio), so remote players now also get the emote **audio**, which the old realm-URL fallback never provided — even on deployed scenes.
- **`avatar_emote_controller.gd`**: resolution chain is now per-avatar registry (local trigger) → loaded-scenes resolver (remote players, AvatarShape) → legacy dash-split (only for dashless deployed CID hashes when the emote's scene isn't loaded locally).
- **`debug_ws_server.gd`**: `DCL_DEBUG_WS_PORT` env override so a second local instance can bind its own debug inspector — needed to verify this fix, generally useful for multiplayer debugging.

## Verification (live, two desktop clients vs LAN preview)

Ran two explorer instances on one machine (separate guest identities) against the goal-legends-arena preview; the scene's auto-PvE played full matches while the other client observed, inspected over the debug WS:

| | before | after |
|---|---|---|
| `Failed to load scene emote` / `not found from player` on observer | 4+ per match | **0** across multiple matches |
| Remote avatar state machine during rounds | pinned to `Idle` | cycles `Run → Emote → Idle` per round |
| Scene emotes loaded on the remote avatar | 0 | 6–8 (distinct library keys) |
| Ball prop on remote kicker | never appears | visible during intro/kick, hidden on idle |

Resolver edge cases checked live via `eval`: preview `b64-…=` ids resolve with correct `looping`; unknown scene returns `{}` and falls through to the legacy parse unchanged.

4 new unit tests for the reverse lookup. `cargo fmt` / `clippy -D warnings` / `gdformat` / `gdlint` clean.

## Scope / risk

Local-player emotes still resolve through the registry exactly as before — only the remote/NPC resolution path changed. If a remote player's scene isn't loaded on the observer, behavior is identical to today's fallback.