### PR TITLE
fix(avatar): camera-distance fade, physics-only occlusion & pending-profile nameplates

### DIFF
--- a/godot/src/decentraland_components/avatar/avatar.gd
+++ b/godot/src/decentraland_components/avatar/avatar.gd
@@ -174,6 +174,14 @@ var _lod_state: int = LODState.FULL
 var _use_2d_nameplate: bool = false
 var _nametag_gate_visible: bool = true
 var _nameplate_occluded: bool = false
+# False until a real profile has been applied (async_update_avatar_from_profile). Until
+# then a remote avatar still shows the NicknameUI scene-default placeholder
+# ("nickname#xxxx"), which we hide in production / replace with a status in dev.
+var _profile_ready: bool = false
+# Comms-side profile-fetch state (pushed from message_processor.rs via AvatarScene). Used
+# for the dev pending nameplate: banned => "Failed", otherwise "Loading".
+var _profile_request_failures: int = 0
+var _profile_request_banned: bool = false
 var _impostor_layer: int = -1
 var _lod_phase: int = 0
 var _mesh_lod_visibility_captured: bool = false
@@ -440,6 +448,7 @@ func _unset_avatar_modifier_area():
 
 
 func async_update_avatar_from_profile(profile: DclUserProfile):
+	_profile_ready = true
 	var avatar = profile.get_avatar()
 	var new_avatar_name: String = profile.get_name()
 	if not profile.has_claimed_name():
@@ -629,6 +638,11 @@ func _request_nickname_redraw() -> void:
 func _apply_nickname_visibility() -> void:
 	if nickname_quad == null:
 		return
+	# Profile not received yet: the NicknameUI still shows its scene-default placeholder
+	# ("nickname#xxxx"). Hide it in production; in dev/staging surface the request state.
+	var profile_pending: bool = not _profile_ready and not is_avatar_shape
+	if profile_pending and not Global.is_production():
+		_apply_pending_profile_nameplate()
 	# Hide nickname for AvatarShapes only when the scene didn't set a real name
 	# (the proto default is "NPC", which is noise). Also hide on FAR LOD —
 	# unreadable at impostor distance and each quad is an extra draw call.
@@ -638,7 +652,12 @@ func _apply_nickname_visibility() -> void:
 	)
 	var far_lod: bool = _lod_state == LODState.FAR
 	var should_hide := (
-		avatar_shape_has_no_name or hide_name or _force_hide_name or far_lod or nametag_hidden
+		avatar_shape_has_no_name
+		or hide_name
+		or _force_hide_name
+		or far_lod
+		or nametag_hidden
+		or (profile_pending and Global.is_production())
 	)
 	if _use_2d_nameplate:
 		# _update_nameplate_2d() positions/shows when allowed; hide now if gated off.
@@ -656,6 +675,30 @@ func _apply_nickname_visibility() -> void:
 			# UPDATE_ONCE: redraw one frame here, then the SubViewport idles until
 			# something nickname-related changes (see _request_nickname_redraw).
 			nickname_viewport.render_target_update_mode = SubViewport.UPDATE_ONCE
+
+
+## Dev/staging only: while the profile is still pending, replace the meaningless
+## "nickname#xxxx" placeholder with the request state so we can see what's happening.
+## (In production the tag is hidden instead — see _apply_nickname_visibility.)
+func _apply_pending_profile_nameplate() -> void:
+	if nickname_ui == null:
+		return
+	nickname_ui.name_claimed = false
+	# banned (>= 2 consecutive fetch failures) => the comms layer gave up for now.
+	var failed: bool = _profile_request_banned
+	nickname_ui.nickname = "Failed" if failed else "Loading"
+	nickname_ui.tag = avatar_id.right(4) if not avatar_id.is_empty() else "…"
+	nickname_ui.nickname_color = Color(0.85, 0.4, 0.4) if failed else Color(0.7, 0.7, 0.7)
+	_request_nickname_redraw()
+
+
+## Pushed from comms (message_processor.rs -> AvatarScene) when a profile fetch fails or
+## gets banned. Refresh the dev pending nameplate so it flips "Loading" -> "Failed".
+func set_profile_request_state(failures: int, banned: bool) -> void:
+	_profile_request_failures = failures
+	_profile_request_banned = banned
+	if not _profile_ready:
+		_apply_nickname_visibility()
 
 
 func update_colors(eyes_color: Color, skin_color: Color, hair_color: Color) -> void:

