### PR TITLE
ci: add manual workflow to publish Docker image to quay.io from main

### DIFF
--- a/.github/workflows/manual_docker_publish.yml
+++ b/.github/workflows/manual_docker_publish.yml
@@ -1,0 +1,39 @@
+name: 🐳📤 Manual Docker Publish to Quay
+# Manually build the Linux artifacts and push the Docker image to quay.io.
+#
+# The normal CI (runner.yml) only pushes to quay.io when:
+#   - pushing to the `release` branch, or
+#   - a PR carries the `publish-docker` label.
+# There is no automatic push from `main`. This workflow fills that gap: run it
+# from the GitHub Actions UI (or `gh`) on `main` (the default) — or any branch —
+# to publish on demand.
+#
+# Image tags follow the same logic as docker_build_test.yml:
+#   - <git-sha>  (always)
+#   - main    -> `staging`
+#   - release -> `latest`
+#   - other   -> `next`
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: manual-docker-publish-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  # Build the Linux artifacts (decentraland-godot-linux + libdclgodot_linux)
+  # that the Docker image is assembled from.
+  linux-build:
+    name: 🐧 Linux
+    uses: ./.github/workflows/linux_builds.yml
+
+  # Build the Docker image and force the push to quay.io via publish_docker.
+  docker-publish:
+    name: 🐳 Docker build & push to quay.io
+    needs: linux-build
+    uses: ./.github/workflows/docker_build_test.yml
+    with:
+      publish_docker: true
+    secrets:
+      QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
+      QUAY_TOKEN: ${{ secrets.QUAY_TOKEN }}


### PR DESCRIPTION
## What

Adds `.github/workflows/manual_docker_publish.yml` — a manual (`workflow_dispatch`) workflow to push the Docker image to quay.io on demand, e.g. from `main`.

## Why

Today the quay.io push (`docker_build_test.yml`) only fires when:
- pushing to the `release` branch, or
- a PR carries the `publish-docker` label.

There was **no way to publish from `main`**. This fills that gap.

## How

It chains the two existing reusable workflows so behavior matches CI exactly, just gated on a manual trigger:

1. `linux-build` → `linux_builds.yml` (produces the `decentraland-godot-linux` + `libdclgodot_linux` artifacts).
2. `docker-publish` → `docker_build_test.yml` with `publish_docker: true`, which satisfies the existing push condition (`github.ref == 'refs/heads/release' || inputs.publish_docker`) so it pushes regardless of branch.

Image tags are unchanged from `docker_build_test.yml`: `<git-sha>` always, plus `staging` for `main` (`latest` for `release`, `next` otherwise).

## Usage

From the Actions UI (pick the branch, defaults to `main`), or:

```bash
gh workflow run "🐳📤 Manual Docker Publish to Quay" --ref main
```

Note: it rebuilds Linux from the selected ref (~50 min) so the image matches the code at that commit, rather than reusing prior CI artifacts.