### PR TITLE
perf(ci): thin LTO + WarpCache (restore-all / save-on-main) for iOS & Android

### DIFF
--- a/.github/actions/save-warp-cache/action.yml
+++ b/.github/actions/save-warp-cache/action.yml
@@ -1,0 +1,37 @@
+name: Save WarpBuild cache (main only)
+description: >
+  Persist the Rust build + cargo registry caches, but ONLY on a push to main. PR builds
+  restore the cache (via set-up-warp-cache) without paying the multi-minute save on every
+  push; only the less-frequent main build refreshes it, which PRs then restore from. Keys
+  come from set-up-warp-cache's outputs (captured before the build, so generated .rs files
+  under target/ can't shift the key between restore and save).
+inputs:
+  cargo-key:
+    description: cargo-key output from set-up-warp-cache.
+    required: true
+  rust-key:
+    description: rust-key output from set-up-warp-cache.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: WarpCache save - Cargo Registry (main only)
+      if: github.ref == 'refs/heads/main'
+      uses: WarpBuilds/cache/save@v1.4.6
+      with:
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+        key: ${{ inputs.cargo-key }}
+
+    - name: WarpCache save - Rust Build (main only)
+      if: github.ref == 'refs/heads/main'
+      uses: WarpBuilds/cache/save@v1.4.6
+      with:
+        path: |
+          target/
+          lib/target/
+        key: ${{ inputs.rust-key }}

--- a/.github/actions/set-up-warp-cache/action.yml
+++ b/.github/actions/set-up-warp-cache/action.yml
@@ -1,15 +1,27 @@
-name: Set up WarpBuild cache
-description: Set up cache with WarpBuild optimized caching
+name: Set up WarpBuild cache (restore)
+description: >
+  Restore the Rust build + cargo registry caches (WarpBuild-native, raw target/ with NO
+  cleaning so the v8 prebuilt static lib survives). Restore runs on every branch; the SAVE
+  is handled separately by save-warp-cache and only writes on main — PR builds get the
+  restore speed-up without paying the multi-minute save on every push.
 inputs:
   cache-name:
-    description: The cache base name (job name by default).
+    description: The cache base name (job name by default). Currently informational; keys are keyed by runner.os.
     default: ${{ github.job }}
+outputs:
+  cargo-key:
+    description: Primary key for the cargo-registry cache. Feed to save-warp-cache.
+    value: ${{ steps.cargo.outputs.cache-primary-key }}
+  rust-key:
+    description: Primary key for the rust-build cache. Feed to save-warp-cache.
+    value: ${{ steps.rust.outputs.cache-primary-key }}
 
 runs:
   using: composite
   steps:
-    - name: WarpCache - Cargo Registry
-      uses: WarpBuilds/cache@v1.4.6
+    - name: WarpCache restore - Cargo Registry
+      id: cargo
+      uses: WarpBuilds/cache/restore@v1.4.6
       with:
         path: |
           ~/.cargo/bin/
@@ -20,12 +32,15 @@ runs:
         restore-keys: |
           ${{ runner.os }}-cargo-
 
-    - name: WarpCache - Rust Build
-      uses: WarpBuilds/cache@v1.4.6
+    - name: WarpCache restore - Rust Build
+      id: rust
+      uses: WarpBuilds/cache/restore@v1.4.6
       with:
         path: |
           target/
           lib/target/
+        # *.rs is hashed BEFORE the build, so generated .rs under target/ can't pollute the
+        # key. Off-main builds miss the exact key and fall back to main's cache via restore-keys.
         key: ${{ runner.os }}-rust-build-${{ hashFiles('**/Cargo.lock') }}-${{ hashFiles('**/*.rs') }}
         restore-keys: |
           ${{ runner.os }}-rust-build-${{ hashFiles('**/Cargo.lock') }}-

--- a/.github/workflows/android_builds.yml
+++ b/.github/workflows/android_builds.yml
@@ -45,6 +45,12 @@ jobs:
       image: quay.io/decentraland/dcl-godot-android-builder:62ef6ebf357897ac382d7a52ac80de20883d9e15
       volumes:
         - /home/user/.cache/devgodot:/github/home/.cache/devgodot
