### PR TITLE
feat: add Hide Scene Interface toggle and improve mobile controls during hide UI

### DIFF
--- a/.gdlintrc
+++ b/.gdlintrc
@@ -35,7 +35,7 @@ function-preload-variable-name: ([A-Z][a-z0-9]*)+
 function-variable-name: '[a-z][a-z0-9]*(_[a-z0-9]+)*'
 load-constant-name: (([A-Z][a-z0-9]*)+|_?[A-Z][A-Z0-9]*(_[A-Z0-9]+)*)
 loop-variable-name: _?[a-z][a-z0-9]*(_[a-z0-9]+)*
-max-file-lines: 1800
+max-file-lines: 1900
 max-line-length: 9999
 max-public-methods: 40
 max-returns: 10

--- a/godot/src/global.gd
+++ b/godot/src/global.gd
@@ -30,9 +30,12 @@ signal close_combo
 signal delete_account
 ## Sync settings "Hide UI" checkbox with explorer session state (no config persistence).
 signal session_hide_ui_toggle_sync(pressed: bool)
-## Sync settings "Hide View Profile" / "Hide World Interactions" checkboxes.
+## Sync settings "Hide View Profile" / "Hide World Interactions" / etc. checkboxes.
 signal session_hide_ui_options_sync(
-	hide_view_profile: bool, hide_world_interactions: bool, hide_player_names: bool
+	hide_view_profile: bool,
+	hide_world_interactions: bool,
+	hide_player_names: bool,
+	hide_scene_ui: bool
 )
 signal camera_mode_set(camera_mode: Global.CameraMode)
 signal camera_mode_block_changed(blocked: bool)

--- a/godot/src/ui/explorer.gd
+++ b/godot/src/ui/explorer.gd
@@ -46,6 +46,7 @@ var _session_hide_view_profile: bool = true
 var _session_hide_world_interactions: bool = true
 var _session_hide_player_names: bool = true
 var _session_hide_scene_ui: bool = true
+var _mobile_controls_hidden_for_hide_ui: bool = false
 
 ## True when the debug panel was enabled from settings toggle.
 var _debug_panel_from_settings: bool = false
@@ -1062,11 +1063,32 @@ func _is_ui_hud_mode_exception(node: Node) -> bool:
 		or node == control_menu
 		or node == margin_container_show_ui
 		or node == profile_container
+		or node.name == "LeftRightSafeContainerMobile"
+		or node.name == "MobileCameraInput"
 	)
+
+
+func _apply_mobile_controls_hide_ui(hidden: bool) -> void:
+	if not Global.is_mobile():
+		return
+	_mobile_controls_hidden_for_hide_ui = hidden
+	if hidden:
+		joypad.hide()
+		virtual_joystick.modulate.a = 0.0
+	else:
+		joypad.show()
+		virtual_joystick.modulate.a = 1.0
+
+
+func _show_joypad() -> void:
+	if _mobile_controls_hidden_for_hide_ui:
+		return
+	joypad.show()
 
 
 func _set_explorer_hud_elements_visible(full_hud: bool) -> void:
 	ui_root.show()
+	_apply_mobile_controls_hide_ui(not full_hud)
 	if full_hud:
 		for node in _ui_children_hidden_for_hud_mode:
 			if is_instance_valid(node):
@@ -1224,7 +1246,7 @@ func _on_profile_container_visibility_changed() -> void:
 		# Avoid forcing hide/show here to prevent visibility_changed re-entrancy loops.
 		return
 	if not profile_container.visible:
-		joypad.show()
+		_show_joypad()
 
 
 func _open_friends_panel() -> void:
@@ -1588,6 +1610,10 @@ func _on_emote_wheel_emote_wheel_opened() -> void:
 
 
 func _update_virtual_controls_visibility() -> void:
+	if _mobile_controls_hidden_for_hide_ui:
+		joypad.hide()
+		virtual_joystick.modulate.a = 0.0
+		return
 	var panel_open := (
 		friends_panel.visible
 		or notifications_panel.visible
@@ -1595,7 +1621,7 @@ func _update_virtual_controls_visibility() -> void:
 		or profile_container.visible
 	)
 	if not panel_open:
