### PR TITLE
ci(mobile): show Branch in the Slack build-pipeline card

### DIFF
--- a/.github/scripts/slack-root.py
+++ b/.github/scripts/slack-root.py
@@ -16,7 +16,7 @@ Env (only NON-EMPTY values are merged; everything else is preserved):
   SLACK_BOT_TOKEN, SLACK_CHANNEL   required
   SLACK_TS                         if set -> read+merge+chat.update; else chat.postMessage
   STATUS                           building | success | failed   (only set it when you mean to)
-  BUILD_VERSION, TRIGGERED_BY
+  BUILD_VERSION, BRANCH, TRIGGERED_BY
   PR_NUMBER, PR_URL, COMMIT, COMMIT_URL
   IOS_LINE, ANDROID_LINE, APK_URL, RUN_URL, TESTFLIGHT_URL
 
@@ -25,7 +25,7 @@ On create prints `ts=<ts>` and appends ts/channel to $GITHUB_OUTPUT.
 import os, sys, json, urllib.request, urllib.parse
 
 API = "https://slack.com/api"
-FIELDS = ["status", "build_version", "triggered_by", "pr_number", "pr_url",
+FIELDS = ["status", "build_version", "branch", "triggered_by", "pr_number", "pr_url",
           "commit", "commit_url", "ios_line", "android_line", "apk_url",
           "run_url", "testflight_url"]
 
@@ -71,6 +71,7 @@ status = (state.get("status") or "building").lower()
 emoji = {"building": "⏳", "success": "✅", "failed": "❌", "cancelled": "⚠️"}.get(status, "⏳")
 label = {"building": "BUILDING", "success": "SUCCESS", "failed": "FAILED", "cancelled": "CANCELLED"}.get(status, status.upper())
 bv = state.get("build_version") or "—"
+branch = state.get("branch", "")
 trig = state.get("triggered_by") or "—"
 commit, commit_url = state.get("commit", ""), state.get("commit_url", "")
 pr_number, pr_url = state.get("pr_number", ""), state.get("pr_url", "")
@@ -81,12 +82,14 @@ run_url = state.get("run_url", "")
 
 commit_md = f"<{commit_url}|`{commit}`>" if (commit_url and commit) else (f"`{commit}`" if commit else "—")
 pr_md = f"<{pr_url}|#{pr_number}>" if (pr_url and pr_number) else (f"#{pr_number}" if pr_number else "—")
+branch_md = f"`{branch}`" if branch else "—"
 
 blocks = [
     {"type": "header", "text": {"type": "plain_text",
         "text": f"🤖 Mobile build pipeline · {emoji} {label} 🍏", "emoji": True}},
     {"type": "section", "fields": [
         {"type": "mrkdwn", "text": f"*Build version:*\n`{bv}`"},
+        {"type": "mrkdwn", "text": f"*Branch:*\n{branch_md}"},
         {"type": "mrkdwn", "text": f"*Triggered by:*\n{trig}"},
         {"type": "mrkdwn", "text": f"*PR:*\n{pr_md}"},
         {"type": "mrkdwn", "text": f"*Commit:*\n{commit_md}"},

--- a/.github/workflows/mobile_distribute.yml
+++ b/.github/workflows/mobile_distribute.yml
@@ -145,6 +145,7 @@ jobs:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
           SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL_ID }}
           STATUS: building
+          BRANCH: ${{ steps.ctx.outputs.ref }}
           TRIGGERED_BY: ${{ steps.ctx.outputs.triggered_by }}
           PR_NUMBER: ${{ steps.ctx.outputs.pr_number }}
           PR_URL: ${{ steps.ctx.outputs.pr_url }}


### PR DESCRIPTION
## What

Adds a **Branch** field to the mobile build pipeline Slack root card, so it's clear at a glance which branch each build came from.

Card now reads:

\`\`\`
*Build version:* \`0.72.0-f719e21-staging\`   *Branch:* \`feat/iap-mobile\`
*Triggered by:* label by kuruk-mm            *PR:* #2315
*Commit:* \`f719e21\`
\`\`\`

## How

- \`.github/scripts/slack-root.py\`: add \`branch\` to \`FIELDS\` (so merge-on-read preserves it) and render a \`*Branch:*\` field.
- \`.github/workflows/mobile_distribute.yml\`: the \`prepare\` job seeds \`BRANCH\` with the real ref (\`steps.ctx.outputs.ref\`, e.g. \`feat/...\`, not the dashed safe-branch). It's set once at card creation; merge-on-read preserves it across the iOS/Android/TestFlight updates.

## ⚠️ Companion PR

\`slack-root.py\` is a duplicated file shared with **decentraland/godot-asc-deploy** (which performs the final TestFlight \`chat.update\`). The identical change is in a companion PR there — both must merge or the final update drops the Branch line from the visible card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)