+      # WarpBuild's cache action authenticates via this token, which exists on the runner
+      # host but is NOT propagated into the container unless forwarded explicitly. Without
+      # it the cache step is a silent no-op ("Authentication token is invalid"). See:
+      # https://github.com/WarpBuilds/cache#running-inside-a-container
+      env:
+        WARPBUILD_RUNNER_VERIFICATION_TOKEN: ${{ env.WARPBUILD_RUNNER_VERIFICATION_TOKEN }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -63,6 +69,9 @@ jobs:
       # crate's prebuilt static lib (librusty_v8.a) lives under target/.../build/v8-*/out, and
       # rust-cache's cleanup strips it while keeping v8's fingerprint → warm builds then fail to
       # link. set-up-warp-cache keeps the full target/, so the lib survives (matches the iOS leg).
+      # WarpBuild's cache action shells out to wget; the builder image may not ship it.
+      - name: Ensure wget (WarpCache dependency)
+        run: command -v wget >/dev/null 2>&1 || (apt-get update && apt-get install -y wget)
       - name: Set up build cache
         uses: ./.github/actions/set-up-warp-cache
         with:

--- a/.github/workflows/android_builds.yml
+++ b/.github/workflows/android_builds.yml
@@ -57,6 +57,15 @@ jobs:
         with:
           toolchain: "1.90"
           components: clippy, rustfmt
+
+      # Cache the Rust build (host + Android target) so the dep tree isn't recompiled from
+      # scratch every push. rust-cache uses the actions/cache (HTTP) backend, which works
+      # inside this Docker container; smart keys (Cargo.lock + rustc) + cleans on save.
+      - name: Set up build cache
+        uses: ./.github/actions/set-up-cache
+        with:
+          cache-name: android-build
+
       - name: Install Android targets
         run: |
           rustup target add aarch64-linux-android

--- a/.github/workflows/android_builds.yml
+++ b/.github/workflows/android_builds.yml
@@ -59,10 +59,12 @@ jobs:
           components: clippy, rustfmt
 
       # Cache the Rust build (host + Android target) so the dep tree isn't recompiled from
-      # scratch every push. rust-cache uses the actions/cache (HTTP) backend, which works
-      # inside this Docker container; smart keys (Cargo.lock + rustc) + cleans on save.
+      # scratch every push. Use the WarpBuild-native cache (raw target/, NO cleaning): the v8
+      # crate's prebuilt static lib (librusty_v8.a) lives under target/.../build/v8-*/out, and
+      # rust-cache's cleanup strips it while keeping v8's fingerprint → warm builds then fail to
+      # link. set-up-warp-cache keeps the full target/, so the lib survives (matches the iOS leg).
       - name: Set up build cache
-        uses: ./.github/actions/set-up-cache
+        uses: ./.github/actions/set-up-warp-cache
         with:
           cache-name: android-build
 

--- a/.github/workflows/android_builds.yml
+++ b/.github/workflows/android_builds.yml
@@ -69,10 +69,13 @@ jobs:
       # crate's prebuilt static lib (librusty_v8.a) lives under target/.../build/v8-*/out, and
       # rust-cache's cleanup strips it while keeping v8's fingerprint → warm builds then fail to
       # link. set-up-warp-cache keeps the full target/, so the lib survives (matches the iOS leg).
+      # Restore runs on every branch; the save (below) only writes on main, so PRs restore from
+      # main's cache without paying the multi-minute save on each push.
       # WarpBuild's cache action shells out to wget; the builder image may not ship it.
       - name: Ensure wget (WarpCache dependency)
         run: command -v wget >/dev/null 2>&1 || (apt-get update && apt-get install -y wget)
       - name: Set up build cache
+        id: cache
         uses: ./.github/actions/set-up-warp-cache
         with:
           cache-name: android-build
@@ -91,6 +94,14 @@ jobs:
           cargo run -- build --release ${{ env.PROD_FLAG }}
           cargo run -- build --release --target android ${{ env.PROD_FLAG }}
           cargo run -- import-assets
+
+      # Persist the freshly built target/ — no-op off main (see save-warp-cache). Placed right
+      # after the build so a later export/sign failure can't lose a valid cache.
+      - name: Save build cache (main only)
+        uses: ./.github/actions/save-warp-cache
+        with:
+          cargo-key: ${{ steps.cache.outputs.cargo-key }}
+          rust-key: ${{ steps.cache.outputs.rust-key }}
       
       - name: Export Android APK
         run: |

--- a/.github/workflows/ios_r2_artifact.yml
+++ b/.github/workflows/ios_r2_artifact.yml
@@ -97,7 +97,7 @@ jobs:
           ref: ${{ inputs.sha || inputs.ref }}
 
       - name: Slack — iOS build started
-        if: env.SLACK_CHANNEL != ''
+        if: env.SLACK_TS != ''
         run: |
           bash .github/scripts/slack-reply.sh "🍏 iOS — building & exporting on CI… (${{ inputs.ref }})"
 
@@ -166,7 +166,7 @@ jobs:
         run: cargo run -- export --target ios
 
       - name: Slack — iOS packaging
-        if: env.SLACK_CHANNEL != ''
+        if: env.SLACK_TS != ''
         run: |
           bash .github/scripts/slack-reply.sh "📦 iOS — export built, packaging & uploading to R2…"
 
@@ -220,12 +220,12 @@ jobs:
           echo "🔗 ${R2_PUBLIC_BASE_URL}/${KEY}"
 
       - name: Slack — iOS export uploaded
-        if: success() && env.SLACK_CHANNEL != ''
+        if: success() && env.SLACK_TS != ''
         run: |
           bash .github/scripts/slack-reply.sh "📦 iOS — unsigned export uploaded to R2 ✓ (${{ inputs.ref }})"
 
       - name: Root — iOS exported
-        if: success() && env.SLACK_CHANNEL != ''
+        if: success() && env.SLACK_TS != ''
         env:
           # Not done yet → no green tick. The ✅ only appears when it's on TestFlight.
           IOS_LINE: "📦 exported to R2 · signing…"
@@ -261,12 +261,12 @@ jobs:
           echo "✅ Dispatched godot-asc-deploy for ${SAFE_BRANCH}@${SHA:-${{ github.sha }}}"
 
       - name: Slack — handed off to signing
-        if: success() && inputs.dispatch_deploy && env.SLACK_CHANNEL != ''
+        if: success() && inputs.dispatch_deploy && env.SLACK_TS != ''
         run: |
           bash .github/scripts/slack-reply.sh "🤝 iOS — export handed off to the signing pipeline (godot-asc-deploy)"
 
       - name: Slack — handoff failed
-        if: failure() && inputs.dispatch_deploy && env.SLACK_CHANNEL != ''
+        if: failure() && inputs.dispatch_deploy && env.SLACK_TS != ''
         run: |
           bash .github/scripts/slack-reply.sh "❌ iOS — failed to hand off to the signing pipeline (check ASC_DEPLOY_DISPATCH_TOKEN)"
 

--- a/.github/workflows/ios_r2_artifact.yml
+++ b/.github/workflows/ios_r2_artifact.yml
@@ -46,6 +46,11 @@ on:
         required: false
         type: string
         default: ''
+      dry_run:
+        description: 'Build only — skip the R2 upload, deploy dispatch and Sentry (for timing)'
+        required: false
+        type: boolean
+        default: false
     outputs:
       build_version:
         description: 'Rust .build.version captured during the iOS lib build'
@@ -58,6 +63,11 @@ on:
         required: true
         type: string
         default: 'main'
+      dry_run:
+        description: 'Build only — skip the R2 upload, deploy dispatch and Sentry (for timing)'
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -95,6 +105,13 @@ jobs:
         with:
           toolchain: "1.90"
           targets: aarch64-apple-ios
+
+      # Cache the Rust dep compilation (host + iOS) so we don't rebuild the whole tree every
+      # run. WarpBuild-native cache (handles the large iOS target; runner is WarpBuild).
+      - name: Set up build cache
+        uses: ./.github/actions/set-up-warp-cache
+        with:
+          cache-name: ios-r2-build
 
       - name: Install dependencies
         uses: ./.github/actions/install-deps
@@ -154,6 +171,7 @@ jobs:
           bash .github/scripts/slack-reply.sh "📦 iOS — export built, packaging & uploading to R2…"
 
       - name: Package & upload unsigned export to R2
+        if: ${{ ! inputs.dry_run }}
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.MOBILE_ARTIFACTS_R2_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.MOBILE_ARTIFACTS_R2_SECRET_ACCESS_KEY }}
@@ -255,7 +273,7 @@ jobs:
       # libdclgodot.dylib is BUILT here, so its dSYM must be uploaded to Sentry from here
       # (the deploy repo only re-archives the already-built dylib). Best-effort.
       - name: Upload libdclgodot to Sentry