-		joypad.show()
+		_show_joypad()
 	virtual_joystick.show()
 
 
@@ -1612,12 +1638,12 @@ func _close_all_panels():
 	_on_notifications_panel_closed()
 	_on_settings_panel_closed()
 	h_box_container_right_panels.mouse_filter = Control.MOUSE_FILTER_IGNORE
-	joypad.show()
+	_show_joypad()
 
 
 func _on_discover_open():
 	navbar.collapse()
-	joypad.show()
+	_show_joypad()
 	_on_friends_panel_closed()
 	_on_notifications_panel_closed()
 	_on_settings_panel_closed()

--- a/godot/src/ui/explorer.gd
+++ b/godot/src/ui/explorer.gd
@@ -71,6 +71,8 @@ var _debug_panel_from_settings: bool = false
 @onready var label_ram = %Label_RAM
 @onready var control_menu = %Control_Menu
 @onready var mobile_ui = %MobileUI
+@onready var mobile_camera_input: Control = %MobileCameraInput
+@onready var left_right_safe_container_mobile: MarginContainer = %LeftRightSafeContainerMobile
 @onready var virtual_joystick: Control = %VirtualJoystick_Left
 @onready var profile_container: Control = %ProfileContainer
 
@@ -1063,8 +1065,8 @@ func _is_ui_hud_mode_exception(node: Node) -> bool:
 		or node == control_menu
 		or node == margin_container_show_ui
 		or node == profile_container
-		or node.name == "LeftRightSafeContainerMobile"
-		or node.name == "MobileCameraInput"
+		or node == left_right_safe_container_mobile
+		or node == mobile_camera_input
 	)
 
 

--- a/godot/src/ui/explorer.gd
+++ b/godot/src/ui/explorer.gd
@@ -45,6 +45,7 @@ var _session_hide_main_hud: bool = false
 var _session_hide_view_profile: bool = true
 var _session_hide_world_interactions: bool = true
 var _session_hide_player_names: bool = true
+var _session_hide_scene_ui: bool = true
 
 ## True when the debug panel was enabled from settings toggle.
 var _debug_panel_from_settings: bool = false
@@ -1436,9 +1437,10 @@ func _on_loading_started() -> void:
 	_session_hide_view_profile = true
 	_session_hide_world_interactions = true
 	_session_hide_player_names = true
+	_session_hide_scene_ui = true
 	set_visible_ui(true, true)
 	Global.session_hide_ui_toggle_sync.emit(false)
-	Global.session_hide_ui_options_sync.emit(true, true, true)
+	Global.session_hide_ui_options_sync.emit(true, true, true, true)
 	_apply_hide_ui_to_avatar_nicks(false)
 
 
@@ -1479,38 +1481,38 @@ func _async_run_ban_check() -> void:
 
 func _on_orientation_changed(is_portrait: bool) -> void:
 	if is_portrait:
-		# Portrait: hide all HUD and scene UI, only chat visible
 		mobile_ui.hide()
 		emote_wheel.hide()
 		navbar.hide()
 		_set_scene_ui_visible(false)
 	else:
-		# Landscape: restore all UI
 		if Global.is_mobile():
 			mobile_ui.show()
 			_update_virtual_controls_visibility()
 		emote_wheel.show()
 		navbar._on_size_changed()
-		_set_scene_ui_visible(true)
+		_set_scene_ui_visible(_should_show_scene_ui())
 
 
 func _on_chat_write_mode_changed(is_writing: bool) -> void:
 	if Global.is_orientation_portrait():
-		return  # Portrait hides everything already
+		return
 	if is_writing:
-		# Landscape writing: hide all UI
 		mobile_ui.hide()
 		emote_wheel.hide()
 		navbar.hide()
 		_set_scene_ui_visible(false)
 	else:
-		# Landscape reading: restore all UI
 		if Global.is_mobile():
 			mobile_ui.show()
 			_update_virtual_controls_visibility()
 		emote_wheel.show()
 		navbar._on_size_changed()