--- a/godot/src/decentraland_components/avatar/nameplate_layer.gd
+++ b/godot/src/decentraland_components/avatar/nameplate_layer.gd
@@ -4,32 +4,37 @@ extends RefCounted
 ## Shared screen-space layer + runtime for all avatar nameplates (#2215). Avatars
 ## add their NicknameUI Control here instead of rendering it into a per-avatar
 ## SubViewport texture (which showed uninitialized-VRAM garbage on mobile). The
-## Control is projected onto the head anchor each frame, distance-faded, depth-
-## occluded against world geometry by a throttled raycast, and depth-sorted.
+## Control is projected onto the head anchor each frame, distance-faded by the
+## camera distance (what the camera sees), depth-occluded against world geometry by a
+## throttled raycast, and depth-sorted.
 ## `layer = -1` draws above the 3D world but below the default-layer HUD.
 
-# On-screen size (matches the prior fixed_size Sprite3D) and distance fade
-# (full < FADE_START, fade to FADE_END), per nickname_quad.gd.
-const SCALE := 0.25
+# On-screen size and distance fade (full < FADE_START, fade to FADE_END), per
+# nickname_quad.gd. SCALE is 15% larger than the prior 0.25.
+const SCALE := 0.2875
+# Fraction of the tag height kept ABOVE the head anchor (1.0 = bottom edge sits on the
+# anchor). Below 1.0 nudges the whole tag down toward the head.
+const ANCHOR_HEIGHT_FACTOR := 0.85
 const FADE_START := 10.0
 const FADE_END := 15.0
 # Alpha units/sec for smooth occlusion fade in/out.
 const FADE_SPEED := 6.0
-# Occlude against solid world geometry (CL_PHYSICS), avatar bodies (CL_AVATAR / layer
-# 30 — remote click_areas) and the body/trigger layer (4 — avatar TriggerDetectors +
-# the local player's CharacterBody, which frees its click_area so this is its only
-# occluder). Own colliders + the camera-mode area (also on layer 4, wraps the camera
-# and would otherwise occlude everything past the player) are excluded per-ray.
+# Occlude ONLY against solid world geometry — the same CL_PHYSICS bodies the player
+# physically collides with (Player.collision_mask == CL_PHYSICS), i.e. the walls/floor
+# that "make you no-walk there". We deliberately do NOT occlude against avatars or any
+# Area3D: avatar bodies/trigger detectors and (nodeless, pooled) DCL scene sensor areas
+# are not walls, and one of those layer-4 scene spheres sits right in front of a third-
+# person camera and was hiding every tag. Bodies only, no areas → no phantom occluders.
 const CL_PHYSICS := 2
-const CL_BODY := 4
-const CL_AVATAR := 536870912
-const OCCLUSION_MASK := CL_PHYSICS | CL_BODY | CL_AVATAR
+const OCCLUSION_MASK := CL_PHYSICS
 # Frames between occlusion raycasts per avatar (staggered) — not every frame.
 const OCCLUSION_PERIOD := 6
+# Debug: set true at runtime (e.g. the debug-ws `eval` command, non-production) to bypass
+# the occlusion raycast entirely so tags fade by distance only — confirms whether a
+# vanishing tag is an occlusion artifact. `NameplateLayer.debug_disable_occlusion = true`.
+static var debug_disable_occlusion := false
 
 static var _root: Control = null
-# Cached camera-mode area (player child) — excluded from every occlusion ray.
-static var _camera_area: Node = null
 
 
 ## The Control to parent nameplates under (screen-space). Created on first use.
@@ -88,13 +93,15 @@ static func update(avatar) -> void:
 	var cam = avatar.get_viewport().get_camera_3d()
 	if cam != null and avatar._nametag_gate_visible:
 		var anchor: Vector3 = avatar.nickname_quad.global_transform.origin
