### PR TITLE
chore: add CODEOWNERS requiring human review on protected branches

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# Every change requires review from a human on the mobile team.
+# Combined with branch protection (require_code_owner_reviews on main and the
+# release ruleset), this ensures a bot approval (e.g. regenesis-claw, which is
+# not a team member) can never satisfy the required review on its own — relevant
+# because merges to main/release auto-sign and ship the iOS app to TestFlight.
+* @decentraland/rgl-mobile-team


### PR DESCRIPTION
Adds a repo-wide `CODEOWNERS` so protected branches require review from a human on `@decentraland/rgl-mobile-team`.

`require_code_owner_reviews` is already enabled on `main` and the `release` ruleset, but had no effect without a CODEOWNERS file. With this, a bot approval (`regenesis-claw`, not a team member) can no longer satisfy the required review on its own — which matters because merges to `main`/`release` auto-sign and ship the iOS build to TestFlight.