-		_set_scene_ui_visible(true)
+		_set_scene_ui_visible(_should_show_scene_ui())
+
+
+func _should_show_scene_ui() -> bool:
+	return not (_session_hide_main_hud and _session_hide_scene_ui)
 
 
 func _set_scene_ui_visible(is_visible: bool) -> void:
@@ -1712,9 +1714,11 @@ func _on_button_show_ui_pressed() -> void:
 	_session_hide_view_profile = true
 	_session_hide_world_interactions = true
 	_session_hide_player_names = true
+	_session_hide_scene_ui = true
 	set_visible_ui(true, true)
+	_set_scene_ui_visible(true)
 	Global.session_hide_ui_toggle_sync.emit(false)
-	Global.session_hide_ui_options_sync.emit(true, true, true)
+	Global.session_hide_ui_options_sync.emit(true, true, true, true)
 	_apply_hide_ui_to_avatar_nicks(false)
 
 
@@ -1725,9 +1729,11 @@ func set_hide_main_hud_from_settings(minimized: bool) -> void:
 		_session_hide_view_profile = true
 		_session_hide_world_interactions = true
 		_session_hide_player_names = true
+		_session_hide_scene_ui = true
 		set_visible_ui(true, true)
+		_set_scene_ui_visible(true)
 		_apply_hide_ui_to_avatar_nicks(false)
-		Global.session_hide_ui_options_sync.emit(true, true, true)
+		Global.session_hide_ui_options_sync.emit(true, true, true, true)
 
 
 func set_hide_view_profile(value: bool) -> void:
@@ -1740,6 +1746,12 @@ func set_hide_world_interactions(value: bool) -> void:
 
 func set_hide_player_names(value: bool) -> void:
 	_session_hide_player_names = value
+
+
+func set_hide_scene_ui(value: bool) -> void:
+	_session_hide_scene_ui = value
+	if _session_hide_main_hud:
+		_set_scene_ui_visible(not value)
 
 
 func is_session_hide_main_hud() -> bool:
@@ -1758,11 +1770,17 @@ func is_session_hide_player_names() -> bool:
 	return _session_hide_player_names
 
 
+func is_session_hide_scene_ui() -> bool:
+	return _session_hide_scene_ui
+
+
 func apply_deferred_hide_ui() -> void:
 	if not _session_hide_main_hud:
 		return
 	set_visible_ui(false, true)
 	_apply_hide_ui_to_avatar_nicks(_session_hide_player_names)
+	if _session_hide_scene_ui:
+		_set_scene_ui_visible(false)
 
 
 func _on_avatar_added_apply_hide_ui(avatar = null) -> void:

--- a/godot/src/ui/explorer.tscn
+++ b/godot/src/ui/explorer.tscn
@@ -103,6 +103,7 @@ mouse_filter = 1
 theme = ExtResource("4_2vs87")
 
 [node name="MobileCameraInput" type="Control" parent="UI" unique_id=435960516]
+unique_name_in_owner = true
 layout_mode = 1
 anchors_preset = 15
 anchor_right = 1.0
@@ -112,6 +113,7 @@ grow_vertical = 2
 script = ExtResource("1_mcinput")
 
 [node name="LeftRightSafeContainerMobile" type="MarginContainer" parent="UI" unique_id=1539864391]
+unique_name_in_owner = true
 layout_mode = 1
 anchors_preset = 15
 anchor_right = 1.0

--- a/godot/src/ui/pages/settings/settings.gd
+++ b/godot/src/ui/pages/settings/settings.gd
@@ -45,9 +45,11 @@ var check_button_submit_message_closes_chat: CheckButton = %CheckButton_SubmitMe
 @onready var check_button_hide_view_profile: CheckButton = %CheckButton_HideViewProfile
 @onready var check_button_hide_world_interactions: CheckButton = %CheckButton_HideWorldInteractions
 @onready var check_button_hide_player_names: CheckButton = %CheckButton_HidePlayerNames
+@onready var check_button_hide_scene_ui: CheckButton = %CheckButton_HideSceneUI
 @onready var hide_view_profile_row: HBoxContainer = %HideViewProfile
 @onready var hide_world_interactions_row: HBoxContainer = %HideWorldInteractions
 @onready var hide_player_names_row: HBoxContainer = %HidePlayerNames