-        if: success()
+        if: success() && ! inputs.dry_run
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: ${{ secrets.SENTRY_ORG }}

--- a/.github/workflows/ios_r2_artifact.yml
+++ b/.github/workflows/ios_r2_artifact.yml
@@ -108,7 +108,10 @@ jobs:
 
       # Cache the Rust dep compilation (host + iOS) so we don't rebuild the whole tree every
       # run. WarpBuild-native cache (handles the large iOS target; runner is WarpBuild).
+      # Restore runs on every branch; the save (below) only writes on main, so PRs restore from
+      # main's cache without paying the multi-minute save on each push.
       - name: Set up build cache
+        id: cache
         uses: ./.github/actions/set-up-warp-cache
         with:
           cache-name: ios-r2-build
@@ -149,6 +152,13 @@ jobs:
       - name: Build iOS
         timeout-minutes: 20
         run: cargo run -- build --release --target ios ${{ env.PROD_FLAG }}
+
+      # Persist the freshly built target/ — no-op off main (see save-warp-cache).
+      - name: Save build cache (main only)
+        uses: ./.github/actions/save-warp-cache
+        with:
+          cargo-key: ${{ steps.cache.outputs.cargo-key }}
+          rust-key: ${{ steps.cache.outputs.rust-key }}
 
       - name: Capture build version
         id: buildver

