### PR TITLE
chore: point iOS deploy pipeline to repo via DEPLOY_REPO secret

### DIFF
--- a/.github/workflows/cleanup_deploy_branches.yml
+++ b/.github/workflows/cleanup_deploy_branches.yml
@@ -33,7 +33,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          DEPLOY_REPO="decentraland/godot-mobile-deploy-pipeline"
+          DEPLOY_REPO="${{ secrets.DEPLOY_REPO }}"
           SOURCE_REPO="${{ github.repository }}"
 
           echo "🔍 Fetching branches from deploy repo: $DEPLOY_REPO"

--- a/.github/workflows/ios_builds.yml
+++ b/.github/workflows/ios_builds.yml
@@ -135,7 +135,7 @@ jobs:
         timeout-minutes: 5
         run: cargo run -- export --target ios
 
-      # Deploy to godot-mobile-deploy-pipeline
+      # Deploy to the deploy pipeline repo (configured via DEPLOY_REPO secret)
       - name: Install Git LFS
         run: |
           brew install git-lfs
@@ -199,7 +199,7 @@ jobs:
           # This avoids downloading potentially GBs of LFS data
           mkdir deploy-repo && cd deploy-repo
           git init
-          GIT_SSH_COMMAND='ssh -i ~/.ssh/deploy_key -o IdentitiesOnly=yes' git remote add origin git@github.com:decentraland/godot-mobile-deploy-pipeline.git
+          GIT_SSH_COMMAND='ssh -i ~/.ssh/deploy_key -o IdentitiesOnly=yes' git remote add origin git@github.com:${{ secrets.DEPLOY_REPO }}.git
 
           # Configure git
           git config user.name "github-actions[bot]"
@@ -430,7 +430,7 @@ jobs:
           REF="${{ inputs.ref || github.event.inputs.ref }}"
           BRANCH_NAME="PR-${PR_NUMBER}-${REF}"
           WORKFLOW_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          DEPLOY_REPO_URL="https://github.com/decentraland/godot-mobile-deploy-pipeline/tree/${BRANCH_NAME}"
+          DEPLOY_REPO_URL="https://github.com/${{ secrets.DEPLOY_REPO }}/tree/${BRANCH_NAME}"
 
           COMMENT_BODY="---
 
@@ -440,7 +440,7 @@ jobs:
 
           🔗 **iOS Workflow**: [View build](${WORKFLOW_URL})
 
-          📦 **Artifacts**: [godot-mobile-deploy-pipeline](${DEPLOY_REPO_URL})
+          📦 **Artifacts**: [deploy pipeline](${DEPLOY_REPO_URL})
 
           📍 **Branch**: \`${BRANCH_NAME}\`
 

--- a/.github/workflows/mobile_distribute.yml
+++ b/.github/workflows/mobile_distribute.yml
@@ -1,7 +1,7 @@
 name: 📱 Mobile Build & Distribute (iOS TestFlight + Android APK)
 
 # Single entry point that builds & distributes BOTH mobile platforms:
-#   - iOS    → godot-mobile-deploy-pipeline → Xcode Cloud → TestFlight
+#   - iOS    → deploy pipeline repo (DEPLOY_REPO secret) → Xcode Cloud → TestFlight
 #   - Android → APK is already uploaded to the R2 mobile-artifacts bucket by the
 #               regular Android CI build (android_builds.yml) for every commit; this
 #               workflow waits for that commit's APK and posts a Slack "build ready"

--- a/.github/workflows/sync_branch_deletion.yml
+++ b/.github/workflows/sync_branch_deletion.yml
@@ -32,7 +32,7 @@ jobs:
           # Initialize fresh repo (no need to clone, we only need to delete a remote branch)
           mkdir deploy-repo && cd deploy-repo
           git init
-          GIT_SSH_COMMAND='ssh -i ~/.ssh/deploy_key -o IdentitiesOnly=yes' git remote add origin git@github.com:decentraland/godot-mobile-deploy-pipeline.git
+          GIT_SSH_COMMAND='ssh -i ~/.ssh/deploy_key -o IdentitiesOnly=yes' git remote add origin git@github.com:${{ secrets.DEPLOY_REPO }}.git
 
           # Configure git
           git config user.name "github-actions[bot]"
@@ -52,7 +52,7 @@ jobs:
           rm -rf deploy-repo
 
           echo "✅ Branch deletion synchronized"
-          echo "📦 Deploy Repository: https://github.com/decentraland/godot-mobile-deploy-pipeline"
+          echo "📦 Deploy Repository: https://github.com/${{ secrets.DEPLOY_REPO }}"
           echo "🗑️ Deleted Branch: ${BRANCH_NAME}"
 
       - name: Cleanup SSH key


### PR DESCRIPTION
## Why
The old deploy repo `decentraland/godot-mobile-deploy-pipeline` blew the org's Git LFS budget (~130 GB — per-PR iOS artifacts: a 2.4 GB debug `libgodot.a` + `.pck` on every branch). This repoints the iOS deploy to a fresh `godot-mobile-deploy-pipeline-2` and centralizes the target behind a **`DEPLOY_REPO` secret**, so future moves are a one-secret change.

## What changed
- `ios_builds.yml`, `sync_branch_deletion.yml`: push remote + status/report URLs use `${{ secrets.DEPLOY_REPO }}`
- `cleanup_deploy_branches.yml`: `DEPLOY_REPO` var reads the secret
- `mobile_distribute.yml`: doc comment

## Already configured
- Secret `DEPLOY_REPO = decentraland/godot-mobile-deploy-pipeline-2` added
- Deploy key `godot-explorer-ci` moved to `-2` (write) — `DEPLOY_SSH_KEY` unchanged

## Still required for an iOS build to fully succeed
- ⚠️ **Free the org LFS budget** — delete old `godot-mobile-deploy-pipeline` (frees ~130 GB) or raise the budget; `-2` shares the same org budget
- Re-bind Xcode Cloud to `-2`
- Re-add `ANDROID_KEYSTORE_*` on `-2` if needed

Adding the `build` label to exercise the pipeline end-to-end.