+@onready var hide_scene_ui_row: HBoxContainer = %HideSceneUI
 @onready var preview_camera_3d: Camera3D = %PreviewCamera3D
 @onready var preview_viewport_container: SubViewportContainer = %PreviewViewportContainer
 @onready var container_interface: MarginContainer = %Container_Interface
@@ -477,26 +479,35 @@ func _on_check_button_hide_player_names_toggled(toggled_on: bool) -> void:
 		explorer.set_hide_player_names(toggled_on)
 
 
+func _on_check_button_hide_scene_ui_toggled(toggled_on: bool) -> void:
+	var explorer = Global.get_explorer()
+	if is_instance_valid(explorer):
+		explorer.set_hide_scene_ui(toggled_on)
+
+
 func _on_session_hide_ui_toggle_sync(pressed: bool) -> void:
 	check_button_hide_explorer_ui.set_pressed_no_signal(pressed)
 	_update_hide_ui_sub_toggles(pressed)
 
 
 func _on_session_hide_ui_options_sync(
-	hide_view_profile: bool, hide_interactions: bool, hide_labels: bool
+	hide_view_profile: bool, hide_interactions: bool, hide_labels: bool, hide_scene_ui: bool
 ) -> void:
 	check_button_hide_view_profile.set_pressed_no_signal(hide_view_profile)
 	check_button_hide_world_interactions.set_pressed_no_signal(hide_interactions)
 	check_button_hide_player_names.set_pressed_no_signal(hide_labels)
+	check_button_hide_scene_ui.set_pressed_no_signal(hide_scene_ui)
 
 
 func _update_hide_ui_sub_toggles(hide_ui_on: bool) -> void:
 	check_button_hide_view_profile.disabled = not hide_ui_on
 	check_button_hide_world_interactions.disabled = not hide_ui_on
 	check_button_hide_player_names.disabled = not hide_ui_on
+	check_button_hide_scene_ui.disabled = not hide_ui_on
 	hide_view_profile_row.modulate.a = 1.0 if hide_ui_on else 0.5
 	hide_world_interactions_row.modulate.a = 1.0 if hide_ui_on else 0.5
 	hide_player_names_row.modulate.a = 1.0 if hide_ui_on else 0.5
+	hide_scene_ui_row.modulate.a = 1.0 if hide_ui_on else 0.5
 
 
 func _refresh_hide_explorer_ui_row() -> void:
@@ -515,12 +526,14 @@ func _refresh_hide_explorer_ui_row() -> void:
 		check_button_hide_player_names.set_pressed_no_signal(
 			explorer.is_session_hide_player_names()
 		)
+		check_button_hide_scene_ui.set_pressed_no_signal(explorer.is_session_hide_scene_ui())
 		_update_hide_ui_sub_toggles(hide_on)
 	else:
 		check_button_hide_explorer_ui.set_pressed_no_signal(false)
 		check_button_hide_view_profile.set_pressed_no_signal(true)
 		check_button_hide_world_interactions.set_pressed_no_signal(true)
 		check_button_hide_player_names.set_pressed_no_signal(true)
+		check_button_hide_scene_ui.set_pressed_no_signal(true)
 		_update_hide_ui_sub_toggles(false)
 
 

--- a/godot/src/ui/pages/settings/settings.tscn
+++ b/godot/src/ui/pages/settings/settings.tscn
@@ -876,7 +876,7 @@ stretch = true
 
 [node name="SubViewport" type="SubViewport" parent="VBoxContainer/MarginContainer_Content/ContentScrollContainer/VBoxContainer_Sections/VBoxContainer_Graphics/SectionVisual/VBoxContainer/PreviewViewportContainer" unique_id=1504030425]
 handle_input_locally = false
-size = Vector2i(2, 351)
+size = Vector2i(624, 351)
 render_target_clear_mode = 2
 render_target_update_mode = 0
 
@@ -1338,7 +1338,7 @@ flat = true
 alignment = 0
 icon_alignment = 2
 