--- a/.github/workflows/mobile_distribute.yml
+++ b/.github/workflows/mobile_distribute.yml
@@ -291,7 +291,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Slack — Android build started
-        if: env.SLACK_CHANNEL != ''
+        if: env.SLACK_TS != ''
         run: |
           bash .github/scripts/slack-reply.sh "🤖 Android — waiting for the signed APK from CI… (${REF})"
 
@@ -345,14 +345,14 @@ jobs:
           done
 
       - name: Slack — Android APK ready
-        if: success() && env.SLACK_CHANNEL != ''
+        if: success() && env.SLACK_TS != ''
         run: |
           APK="${R2_PUBLIC_BASE_URL}/android/${SAFE_BRANCH}/${SHA}/decentraland.godot.client.apk"
           bash .github/scripts/slack-reply.sh "✅ Android — APK ready: ${APK}"
           ANDROID_LINE="✅ APK ready" APK_URL="$APK" python3 .github/scripts/slack-root.py
 
       - name: Slack — Android failed
-        if: failure() && env.SLACK_CHANNEL != ''
+        if: failure() && env.SLACK_TS != ''
         run: |
           bash .github/scripts/slack-reply.sh "❌ Android — APK not produced for ${SHA} (CI build failed)"
           ANDROID_LINE="❌ CI build failed" python3 .github/scripts/slack-root.py
@@ -386,7 +386,7 @@ jobs:
           done
 
       - name: Slack — Android AAB ready
