### PR TITLE
feat: highlight effect on objects (pointer-events show_highlight)

### DIFF
--- a/godot/src/logic/player/outline_system.gd
+++ b/godot/src/logic/player/outline_system.gd
@@ -5,6 +5,7 @@ const OUTLINE_LAYER = 20  # Using layer 20 for outlined objects (bit 19, value 5
 
 var main_camera: Camera3D = null
 var current_outlined_avatar: Node3D = null
+var current_outlined_entity: Node3D = null
 
 # Cached so we only push to the shader on size changes.
 var _last_pushed_viewport_size: Vector2i = Vector2i.ZERO
@@ -68,11 +69,35 @@ func set_outlined_avatar(avatar: Node3D):
 	if avatar:
 		_set_avatar_layers(avatar, true)
 
+	_update_effect_visibility()
+
+
+func set_outlined_entity(entity: Node3D):
+	if current_outlined_entity == entity:
+		return
+
+	# Clear previous outline (guard against a freed entity node)
+	if is_instance_valid(current_outlined_entity):
+		_set_layers_recursive(current_outlined_entity, false)
+
+	current_outlined_entity = entity
+
+	# Set new outline
+	if entity:
+		_set_layers_recursive(entity, true)
+
+	_update_effect_visibility()
+
+
+# The outline post-process is shared by the avatar and entity paths; keep it
+# rendering while either has a target (the crosshair hits only one at a time).
+func _update_effect_visibility():
+	var active := current_outlined_avatar != null or current_outlined_entity != null
 	if outline_quad:
-		outline_quad.visible = avatar != null
+		outline_quad.visible = active
 	if sub_viewport:
 		sub_viewport.render_target_update_mode = (
-			SubViewport.UPDATE_ALWAYS if avatar != null else SubViewport.UPDATE_DISABLED
+			SubViewport.UPDATE_ALWAYS if active else SubViewport.UPDATE_DISABLED
 		)
 
 
@@ -101,5 +126,7 @@ func _set_layers_recursive(node: Node, add_outline: bool):
 
 
 func _exit_tree():
-	if current_outlined_avatar:
+	if is_instance_valid(current_outlined_avatar):
 		_set_avatar_layers(current_outlined_avatar, false)
+	if is_instance_valid(current_outlined_entity):
+		_set_layers_recursive(current_outlined_entity, false)

--- a/godot/src/ui/explorer.gd
+++ b/godot/src/ui/explorer.gd
@@ -27,6 +27,7 @@ var _first_time_refresh_warning = true
 var _last_parcel_position: Vector2i = Vector2i.MAX
 var _avatar_under_crosshair: Avatar = null
 var _last_outlined_avatar: Avatar = null
+var _last_outlined_entity: Node3D = null
 var _is_loading: bool = true  # Start as loading
 var _ban_check_generation: int = 0
 var _pending_notification_toast: Dictionary = {}  # Store notification waiting to be shown
@@ -652,6 +653,16 @@ func change_tooltips():
 	if _avatar_under_crosshair != _last_outlined_avatar:
 		player.outline_system.set_outlined_avatar(_avatar_under_crosshair)
 		_last_outlined_avatar = _avatar_under_crosshair
+
+	# Handle the highlight (outline) for scene objects with show_highlight=true
+	var highlighted_entity: Node3D = Global.scene_runner.highlighted_entity
+	if not is_instance_valid(highlighted_entity):
+		highlighted_entity = null
+	if _session_hide_main_hud and _session_hide_world_interactions:
+		highlighted_entity = null
+	if highlighted_entity != _last_outlined_entity:
+		player.outline_system.set_outlined_entity(highlighted_entity)
+		_last_outlined_entity = highlighted_entity
 
 	# Filter tooltips based on hide UI sub-toggles
 	if _session_hide_main_hud and (_session_hide_view_profile or _session_hide_world_interactions):