+		# Fade by the camera distance — what the camera actually sees.
 		var dist: float = cam.global_position.distance_to(anchor)
 		if dist <= FADE_END and not cam.is_position_behind(anchor):
 			ui.size = ui.get_combined_minimum_size()
 			ui.scale = Vector2(SCALE, SCALE)
 			var screen_size: Vector2 = ui.size * SCALE
 			var pos: Vector2 = (
-				cam.unproject_position(anchor) - Vector2(screen_size.x * 0.5, screen_size.y)
+				cam.unproject_position(anchor)
+				- Vector2(screen_size.x * 0.5, screen_size.y * ANCHOR_HEIGHT_FACTOR)
 			)
 			ui.position = pos
 			# Closer avatars draw on top.
@@ -112,6 +119,9 @@ static func update(avatar) -> void:
 ## Throttled occlusion raycast. MUST run from _physics_process — direct_space_state
 ## crashes when queried from _process (idle frame).
 static func update_occlusion(avatar) -> void:
+	if debug_disable_occlusion:
+		avatar._nameplate_occluded = false
+		return
 	if not avatar._nametag_gate_visible:
 		return
 	if (Engine.get_physics_frames() + int(avatar.unique_id)) % OCCLUSION_PERIOD != 0:
@@ -125,39 +135,14 @@ static func update_occlusion(avatar) -> void:
 	avatar._nameplate_occluded = _occluded(avatar, cam.global_position, anchor)
 
 
-## True if solid world geometry or another avatar's body sits between camera and anchor.
+## True if solid world geometry (a CL_PHYSICS body — the walls/floor the player collides
+## with) sits between camera and anchor. Bodies only: avatars and Area3D sensors don't
+## occlude, so no exclude list is needed (the player/avatar colliders live on other layers).
 static func _occluded(avatar, from: Vector3, to: Vector3) -> bool:
 	var space = avatar.get_world_3d().direct_space_state
 	if space == null:
 		return false
 	var query := PhysicsRayQueryParameters3D.create(from, to)
 	query.collision_mask = OCCLUSION_MASK
-	# click_area is an Area3D, so areas too; bodies (TriggerDetector / player) are on by default.
-	query.collide_with_areas = true
-	# Exclude this avatar's own colliders (so it never occludes its own tag) and the
-	# camera-mode area that wraps the camera.
-	var excludes: Array = []
-	if is_instance_valid(avatar.click_area):
-		excludes.append(avatar.click_area.get_rid())
-	if is_instance_valid(avatar.trigger_detector):
-		excludes.append(avatar.trigger_detector.get_rid())
-	if avatar.is_local_player:
-		var body = avatar.get_parent()
-		if body is CollisionObject3D:
-			excludes.append(body.get_rid())
-	var cam_area := _get_camera_area()
-	if cam_area != null:
-		excludes.append(cam_area.get_rid())
-	query.exclude = excludes
+	query.collide_with_areas = false
 	return not space.intersect_ray(query).is_empty()
-
-
-## The player's camera-mode area detector (cached). It sits on the occlusion layer
-## and wraps the camera, so it must be excluded or it occludes everything beyond the
-## player.
-static func _get_camera_area() -> CollisionObject3D:
-	if not is_instance_valid(_camera_area):
-		var explorer := Global.get_explorer()
-		if explorer != null and is_instance_valid(explorer.player):
-			_camera_area = explorer.player.get_node_or_null("camera_mode_area_detector")
-	return _camera_area as CollisionObject3D

--- a/lib/src/avatars/avatar_scene.rs
+++ b/lib/src/avatars/avatar_scene.rs
@@ -1631,6 +1631,19 @@ impl AvatarScene {
         }
     }
 
