### PR TITLE
fix(ci): disable multithreaded asset import to stop headless font-reimport hang

### DIFF
--- a/godot/project.godot
+++ b/godot/project.godot
@@ -68,6 +68,10 @@ window/size/window_height_override=1280
 window/frame_pacing/android/enable_frame_pacing=false
 window/handheld/orientation=6
 
+[editor]
+
+import/use_multiple_threads=false
+
 [editor_plugins]
 
 enabled=PackedStringArray("res://addons/dcl-godot-android/plugin.cfg", "res://addons/dcl_build_plugin/plugin.cfg", "res://addons/dcl_dev_tools/plugin.cfg", "res://addons/dcl_mobile_preview/plugin.cfg", "res://addons/emote_converter/plugin.cfg", "res://addons/resource_tracker/plugin.cfg")


### PR DESCRIPTION
## Problem

The Linux CI **Import Assets** step intermittently hangs forever (until the 50-min job
timeout), stuck reimporting a TTF font in headless mode:

```
[ 56% ] reimport | Lato-BlackItalic.ttf   ← looping every second, frozen at 56%
...
Terminate orphan process: pid (6793) (godot...editor.x86_64)   ← killed by timeout
```

It's **flaky** and intermittent; the font file/`.import` are fine — it's a non-deterministic
**deadlock in Godot's multithreaded editor import**, where the font / TextServer importer
is a known non-thread-safe path. Far more likely on the low-core CI runners.

## Fix

Set `editor/import/use_multiple_threads=false` in `project.godot` → import runs serially,
the deadlock can't occur, and `--import` completes and self-quits cleanly. Editor-only
(no runtime/gameplay impact); applies to all platforms since they share `import_assets()`
and this `project.godot`.

Deliberately **not** re-adding `--quit-after` (removed in #597): it would force-quit
mid-reimport and leave an incomplete/corrupt font cache.

## Verification (this branch)

| Run | Import config | Duration | Result |
|-----|---------------|----------|--------|
| Baseline (empty commit on `main`) | multithreaded (default) | **16 s** | ✅ |
| This fix | **serial** | **17 s** | ✅ |

Negligible overhead. (Note: a single green run can't *prove* absence of a flaky deadlock;
the fix is grounded in the upstream root cause below.)

Refs:
- godotengine/godot#109374 — stuck import on low-core systems, fixed via `use_multiple_threads=false`
- godotengine/godot#77508 — headless `--import` + `--quit-after` incomplete-import mechanism