--- a/lib/src/scene_runner/scene_manager.rs
+++ b/lib/src/scene_runner/scene_manager.rs
@@ -110,6 +110,11 @@ pub struct SceneManager {
     #[var]
     pointer_tooltips: VarArray,
 
+    // Entity under the crosshair that should show the hover highlight (outline),
+    // or null. Read from GDScript on the pointer_tooltip_changed signal.
+    #[var]
+    highlighted_entity: Option<Gd<Node3D>>,
+
     // Stored as InstanceId, not Gd<DclAvatar>: the underlying Node3D may be freed
     // between physics ticks (despawn, scene unload, teleport).
     last_avatar_under_crosshair: Option<InstanceId>,
@@ -2216,6 +2221,7 @@ impl INode for SceneManager {
             last_raycast_result: None,
             last_proximity_entity: None,
             pointer_tooltips: VarArray::new(),
+            highlighted_entity: None,
             interactable_area: Rect2i::from_components(
                 0,
                 0,
@@ -2384,7 +2390,9 @@ impl INode for SceneManager {
         );
 
         let mut tooltips = VarArray::new();
+        let mut new_highlighted: Option<Gd<Node3D>> = None;
         if let Some(raycast) = current_pointer_raycast_result.as_ref() {
+            let mut should_highlight = false;
             if let Some(pointer_events) =
                 get_entity_pointer_event(&self.scenes, &raycast.scene_id, &raycast.entity_id)
             {
@@ -2398,6 +2406,12 @@ impl INode for SceneManager {
                         let max_distance = *info.max_distance.as_ref().unwrap_or(&10.0);
                         if !show_feedback || raycast.hit.length > max_distance {
                             continue;
+                        }
+
+                        // show_highlight (default true) gates the hover outline. show_feedback
+                        // was already checked above, so disabling it suppresses the highlight too.
+                        if *info.show_highlight.as_ref().unwrap_or(&true) {
+                            should_highlight = true;
                         }
 
                         let input_action =
@@ -2443,6 +2457,17 @@ impl INode for SceneManager {
                             }
                         }
                     }
+                }
+            }
+
+            // Resolve the entity's Node3D after the pointer_events borrow ends.
+            if should_highlight {
+                if let Some(node) = self.scenes.get(&raycast.scene_id).and_then(|scene| {
+                    scene
+                        .godot_dcl_scene
+                        .get_node_or_null_3d(&raycast.entity_id)
+                }) {
+                    new_highlighted = Some(node.clone());
                 }
             }
         }
@@ -2505,8 +2530,15 @@ impl INode for SceneManager {
             }
         }
 
-        if self.pointer_tooltips != tooltips {
+        let tooltips_changed = self.pointer_tooltips != tooltips;
+        let highlight_changed = self.highlighted_entity != new_highlighted;
+        if tooltips_changed {
             self.pointer_tooltips = tooltips;
+        }
+        if highlight_changed {
+            self.highlighted_entity = new_highlighted;
+        }
+        if tooltips_changed || highlight_changed {
             self.base_mut().emit_signal("pointer_tooltip_changed", &[]);
         }
 


### PR DESCRIPTION
## What

Implements the **"Highlights" effect** on interactive scene objects, and wires up the new `show_highlight` pointer-events property.

Closes #857. Implements protocol change decentraland/protocol#224.

When the crosshair hovers an entity whose `PBPointerEvents.Info` has `show_highlight = true` (default) and `show_feedback = true` within `max_distance`, the entity's meshes get the **same outline effect already used for avatars** — no new shader, no new camera/viewport.

Semantics (per the protocol comments):
- `show_feedback = false` → no hover text **and** no highlight.
- `show_highlight = false` → hover text still shows, **no** highlight.

## How

Minimal change, reusing existing machinery (the layer-20 depth camera + Sobel post-process and `_set_layers_recursive`):

- **`lib/src/scene_runner/scene_manager.rs`** — new `#[var] highlighted_entity: Option<Gd<Node3D>>`, computed inside the existing hover/tooltip loop (same place `show_feedback`/`max_distance` are read) and surfaced to GDScript on the existing `pointer_tooltip_changed` signal.
- **`godot/src/logic/player/outline_system.gd`** — `set_outlined_entity()` reuses `_set_layers_recursive` to toggle the outline render layer; a shared `_update_effect_visibility()` keeps the post-process active while **either** an avatar or an entity is highlighted (the crosshair only hits one at a time).
- **`godot/src/ui/explorer.gd`** — drives the entity highlight from `change_tooltips()`, tracking `_last_outlined_entity` and respecting the hide-world-interactions session toggle.

No protocol bump needed — `show_highlight = 5` is already in the pinned protocol; prost generates the field automatically.

## Testing

- `cargo run -- full-tests --skip-visual` passes (fmt, gdformat, gdlint, clippy, GDScript validation, Rust unit + integration tests).
- Manual: a scene with `PBPointerEvents` on a mesh entity — outline appears on hover by default; disappears with `show_highlight:false` (tooltip stays); neither tooltip nor outline with `show_feedback:false`; nothing beyond `max_distance`; avatar vs object never both outlined at once.