### PR TITLE
chore(rendering): default iOS/macOS to Metal driver

### DIFF
--- a/godot/project.godot
+++ b/godot/project.godot
@@ -234,8 +234,6 @@ limits/debugger/max_chars_per_second=3276800
 
 occlusion_culling/bvh_build_quality=1
 rendering_device/vulkan/max_descriptors_per_pool=256
-rendering_device/driver.ios="vulkan"
-rendering_device/driver.macos="vulkan"
 renderer/rendering_method="mobile"
 textures/vram_compression/import_etc2_astc=true
 lights_and_shadows/directional_shadow/size=512


### PR DESCRIPTION
## Summary

Switches the default rendering driver on **iOS and macOS** from **Vulkan** to **Metal**.

This is done by removing the explicit per-platform overrides in `godot/project.godot`:

```diff
-rendering_device/driver.ios="vulkan"
-rendering_device/driver.macos="vulkan"
```

With these overrides gone, Apple platforms fall back to Godot 4.6's **default Metal rendering driver** (Vulkan on Apple is only available via the MoltenVK translation layer, so native Metal is the preferred path). Other platforms are unaffected.

## Test plan

- [ ] iOS build renders correctly on device (no MoltenVK/Vulkan init)
- [ ] macOS build renders correctly
- [ ] No regressions on Linux/Windows/Android (unchanged — they never used these overrides)