-        if: success() && env.AAB_READY == 'true' && env.SLACK_CHANNEL != ''
+        if: success() && env.AAB_READY == 'true' && env.SLACK_TS != ''
         run: |
           bash .github/scripts/slack-reply.sh "📦 Android — AAB ready (Play Store): ${R2_PUBLIC_BASE_URL}/android/${SAFE_BRANCH}/${SHA}/decentraland.godot.client.aab"
 

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -124,7 +124,7 @@ dcl-rpc = { git = "https://github.com/decentraland/rpc-rust", rev = "aa2302d6918
 
 [profile.release]
 opt-level = 3
-lto = true
+lto = "thin"
 debug = 1
 strip = false
 


### PR DESCRIPTION
Speeds up the iOS **and** Android CI builds substantially, plus a small Slack fix.

## What
- **`lto = "thin"`** in `[profile.release]` (`lib/Cargo.toml`): the dominant build cost was the fat-LTO whole-program link, which a cache can't skip — thin LTO nearly halves it. This profile is **shared**, so it speeds up *every* platform (iOS, Android, Linux, Windows, macOS), not just iOS.
- **Cache the Rust build** so the dep tree (v8/deno, ffmpeg, livekit, godot-rust) isn't recompiled from scratch every run. Both legs use the **WarpBuild-native cache** (raw `target/`, no cleaning), split into two composite actions:
  - `set-up-warp-cache` → **restore**, runs on **every branch**.
  - `save-warp-cache` → **save**, runs **only on `main`** (see below).
  - iOS (`ios_r2_artifact.yml`) and Android (`android_builds.yml`). The Android build runs on **every push/PR**, so it benefits far more often.
- **Android runs inside a Docker container**, so two extra bits are needed for WarpCache there:
  - forward `WARPBUILD_RUNNER_VERIFICATION_TOKEN` into the container (without it the cache action silently no-ops with `Authentication token is invalid`);
  - ensure `wget` (the action shells out to it).
- **`dry_run` input** on `ios_r2_artifact` (build only: skip the R2 upload / deploy dispatch / Sentry) — used for the timing runs below and handy for future build validation.
- **Fix**: gate the Slack thread posts on `SLACK_TS` (a thread exists) instead of `SLACK_CHANNEL`. Since the channel is now read straight from the secret it's always set, so standalone `workflow_dispatch` runs were posting messages outside any thread.

## Why save only on main
The cache **save** is the expensive half: it uploads the full multi-GB `target/` and takes **~5 min**. If every push saved, that ~5 min would cancel almost the entire build speed-up on a typical (code-changing) PR push — a wash. So PR builds **restore** from main's cache (via `restore-keys` prefix match) but **don't save**; only the less-frequent `main` build refreshes it. PRs get the full speed-up for free.

## Why WarpCache and not rust-cache (Android)
`Swatinem/rust-cache`'s cleanup **strips the prebuilt `librusty_v8.a`** (the v8 crate's downloaded static lib under `target/.../build/v8-*/out`) while keeping v8's fingerprint, so warm builds skip rebuilding v8 but then **fail to link** (`could not find native static library rusty_v8`). The WarpBuild-native cache keeps the raw `target/`, so the lib survives — matching the iOS leg.

## Measured — iOS (build-only timing runs, `warp-macos-26`)
| | Build MacOS | Build iOS | TOTAL |
|---|---|---|---|
| fat LTO (cold) | 8:27 | 7:59 | 20:19 |
| fat LTO (warm cache) | 6:47 | 6:19 | 16:35 |
| **thin LTO (cold)** | **4:26** | **4:22** | **12:28** |

## Measured — Android (`Build Rust libraries`, `warp-ubuntu` container)
| | Build Rust | Restore | Save |
|---|---|---|---|
| fat LTO, no cache (main today) | 13:48 | — | — |
| thin LTO, cold (no cache hit) | ~11:23 | — | — |
| **thin LTO, warm (WarpCache)** | **5:21** | 1:16 | 0 on PRs / ~5:15 on main |

Net on a warm PR push: `1:16 + 5:21 + 0 ≈ 6:37` vs `11:23` uncached → **~5 min faster**, and the v8 link error is gone.

## Why thin LTO is worth it (the trade-off)
Thin LTO recovers ~90–95% of full (fat) LTO's optimization, so the **runtime/battery difference vs fat is ~1–2% — imperceptible** for this app, whose hot path is the Godot engine (C++) + V8 + GPU, not the Rust gdextension's cross-crate inlining. In exchange it nearly halves the Rust compile time on every build. The imperceptible perf delta is well worth the large, recurring CI speedup, and it's reversible in one line if an on-device benchmark ever shows otherwise.
