### PR TITLE
fix(ios): declare NSLocalNetworkUsageDescription for local scene/realm loading

### DIFF
--- a/godot/export_presets.cfg
+++ b/godot/export_presets.cfg
@@ -314,7 +314,9 @@ application/additional_plist_content="	<key>CFBundleURLTypes</key>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>This app does not use the microphone, but a third-party library may require this permission.</string>
 	<key>NSPhotoLibraryUsageDescription</key>
-	<string>This app does not use the photo library, but a third-party library may require this permission.</string>"
+	<string>This app does not use the photo library, but a third-party library may require this permission.</string>
+	<key>NSLocalNetworkUsageDescription</key>
+	<string>Decentraland connects to servers on your local network to load custom scenes and realms.</string>"
 application/icon_interpolation=4
 application/export_project_only=true
 application/delete_old_export_files_unconditionally=true


### PR DESCRIPTION
## What

Add a user-facing `NSLocalNetworkUsageDescription` purpose string to the iOS export's `additional_plist_content` (applies to all builds, debug + release).

## Why

Pointing the explorer at a custom **scene or realm hosted on the local network** is a direct outgoing connection to a LAN address, which iOS gates behind the **Local Network** permission (see [TN3179](https://developer.apple.com/documentation/technotes/tn3179-understanding-local-network-privacy)). The app never declared `NSLocalNetworkUsageDescription`, so when a user loaded a local server the system prompt showed **`(null)`** where the purpose string should be:

> Allow "Decentraland" to find devices on local networks?
> **(null)**

## Notes

- The string **only** appears in the one-time permission prompt — not in Settings, not anywhere else.
- This is **purely cosmetic/UX + App-Review hygiene**: it does **not** change behavior or add a prompt. The prompt already fires from the local-network access itself (the key isn't the trigger — the connection attempt is).
- Sits alongside the existing camera/microphone/photo-library purpose strings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)