### PR TITLE
fix: flaky Linux test (serve fixtures from localhost, not httpbin)

### DIFF
--- a/lib/src/content/resource_provider.rs
+++ b/lib/src/content/resource_provider.rs
@@ -669,9 +669,52 @@ mod tests {
         Ok(())
     }
 
+    /// Spawn an ephemeral localhost HTTP server that returns a fixed image body for any GET.
+    /// Replaces the old dependency on the public `httpbin.org` service, which made this test
+    /// flake whenever that service returned a transient 5xx. `ResourceProvider` keys cached
+    /// entries by the caller-supplied file hash (it never hashes the bytes), so an arbitrary
+    /// non-empty body is a valid stand-in for the image.
+    async fn spawn_fake_image_server() -> String {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        const BODY: &[u8] = b"\x89PNG\r\n\x1a\n--fake-image-bytes-for-resource-provider-test--";
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind ephemeral test server");
+        let addr = listener.local_addr().expect("read local addr");
+
+        tokio::spawn(async move {
+            while let Ok((mut socket, _)) = listener.accept().await {
+                tokio::spawn(async move {
+                    // Read and discard the request; we serve the same body regardless.
+                    let mut buf = [0u8; 1024];
+                    let _ = socket.read(&mut buf).await;
+                    let head = format!(
+                        "HTTP/1.1 200 OK\r\nContent-Type: image/png\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                        BODY.len()
+                    );
+                    let _ = socket.write_all(head.as_bytes()).await;
+                    let _ = socket.write_all(BODY).await;
+                    let _ = socket.flush().await;
+                });
+            }
+        });
+
+        format!("http://{}/image.png", addr)
+    }
+
     #[tokio::test]
     async fn test_fetch_resource_or_wait() {
-        let path = "./cache";
+        // Serve the image bytes from localhost instead of the public httpbin.org service,
+        // which made this test flake on its transient 5xx responses.
+        let base_url = spawn_fake_image_server().await;
+
+        // Unique cache dir per process so a leftover dir from a previous or parallel run can't
+        // change behavior (the old hardcoded "./cache" was shared and polluted the repo dir).
+        let dir =
+            std::env::temp_dir().join(format!("dcl-resource-provider-test-{}", std::process::id()));
+        let path = dir.to_str().expect("temp dir path is valid utf-8");
         let max_cache_size = 1024 * 1024 * 1024; // Set the cache size to 1 GB
 
         setup_cache_folder(path)
@@ -692,15 +735,15 @@ mod tests {
 
         let files_to_download = vec![
             (
-                "https://httpbin.org/image/png",
+                base_url.clone(),
                 "bafkreibmrvrdgqthfrvehyell552sk7ivuas2ozzjdmlojbzttqlcrxiya",
             ),
             (
-                "https://httpbin.org/image/png",
+                base_url.clone(),
                 "bafkreic4osvzsjzyqutwjxt2xmyd4hjrwukrxzclvixke3putyrihggmam",
             ),
             (
-                "https://httpbin.org/image/png",
+                base_url.clone(),
                 "bafkreibhjuitdcu3jwu7khjcg2fo6xf2h3hilnfv4liy4p5h2olxj6tcce",
             ),
         ];
@@ -724,8 +767,11 @@ mod tests {
             })
             .collect();
 
-        // Await all the handles
-        join_all(handles).await;
+        // Await all the handles, surfacing any panicked download task instead of letting
+        // join_all swallow the JoinError (which would resurface as a confusing assertion below).
+        for result in join_all(handles).await {
+            result.expect("download task panicked");
+        }
 
         // Extract file hashes from the files_to_download vector
         let file_hashes: Vec<_> = files_to_download
@@ -752,5 +798,7 @@ mod tests {
             assert!(provider.total_size(&existing_files) == 0);
             assert!(existing_files.is_empty());
         }
+
+        let _ = tokio::fs::remove_dir_all(path).await;
     }
 }


### PR DESCRIPTION
## Problem

`content::resource_provider::tests::test_fetch_resource_or_wait` flakes the **Linux pipeline**. It downloads 3 PNGs from the public **`httpbin.org`** service and hard-fails (`.expect("Failed to fetch resource")`) whenever that service returns a transient **5xx** (most recently a 502):

```
thread '...test_fetch_resource_or_wait' panicked at src/content/resource_provider.rs:722:26:
Failed to fetch resource: "Failed to download file: 502"
```

This fixture URL has rotted before — `f29aa7cd` ("fix: replace dead test fixture URL in resource_provider test", #1954) already swapped a previous dead URL for httpbin. Depending on an external service in a unit test is the root cause.

## Fix

Serve the image bytes from an **ephemeral `127.0.0.1` server** spun up inside the test instead of the public internet — deterministic, hermetic, and can't rot again. `ResourceProvider` keys cache entries by the caller-supplied file hash (it never hashes the bytes), so a fixed stand-in body is valid.

While here, two smaller robustness fixes the multi-agent audit (below) surfaced on the same test:
- **Unique per-process temp cache dir** instead of the shared hardcoded `./cache` (which leaked into the repo dir and could pick up leftovers from a previous/parallel run).
- **Surface panicked download tasks** instead of letting `join_all` swallow the `JoinError` (a failed task used to resurface as a confusing later assertion).

The test now runs in **0.02s** (was network-latency bound) and is network-free.

## Broader flaky sweep

I ran a 4-way audit over the whole `cargo test` surface in `lib/src` (network, timing/concurrency, filesystem/global-state, randomness/ordering). Summary:

- **Hard-fails the pipeline:** only this test. ✅ fixed here.
- **Non-hermetic but don't fail** (real network I/O, but no assertion on the result, so they pass even when the call fails): `auth::decentraland_auth_server::tests::test_gen_id` and `auth::remote_wallet::tests::test_get_remote_wallet` — both POST to `auth-api.decentraland`. Left as-is for now; candidates for `#[ignore]`/mock in a follow-up.
- **Not a risk:** `realm::scene_entity_coordinator`'s `test_scene_entity_coordinator` looks like it hits live Decentraland servers, but its entire `mod tests` is commented out (`/* … */`), so it never compiles/runs.
- Timing, randomness and ordering modalities came back clean.

## Validation

`cargo test --lib test_fetch_resource_or_wait` → `ok. 1 passed` locally.