+    /// Forward the comms-side profile-fetch state to the avatar so a pending nameplate
+    /// can show "Loading"/"Failed" in dev (see avatar.gd `set_profile_request_state`).
+    pub fn set_avatar_profile_fetch_state(&mut self, alias: u32, failures: i32, banned: bool) {
+        if let Some(entity_id) = self.avatar_entity.get(&alias) {
+            if let Some(avatar) = self.avatar_godot_scene.get_mut(entity_id) {
+                avatar.call(
+                    "set_profile_request_state",
+                    &[failures.to_variant(), banned.to_variant()],
+                );
+            }
+        }
+    }
+
     pub fn set_avatar_blocked_by_address(&mut self, address: &H160, blocked: bool) {
         if let Some(alias) = self.avatar_address.get(address) {
             self.set_avatar_blocked(*alias, blocked);

--- a/lib/src/comms/adapter/message_processor.rs
+++ b/lib/src/comms/adapter/message_processor.rs
@@ -456,6 +456,7 @@ impl MessageProcessor {
 
         // Handle profile fetch failures
         while let Ok(failure) = self.profile_failure_receiver.try_recv() {
+            let mut fetch_state: Option<(u32, i32, bool)> = None;
             if let Some(peer) = self.peer_identities.get_mut(&failure.address) {
                 peer.profile_fetch_failures += 1;
                 peer.profile_fetch_attempted = false; // Allow retry
@@ -471,6 +472,17 @@ impl MessageProcessor {
                         failure.announced_version
                     );
                 }
+                fetch_state = Some((
+                    peer.alias,
+                    peer.profile_fetch_failures as i32,
+                    peer.profile_fetch_banned_until.is_some(),
+                ));
+            }
+            // Surface the state to the avatar's nameplate (dev shows "Loading"/"Failed").
+            if let Some((alias, failures, banned)) = fetch_state {
+                let mut avatar_scene_ref = self.avatars.clone();
+                let mut avatar_scene = avatar_scene_ref.bind_mut();
+                avatar_scene.set_avatar_profile_fetch_state(alias, failures, banned);
             }
         }
 


### PR DESCRIPTION
Fix https://github.com/decentraland/godot-explorer/issues/2297
2D nameplate follow-ups on top of #2224.

> Note: originally intended to target `spike/avatar-hiccups-2269`, but that branch was merged into `main` (#2311) and deleted, so this targets `main` (which now contains that work).

## What & why

### 1. Fade by camera distance
Reverted a brief experiment that faded by the main-player distance — back to **camera distance** ("what the camera sees").

### 2. Occlude with physics only (the big fix)
Tags were disappearing for **everyone**, depending on where you stood / how the camera was angled. Debugged live over the port-9230 debug WS by casting the real occlusion ray: every front avatar was being occluded by an **invisible collider ~1.1 m in front of the camera** with `collider_id = 0` — a **nodeless, pooled DCL scene sensor Area** (sphere, layer 4, from `object_pool.rs`) that rides the player and sat between the third-person camera and everyone else. Being node-less, it could never be excluded by RID.

Fix: occlude **only against `CL_PHYSICS` (layer 2) solid bodies** — the same geometry the player physically collides with (`Player.collision_mask == 2`; verified the ray hits real `StaticBody3D` scene colliders). Avatars and **all** Area3D sensors no longer occlude. This also let me delete the self-exclude apparatus (player body / trigger / camera-area RID juggling) — unnecessary now.

Live verification after the change: nearby avatars VISIBLE; only those behind a real wall or behind the camera are hidden.

### 3. Size & placement
Nameplate **+15%** (`SCALE` 0.25 → 0.2875) and nudged **slightly lower** (`ANCHOR_HEIGHT_FACTOR`).

### 4. Pending-profile nameplates
A livekit peer gets an avatar (`add_avatar`) before its profile arrives, so it shows the `NicknameUI` scene-default placeholder **`nickname#xxxx`**.
- **Production** → hide the tag until the profile lands.
- **Dev/staging** → show the request state: **`Loading`** → **`Failed`** (red) once comms bans the fetch after repeated failures.

The `Failed` state is plumbed from `message_processor.rs` (`profile_fetch_failures` / `profile_fetch_banned_until`) → `AvatarScene.set_avatar_profile_fetch_state` → `avatar.gd set_profile_request_state`.

## Files
- `godot/.../avatar/nameplate_layer.gd` — camera-distance fade, physics-only occlusion, size/offset.
- `godot/.../avatar/avatar.gd` — pending-profile gating (`_profile_ready`, dev status text, prod hide).
- `lib/src/avatars/avatar_scene.rs` — `set_avatar_profile_fetch_state`.
- `lib/src/comms/adapter/message_processor.rs` — forward fetch failures/bans to the avatar.

## Verification
- gdformat / gdlint clean; `cargo check` passes.
- Occlusion/fade verified live in Genesis Plaza via the debug WS.
- Not yet verified on-device: the `Failed` path (needs a peer whose profile genuinely fails to fetch) and the production-hide branch.