### PR TITLE
fix: Discover search returns no results for inactive worlds/scenes

### DIFF
--- a/godot/src/ui/pages/discover/places/places_generator.gd
+++ b/godot/src/ui/pages/discover/places/places_generator.gd
@@ -161,7 +161,10 @@ func async_request_from_api(offset: int, limit: int) -> void:
 	if only_featured:
 		query += "&tag=featured"
 
-	if order_by != OrderBy.NONE:
+	# When searching, don't apply order_by=most_active: the destinations BFF drops
+	# zero-activity worlds/scenes under that ordering, so quiet results (e.g. "pepino")
+	# would never appear. Let the API rank search results by relevance instead.
+	if order_by != OrderBy.NONE and search_param.length() == 0:
 		query += "&order_by=" + ("like_score" if order_by == OrderBy.LIKE_SCORE else "most_active")
 
 	if Global.is_ios_or_emulating():


### PR DESCRIPTION
## Problem
  Discover search returns "No Results" for existing worlds/scenes (e.g. "pepino") that currently have no active users. Affects iOS and Android.

**After fix:**
<img width="365" height="675" alt="imagen" src="https://github.com/user-attachments/assets/e4dc6191-3028-407c-ada8-477784e37b30" />


  ## Root cause
  The "Scenes" carousel (`places_most_active`) is configured with `order_by = MOST_ACTIVE`, and `places_generator.gd` appended `&order_by=most_active` to every request including searches. The destinations BFF 
  excludes zero-activity worlds/scenes under that ordering:

  search=pepino&tag=allowed_ios&sdk=7                       → 1 result (CozyFarm / pepino.dcl.eth)
  search=pepino&tag=allowed_ios&sdk=7&order_by=most_active  → 0 results   ← the bug
  search=pepino&tag=allowed_ios&sdk=7&order_by=like_score   → 1 result

  The suggestions dropdown worked because it never sends `order_by`; only the submitted carousel search was broken. This also explains the "intermittent" symptom: active destinations still pass the
  `most_active` filter, quiet ones don't.

  ## Fix
  Skip `order_by` when a search term is present so search ranks by relevance instead of activity. Scoped to the one affected path: default browsing, favorites, and my-places are unchanged (verified via git
  blame + scene inspection).

  Closes #2289