-[node name="Button_Marketplace" type="Button" parent="VBoxContainer/MarginContainer_Content/ContentScrollContainer/VBoxContainer_Sections/VBoxContainer_Account/SectionHelp/VBoxContainer/VBoxContainer2" unique_id=658648033]
+[node name="Button_Marketplace" type="Button" parent="VBoxContainer/MarginContainer_Content/ContentScrollContainer/VBoxContainer_Sections/VBoxContainer_Account/SectionHelp/VBoxContainer/VBoxContainer2"]
 custom_minimum_size = Vector2(0, 40)
 layout_mode = 2
 size_flags_horizontal = 0

--- a/godot/src/ui/pages/settings/settings.tscn
+++ b/godot/src/ui/pages/settings/settings.tscn
@@ -379,7 +379,7 @@ size_flags_horizontal = 3
 theme_override_colors/font_color = Color(1, 1, 1, 1)
 theme_override_fonts/font = ExtResource("16_blskf")
 theme_override_font_sizes/font_size = 14
-text = "Hide UI"
+text = "Hide Interface"
 label_settings = ExtResource("17_67hd5")
 
 [node name="HSeparator2" type="HSeparator" parent="VBoxContainer/MarginContainer_Content/ContentScrollContainer/VBoxContainer_Sections/VBoxContainer_Gameplay/Container_Interface/VBoxContainer/HideExplorerUI/VBoxContainer" unique_id=271447150]
@@ -484,6 +484,34 @@ unique_name_in_owner = true
 layout_mode = 2
 size_flags_vertical = 0
 theme = ExtResource("12_sa1v7")
+disabled = true
+
+[node name="HSeparator5" type="HSeparator" parent="VBoxContainer/MarginContainer_Content/ContentScrollContainer/VBoxContainer_Sections/VBoxContainer_Gameplay/Container_Interface/VBoxContainer" unique_id=921095553]
+layout_mode = 2
+mouse_filter = 2
+theme_override_constants/separation = 44
+theme_override_styles/separator = SubResource("StyleBoxEmpty_xewta")
+
+[node name="HideSceneUI" type="HBoxContainer" parent="VBoxContainer/MarginContainer_Content/ContentScrollContainer/VBoxContainer_Sections/VBoxContainer_Gameplay/Container_Interface/VBoxContainer" unique_id=1344310268]
+unique_name_in_owner = true
+layout_mode = 2
+theme_override_constants/separation = 32
+
+[node name="Label_Title" type="Label" parent="VBoxContainer/MarginContainer_Content/ContentScrollContainer/VBoxContainer_Sections/VBoxContainer_Gameplay/Container_Interface/VBoxContainer/HideSceneUI" unique_id=1041295819]
+layout_mode = 2
+size_flags_horizontal = 3
+theme_override_colors/font_color = Color(1, 1, 1, 1)
+theme_override_fonts/font = ExtResource("16_blskf")
+theme_override_font_sizes/font_size = 14
+text = "Hide Scene Interface"
+label_settings = ExtResource("17_67hd5")
+
+[node name="CheckButton_HideSceneUI" type="CheckButton" parent="VBoxContainer/MarginContainer_Content/ContentScrollContainer/VBoxContainer_Sections/VBoxContainer_Gameplay/Container_Interface/VBoxContainer/HideSceneUI" unique_id=1747745546]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_vertical = 0
+theme = ExtResource("12_sa1v7")
+button_pressed = true
 disabled = true
 
 [node name="HSeparator" type="HSeparator" parent="VBoxContainer/MarginContainer_Content/ContentScrollContainer/VBoxContainer_Sections/VBoxContainer_Gameplay" unique_id=1380535543]
@@ -848,7 +876,7 @@ stretch = true
 
 [node name="SubViewport" type="SubViewport" parent="VBoxContainer/MarginContainer_Content/ContentScrollContainer/VBoxContainer_Sections/VBoxContainer_Graphics/SectionVisual/VBoxContainer/PreviewViewportContainer" unique_id=1504030425]
 handle_input_locally = false
-size = Vector2i(624, 351)
+size = Vector2i(2, 351)
 render_target_clear_mode = 2
 render_target_update_mode = 0
 
@@ -1310,7 +1338,7 @@ flat = true
 alignment = 0
 icon_alignment = 2
 
-[node name="Button_Marketplace" type="Button" parent="VBoxContainer/MarginContainer_Content/ContentScrollContainer/VBoxContainer_Sections/VBoxContainer_Account/SectionHelp/VBoxContainer/VBoxContainer2"]
+[node name="Button_Marketplace" type="Button" parent="VBoxContainer/MarginContainer_Content/ContentScrollContainer/VBoxContainer_Sections/VBoxContainer_Account/SectionHelp/VBoxContainer/VBoxContainer2" unique_id=658648033]
 custom_minimum_size = Vector2(0, 40)
 layout_mode = 2
 size_flags_horizontal = 0
@@ -1362,6 +1390,7 @@ font = ExtResource("25_jf4mt")
 [connection signal="toggled" from="VBoxContainer/MarginContainer_Content/ContentScrollContainer/VBoxContainer_Sections/VBoxContainer_Gameplay/Container_Interface/VBoxContainer/HidePlayerNames/CheckButton_HidePlayerNames" to="." method="_on_check_button_hide_player_names_toggled"]
 [connection signal="toggled" from="VBoxContainer/MarginContainer_Content/ContentScrollContainer/VBoxContainer_Sections/VBoxContainer_Gameplay/Container_Interface/VBoxContainer/HideViewProfile/CheckButton_HideViewProfile" to="." method="_on_check_button_hide_view_profile_toggled"]
 [connection signal="toggled" from="VBoxContainer/MarginContainer_Content/ContentScrollContainer/VBoxContainer_Sections/VBoxContainer_Gameplay/Container_Interface/VBoxContainer/HideWorldInteractions/CheckButton_HideWorldInteractions" to="." method="_on_check_button_hide_world_interactions_toggled"]
+[connection signal="toggled" from="VBoxContainer/MarginContainer_Content/ContentScrollContainer/VBoxContainer_Sections/VBoxContainer_Gameplay/Container_Interface/VBoxContainer/HideSceneUI/CheckButton_HideSceneUI" to="." method="_on_check_button_hide_scene_ui_toggled"]
 [connection signal="visibility_changed" from="VBoxContainer/MarginContainer_Content/ContentScrollContainer/VBoxContainer_Sections/VBoxContainer_Storage" to="." method="_on_container_storage_visibility_changed"]
 [connection signal="pressed" from="VBoxContainer/MarginContainer_Content/ContentScrollContainer/VBoxContainer_Sections/VBoxContainer_Storage/Button_ClearCache" to="." method="_on_button_clear_cache_pressed"]
 [connection signal="toggled" from="VBoxContainer/MarginContainer_Content/ContentScrollContainer/VBoxContainer_Sections/VBoxContainer_Graphics/SectionPerformance/VBoxContainer/DynamicGraphics/CheckButton_DynamicGraphics" to="." method="_on_check_button_dynamic_graphics_toggled"]


### PR DESCRIPTION
## Summary

Closes #2113 
Closes #2250

- Adds a new **Hide Scene Interface** sub-toggle under Settings > Gameplay > Interface, following the same pattern as the existing Hide View Profile / Hide World Interactions / Hide Player Names toggles
- When Hide Interface is active with Hide Scene Interface enabled, the scene's base UI (`base_ui`) is hidden
- Camera touch input and virtual joystick (invisible, `modulate.a = 0`) remain functional during Hide Interface, allowing players to walk and look around without any rendered controls
- Joypad action buttons (jump, interact, etc.) are fully hidden and disabled during Hide Interface via a `_show_joypad()` wrapper that respects the hide state


## Test plan

- [ ] Toggle Hide Interface ON → all sub-toggles (including Hide Scene Interface) should be enabled and checked
- [ ] With Hide Scene Interface ON, scene UI should be hidden
- [ ] With Hide Scene Interface OFF (unchecked), scene UI should remain visible even with Hide Interface ON
- [ ] Toggle Hide Interface OFF → sub-toggles reset to checked and disabled, all UI restored
- [ ] Hide UI active → camera touch works, joystick works (invisible), joypad buttons hidden
- [ ] Restore UI → joystick visible, joypad buttons visible
- [ ] Open/close panels (friends, settings, profile) and check that the joystick and joypad buttons work properly.