### PR TITLE
ci(ios): self-hosted iOS pipeline — runner, SHA-pinned Godot, R2 latest, build-label reuse

### DIFF
--- a/.github/actions/dispatch-asc-deploy/action.yml
+++ b/.github/actions/dispatch-asc-deploy/action.yml
@@ -1,0 +1,70 @@
+name: Dispatch godot-asc-deploy
+description: >
+  Hand off an unsigned iOS export already in R2 (ios/<branch>/<sha>/export.tar.gz) to the
+  decentraland/godot-asc-deploy pipeline (deploy_testflight.yml), which signs it and uploads to
+  TestFlight. Factored out of ios_r2_artifact.yml so BOTH the WarpBuild build path and the
+  reuse-existing-export path (mobile_distribute.yml ios-dispatch) hand off identically.
+
+inputs:
+  gh-token:
+    description: PAT that can dispatch deploy_testflight.yml in godot-asc-deploy (ASC_DEPLOY_DISPATCH_TOKEN).
+    required: true
+  ref:
+    description: Source branch — sanitized to the R2 key segment (slashes → dashes).
+    required: true
+  sha:
+    description: Commit SHA of the export to ship (godot-asc-deploy reconstructs the R2 key from branch + sha).
+    required: true
+  whats_new:
+    description: TestFlight "What to Test" notes.
+    required: false
+    default: ""
+  pr_number:
+    required: false
+    default: ""
+  slack_ts:
+    required: false
+    default: ""
+  build_version:
+    required: false
+    default: ""
+  build_number:
+    description: Explicit CFBundleVersion (date-based, idempotent per SHA). Empty → asc-deploy falls back to TestFlight latest+1.
+    required: false
+    default: ""
+  triggered_by:
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    - name: Dispatch godot-asc-deploy
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.gh-token }}
+        REF: ${{ inputs.ref }}
+        SHA: ${{ inputs.sha }}
+        WHATS_NEW: ${{ inputs.whats_new }}
+        PR_NUMBER: ${{ inputs.pr_number }}
+        TS: ${{ inputs.slack_ts }}
+        BUILD_VERSION: ${{ inputs.build_version }}
+        BUILD_NUMBER: ${{ inputs.build_number }}
+        TRIGGERED_BY: ${{ inputs.triggered_by }}
+      run: |
+        set -eu
+        if [ -z "${GH_TOKEN:-}" ]; then
+          echo "❌ ASC_DEPLOY_DISPATCH_TOKEN not set — cannot hand off to godot-asc-deploy."
+          exit 1
+        fi
+        if [ -z "${SHA:-}" ]; then
+          echo "❌ sha is empty — godot-asc-deploy cannot locate the export in R2."
+          exit 1
+        fi
+        SAFE_BRANCH=$(echo "$REF" | tr '/' '-')
+        gh workflow run deploy_testflight.yml \
+          --repo decentraland/godot-asc-deploy --ref main \
+          -f branch="$SAFE_BRANCH" -f sha="$SHA" -f whats_new="$WHATS_NEW" \
+          -f pr_number="$PR_NUMBER" -f slack_ts="$TS" \
+          -f build_version="$BUILD_VERSION" -f build_number="$BUILD_NUMBER" -f triggered_by="$TRIGGERED_BY"
+        echo "✅ Dispatched godot-asc-deploy for ${SAFE_BRANCH}@${SHA}"

--- a/.github/workflows/android_builds.yml
+++ b/.github/workflows/android_builds.yml
@@ -237,7 +237,12 @@ jobs:
 
           echo "📤 Uploading APK to s3://${AWS_S3_BUCKET}/${KEY}"
           aws s3 cp "$APK_PATH" "s3://${AWS_S3_BUCKET}/${KEY}" --endpoint-url "$AWS_ENDPOINT_URL"
-          aws s3 cp "$APK_PATH" "s3://${AWS_S3_BUCKET}/${LATEST_KEY}" --endpoint-url "$AWS_ENDPOINT_URL"
+          # Update the branch 'latest' pointer WITHOUT re-uploading. The managed `aws s3 cp s3:// s3://`
+          # is unusable on R2 (tagging headers NotImplemented), so use low-level copy-object; fall
+          # back to a plain re-upload if R2 rejects the copy.
+          aws s3api copy-object --bucket "$AWS_S3_BUCKET" --key "$LATEST_KEY" \
+            --copy-source "${AWS_S3_BUCKET}/${KEY}" --endpoint-url "$AWS_ENDPOINT_URL" >/dev/null \
+            || aws s3 cp "$APK_PATH" "s3://${AWS_S3_BUCKET}/${LATEST_KEY}" --endpoint-url "$AWS_ENDPOINT_URL"
 
           PUBLIC_URL="${R2_PUBLIC_BASE_URL}/${KEY}"
           echo "✅ APK uploaded to R2 (sha=${SHA}, branch=${SAFE_BRANCH})"
@@ -253,7 +258,11 @@ jobs:
               AAB_LATEST_KEY="android/${SAFE_BRANCH}/latest/decentraland.godot.client.aab"
               echo "📤 Uploading AAB to s3://${AWS_S3_BUCKET}/${AAB_KEY}"
               aws s3 cp "$AAB_PATH" "s3://${AWS_S3_BUCKET}/${AAB_KEY}" --endpoint-url "$AWS_ENDPOINT_URL"
-              aws s3 cp "$AAB_PATH" "s3://${AWS_S3_BUCKET}/${AAB_LATEST_KEY}" --endpoint-url "$AWS_ENDPOINT_URL"
+              # Update the branch 'latest' pointer WITHOUT re-uploading (low-level copy-object;
+              # R2 rejects the managed server-side copy). Fall back to a re-upload on failure.
+              aws s3api copy-object --bucket "$AWS_S3_BUCKET" --key "$AAB_LATEST_KEY" \
+                --copy-source "${AWS_S3_BUCKET}/${AAB_KEY}" --endpoint-url "$AWS_ENDPOINT_URL" >/dev/null \
+                || aws s3 cp "$AAB_PATH" "s3://${AWS_S3_BUCKET}/${AAB_LATEST_KEY}" --endpoint-url "$AWS_ENDPOINT_URL"
               echo "✅ AAB uploaded to R2"
               echo "🔗 Public URL: ${R2_PUBLIC_BASE_URL}/${AAB_KEY}"
             else

--- a/.github/workflows/ios_r2_artifact.yml
+++ b/.github/workflows/ios_r2_artifact.yml
@@ -236,7 +236,15 @@ jobs:
 
           echo "📤 Uploading export to s3://${AWS_S3_BUCKET}/${KEY}"
           aws s3 cp export.tar.gz "s3://${AWS_S3_BUCKET}/${KEY}" --endpoint-url "$AWS_ENDPOINT_URL"
-          aws s3 cp export.tar.gz "s3://${AWS_S3_BUCKET}/${LATEST_KEY}" --endpoint-url "$AWS_ENDPOINT_URL"
+          # Update the branch 'latest' pointer WITHOUT re-uploading the tarball. The managed
+          # `aws s3 cp s3:// s3://` is unusable on R2 (it sends GetObjectTagging / x-amz-tagging-
+          # directive, both NotImplemented), so use the low-level copy-object; fall back to a plain
+          # re-upload if R2 ever rejects the copy, so the build never breaks. asc-deploy's manual
+          # dispatch defaults to ios/<branch>/latest, so this key must stay populated.
+          echo "🔗 Updating latest pointer s3://${AWS_S3_BUCKET}/${LATEST_KEY}"
+          aws s3api copy-object --bucket "$AWS_S3_BUCKET" --key "$LATEST_KEY" \
+            --copy-source "${AWS_S3_BUCKET}/${KEY}" --endpoint-url "$AWS_ENDPOINT_URL" >/dev/null \
+            || aws s3 cp export.tar.gz "s3://${AWS_S3_BUCKET}/${LATEST_KEY}" --endpoint-url "$AWS_ENDPOINT_URL"
 
           echo "✅ Unsigned export uploaded to R2 (sha=${SHA}, branch=${SAFE_BRANCH})"
           echo "🔗 ${R2_PUBLIC_BASE_URL}/${KEY}"
@@ -259,29 +267,17 @@ jobs:
       # runs in parallel with the (best-effort) Sentry upload below instead of waiting for it.
       - name: Dispatch godot-asc-deploy (sign & upload to TestFlight)
         if: success() && inputs.dispatch_deploy
-        env:
-          GH_TOKEN: ${{ secrets.ASC_DEPLOY_DISPATCH_TOKEN }}
-          REF: ${{ inputs.ref }}
-          SHA: ${{ inputs.sha }}
-          WHATS_NEW: ${{ inputs.whats_new }}
-          PR_NUMBER: ${{ inputs.pr_number }}
-          TS: ${{ inputs.slack_ts }}
-          BUILD_VERSION: ${{ steps.buildver.outputs.build_version }}
-          BUILD_NUMBER: ${{ env.DCL_BUILD_NUMBER }}
-          TRIGGERED_BY: ${{ inputs.triggered_by }}
-        run: |
-          set -eu
-          if [ -z "${GH_TOKEN:-}" ]; then
-            echo "❌ ASC_DEPLOY_DISPATCH_TOKEN not set — cannot hand off to godot-asc-deploy."
-            exit 1
-          fi
-          SAFE_BRANCH=$(echo "$REF" | tr '/' '-')
-          gh workflow run deploy_testflight.yml \
-            --repo decentraland/godot-asc-deploy --ref main \
-            -f branch="$SAFE_BRANCH" -f sha="${SHA:-${{ github.sha }}}" -f whats_new="$WHATS_NEW" \
-            -f pr_number="$PR_NUMBER" -f slack_ts="$TS" \
-            -f build_version="$BUILD_VERSION" -f build_number="$BUILD_NUMBER" -f triggered_by="$TRIGGERED_BY"
-          echo "✅ Dispatched godot-asc-deploy for ${SAFE_BRANCH}@${SHA:-${{ github.sha }}}"
+        uses: ./.github/actions/dispatch-asc-deploy
+        with:
+          gh-token: ${{ secrets.ASC_DEPLOY_DISPATCH_TOKEN }}
+          ref: ${{ inputs.ref }}
+          sha: ${{ inputs.sha || github.sha }}
+          whats_new: ${{ inputs.whats_new }}
+          pr_number: ${{ inputs.pr_number }}
+          slack_ts: ${{ inputs.slack_ts }}
+          build_version: ${{ steps.buildver.outputs.build_version }}
+          build_number: ${{ env.DCL_BUILD_NUMBER }}
+          triggered_by: ${{ inputs.triggered_by }}
 
       - name: Slack — handed off to signing
         if: success() && inputs.dispatch_deploy && env.SLACK_TS != ''

--- a/.github/workflows/ios_self_hosted.yml
+++ b/.github/workflows/ios_self_hosted.yml
@@ -1,0 +1,305 @@
+name: 🍏 iOS (self-hosted)
+
+# Builds the iOS app (Rust lib + Godot export) and uploads the UNSIGNED export tree to the R2
+# mobile-artifacts bucket on every push to main/release and on PRs — the iOS counterpart of
+# android_builds.yml's per-push APK. It runs on a SELF-HOSTED macOS runner (a dev Mac labelled
+# `dcl-ios`), so it only builds when that Mac is registered.
+#
+# Two-tier gating:
+#   • `gate` job (GitHub-hosted): if the `RUNNERS_READ_TOKEN` PAT exists, it checks that a runner
+#     labelled `dcl-ios` is ONLINE and that the actor is an active member of the CODEOWNERS team
+#     (decentraland/rgl-mobile-team). If the PAT is ABSENT, the gate BYPASSES (outputs `bypass`),
+#     so the workflow works with zero extra setup and auto-upgrades the day the PAT is added.
+#   • inline `if` on build-ios (always applies): non-fork PR authored by an OWNER/MEMBER/COLLABORATOR,
+#     or a push (write access already required), and the PR must not carry the `build` label.
+#
+# Queueing behaviour:
+#   • Runner BUSY with another job  → build-ios QUEUES natively until the runner frees up
+#     (a busy runner still reports status==online, so the gate does not skip it).
+#   • Runner OFFLINE + PAT present  → gate outputs `false` → build-ios is cleanly SKIPPED.
+#   • Runner OFFLINE + no PAT       → gate BYPASSES → build-ios stays QUEUED (pending) until a
+#     newer push cancels it (concurrency) or up to 24h.
+#   • New push on the same branch   → cancels the in-progress/queued run (concurrency), like Android.
+#   • PR gets the `build` label     → the full WarpBuild pipeline (mobile_distribute → ios_r2_artifact)
+#     owns iOS, so this build SKIPS; the `labeled` trigger + concurrency cancels any queued run here.
+#
+# Security: PUBLIC repo — a self-hosted runner can run arbitrary PR code. NOTE: the `if:` gates
+# below are NOT a security boundary — a `pull_request` runs the workflow as modified by the PR,
+# so they can be edited away. The real, PR-proof controls are SERVER-SIDE: (1) require approval
+# for all outside collaborators (Settings → Actions), and (2) an org runner group restricted to
+# this workflow. The `if:` gates are correctness/convenience only. The runner/VM setup scripts are
+# kept LOCAL (outside this repo) and provision the `dcl-ios`-labelled runner this workflow targets.
+
+on:
+  push:
+    branches:
+      - main
+      - release
+  pull_request:
+    # `labeled` is included so adding the `build` label re-triggers this workflow; combined with
+    # the `if` skip + concurrency below, that cancels any per-push run already queued on the Mac.
+    types: [opened, synchronize, reopened, labeled]
+
+permissions:
+  contents: read
+
+concurrency:
+  # Include the event action so a `labeled` (build-label) event gets its OWN group and does NOT
+  # cancel an in-flight `synchronize` self-hosted build for the same commit — that build's R2 export
+  # is exactly what mobile_distribute's `ios-resolve` reuses to skip the WarpBuild rebuild. Two
+  # `synchronize` pushes still share a group (newer cancels older), so only the latest build runs.
+  group: ios-selfhosted-${{ github.actor }}-${{ github.head_ref || github.run_number }}-${{ github.ref }}-${{ github.event.action }}
+  cancel-in-progress: true
+
+jobs:
+  # ───────────────────────────────────────────────────────────────────────────────────────────
+  # Gate: cheap GitHub-hosted check. With a PAT it yields a deterministic online + codeowner
+  # verdict; without a PAT it bypasses so the rest still runs (queue + inline checks).
+  # ───────────────────────────────────────────────────────────────────────────────────────────
+  gate:
+    name: Gate (runner online + codeowner)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      # `true` = online && codeowner · `false` = offline or not-codeowner (skip) · `bypass` = no PAT.
+      should_build: ${{ steps.check.outputs.should_build }}
+    steps:
+      - id: check
+        env:
+          # Optional fine-grained PAT: repo `Administration: Read` + org `Members: Read`
+          # (or classic PAT `repo` + `read:org`). Absent → the gate bypasses.
+          GH_TOKEN: ${{ secrets.RUNNERS_READ_TOKEN }}
+          # GitHub-authenticated identity of whoever triggered this (NOT the spoofable git author):
+          # the PR author on pull_request, the pusher on push.
+          ACTOR: ${{ github.event_name == 'pull_request' && github.event.pull_request.user.login || github.actor }}
+        run: |
+          set -u
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "ℹ️  RUNNERS_READ_TOKEN not set — bypassing the gate (queue + inline checks apply)."
+            echo "should_build=bypass" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Is a runner labelled `dcl-ios` online? (busy-but-online still counts → job queues)
+          ONLINE=$(gh api "/repos/${{ github.repository }}/actions/runners" \
+            --jq '[.runners[] | select(.status=="online") | select(any(.labels[]; .name=="dcl-ios"))] | length' \
+            2>/dev/null || echo 0)
+          # Is the actor an active member of the CODEOWNERS team? (404 for non-members → empty)
+          STATE=$(gh api "/orgs/decentraland/teams/rgl-mobile-team/memberships/${ACTOR}" \
+            --jq '.state' 2>/dev/null || echo "")
+          echo "runners_online=${ONLINE:-0} · actor=${ACTOR} · membership=${STATE:-none}"
+
+          if [ "${ONLINE:-0}" -gt 0 ] 2>/dev/null && [ "$STATE" = "active" ]; then
+            echo "should_build=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "should_build=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  # ───────────────────────────────────────────────────────────────────────────────────────────
+  # Build: runs on the dev Mac. No WarpBuild cache actions — the self-hosted runner persists the
+  # build artifacts between runs (target/, lib/target/, .bin/) via `clean: false` on checkout, so
+  # cargo compiles incrementally instead of from scratch every run. The xtask hardcodes the lib
+  # output under lib/target/ (copy_files.rs / ios_xcode.rs), so the cache MUST live in-tree —
+  # redirecting CARGO_TARGET_DIR elsewhere would break those paths.
+  # ───────────────────────────────────────────────────────────────────────────────────────────
+  build-ios:
+    name: Build iOS export → R2
+    needs: gate
+    if: >
+      needs.gate.outputs.should_build != 'false' &&
+      (github.event_name != 'pull_request' ||
+       (github.event.pull_request.head.repo.full_name == github.repository &&
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association))) &&
+      !contains(github.event.pull_request.labels.*.name, 'build')
+    runs-on: [self-hosted, macOS, ARM64, dcl-ios]
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          # Local incremental-build cache: keep untracked/gitignored artifacts (target/, lib/target/,
+          # .bin/) across runs on this persistent runner. Default `clean: true` runs `git clean -ffdx`
+          # which would wipe them every run. Tracked files are still force-checked-out to the ref, so
+          # the source tree stays correct — only the build cache survives.
+          clean: false
+
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # @stable
+        with:
+          toolchain: "1.90"
+          targets: aarch64-apple-ios
+
+      - name: Install dependencies
+        uses: ./.github/actions/install-deps
+
+      - name: Cargo install
+        timeout-minutes: 15
+        run: cargo run -- install --targets ios
+
+      - name: Set prod flag
+        uses: ./.github/actions/set-prod-flag
+
+      # Build the iOS dylib against the iOS 26 SDK (matches ios_r2_artifact.yml). On a WarpBuild
+      # macOS image Xcode lives at /Applications/Xcode_26*.app; on a personal Mac it's the default
+      # /Applications/Xcode.app — so prefer a versioned app, else accept the selected Xcode if ≥ 26.
+      - name: Select Xcode 26 (iOS 26 SDK)
+        run: |
+          set -eu
+          XCODE_APP="$(ls -d /Applications/Xcode_26*.app 2>/dev/null | sort -V | tail -1 || true)"
+          if [ -n "$XCODE_APP" ] && [ -d "$XCODE_APP" ]; then
+            echo "Using $XCODE_APP"
+            echo "DEVELOPER_DIR=$XCODE_APP/Contents/Developer" >> "$GITHUB_ENV"
+            "$XCODE_APP/Contents/Developer/usr/bin/xcodebuild" -version
+            exit 0
+          fi
+          # Fall back to the currently selected Xcode if it satisfies the SDK floor.
+          CUR="$(xcode-select -p 2>/dev/null || true)"
+          VER="$(xcodebuild -version 2>/dev/null | awk '/^Xcode/{print $2}')"
+          MAJOR="${VER%%.*}"
+          if [ -n "${MAJOR:-}" ] && [ "$MAJOR" -ge 26 ] 2>/dev/null; then
+            echo "Using selected Xcode $VER at $CUR"
+            echo "DEVELOPER_DIR=$CUR" >> "$GITHUB_ENV"
+            xcodebuild -version
+            exit 0
+          fi
+          echo "❌ No Xcode >= 26 found on the runner. Installed Xcodes:"
+          ls -d /Applications/Xcode*.app 2>/dev/null || true
+          exit 1
+
+      # Lightweight resource sampler — RAM is the scarce resource on this small VM, so record
+      # free/compressed/swap (+ loadavg + top-RSS process) every 15s during the build. Surfaces a
+      # peak summary in the run's Step Summary and uploads the full trace as an artifact, so we know
+      # how much headroom the 6 GB VM actually had instead of only "it didn't OOM".
+      - name: Start resource sampler
+        run: |
+          LOG="$RUNNER_TEMP/mem_usage.log"
+          echo "time     free_mb  compressed_mb  swap_used_mb  load1  top_rss_mb cmd" > "$LOG"
+          (
+            PAGE=$(vm_stat | awk '/page size of/{print $8; exit}'); PAGE=${PAGE:-16384}
+            while :; do
+              V=$(vm_stat)
+              F=$(echo "$V" | awk '/Pages free/{gsub(/\./,"",$3); print $3}')
+              C=$(echo "$V" | awk '/occupied by compressor/{gsub(/\./,"",$5); print $5}')
+              S=$(sysctl -n vm.swapusage | awk '{gsub(/M/,"",$6); print $6}')
+              L=$(sysctl -n vm.loadavg | awk '{print $2}')
+              T=$(ps -axo rss=,comm= | sort -rn | head -1 | awk '{r=$1/1024; $1=""; sub(/^ /,""); printf "%.0f %s", r, $0}')
+              printf '%s  %s  %s  %s  %s  %s\n' "$(date -u +%H:%M:%S)" "$((F*PAGE/1048576))" "$((C*PAGE/1048576))" "${S:-0}" "${L:-0}" "$T" >> "$LOG"
+              sleep 15
+            done
+          ) >/dev/null 2>&1 &
+          echo $! > "$RUNNER_TEMP/mem_sampler.pid"
+          echo "resource sampler started (pid $(cat "$RUNNER_TEMP/mem_sampler.pid")) → $LOG"
+
+      - name: Build macOS (host)
+        timeout-minutes: 30
+        run: cargo run -- build --release ${{ env.PROD_FLAG }}
+
+      - name: Build iOS
+        timeout-minutes: 30
+        run: cargo run -- build --release --target ios ${{ env.PROD_FLAG }}
+
+      # Allocate the store build number (idempotent per commit SHA, matches the Android versionCode
+      # for the same commit); export below stamps it into CFBundleVersion. Skipped if the secret is
+      # absent (keeps the committed placeholder — these unsigned per-push builds never ship).
+      - name: Compute build number
+        uses: ./.github/actions/compute-build-number
+        with:
+          sha: ${{ github.event.pull_request.head.sha || github.sha }}
+          secret: ${{ secrets.BUILD_NUMBER_SECRET }}
+          allocated-by: ios
+
+      - name: Import assets
+        uses: ./.github/actions/import-assets
+
+      - name: Export
+        timeout-minutes: 10
+        run: cargo run -- export --target ios
+
+      # Package the export TREE (Xcode project + embedded libdclgodot.dylib + assets) and upload it
+      # to R2, keyed by branch + commit (mirrors ios_r2_artifact.yml). A separate deploy repo can
+      # pull, sign and ship it; this repo holds no Apple signing material.
+      - name: Package & upload unsigned export to R2
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.MOBILE_ARTIFACTS_R2_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.MOBILE_ARTIFACTS_R2_SECRET_ACCESS_KEY }}
+          AWS_ENDPOINT_URL: ${{ secrets.MOBILE_ARTIFACTS_R2_ENDPOINT }}
+          AWS_S3_BUCKET: ${{ secrets.MOBILE_ARTIFACTS_R2_BUCKET }}
+          R2_PUBLIC_BASE_URL: "https://mobile-artifacts.dclregenesislabs.xyz"
+          REF: ${{ github.head_ref || github.ref_name }}
+          SHA_INPUT: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -eu
+          if [ -z "${AWS_ACCESS_KEY_ID:-}" ] || [ -z "${AWS_S3_BUCKET:-}" ] || [ -z "${AWS_ENDPOINT_URL:-}" ]; then
+            echo "❌ R2 mobile-artifacts bucket not configured (MOBILE_ARTIFACTS_R2_* secrets)"
+            exit 1
+          fi
+          if [ ! -d exports ]; then
+            echo "❌ exports/ not found — the Godot iOS export did not run"
+            exit 1
+          fi
+
+          echo "exports/ contents:"; ls -la exports/
+          echo "dylibs found:"; find exports -name "*.dylib" 2>/dev/null || true
+
+          tar -czf export.tar.gz -C exports .
+          echo "Export tarball size: $(du -h export.tar.gz | cut -f1)"
+
+          # The macOS runner may not ship the AWS CLI — install it on demand via Homebrew.
+          if ! command -v aws >/dev/null 2>&1; then
+            echo "Installing AWS CLI via Homebrew..."
+            brew install awscli
+          fi
+
+          SHA="${SHA_INPUT:-${{ github.sha }}}"
+          SAFE_BRANCH=$(echo "$REF" | tr '/' '-')
+          KEY="ios/${SAFE_BRANCH}/${SHA}/export.tar.gz"
+          LATEST_KEY="ios/${SAFE_BRANCH}/latest/export.tar.gz"
+
+          echo "📤 Uploading export to s3://${AWS_S3_BUCKET}/${KEY}"
+          aws s3 cp export.tar.gz "s3://${AWS_S3_BUCKET}/${KEY}" --endpoint-url "$AWS_ENDPOINT_URL"
+          # Update the branch 'latest' pointer WITHOUT re-uploading the tarball. The managed
+          # `aws s3 cp s3:// s3://` is unusable on R2 (it sends GetObjectTagging / x-amz-tagging-
+          # directive, both NotImplemented), so use the low-level copy-object; fall back to a plain
+          # re-upload if R2 ever rejects the copy, so the build never breaks. asc-deploy's manual
+          # dispatch defaults to ios/<branch>/latest, so this key must stay populated.
+          echo "🔗 Updating latest pointer s3://${AWS_S3_BUCKET}/${LATEST_KEY}"
+          aws s3api copy-object --bucket "$AWS_S3_BUCKET" --key "$LATEST_KEY" \
+            --copy-source "${AWS_S3_BUCKET}/${KEY}" --endpoint-url "$AWS_ENDPOINT_URL" >/dev/null \
+            || aws s3 cp export.tar.gz "s3://${AWS_S3_BUCKET}/${LATEST_KEY}" --endpoint-url "$AWS_ENDPOINT_URL"
+
+          echo "✅ Unsigned export uploaded to R2 (sha=${SHA}, branch=${SAFE_BRANCH})"
+          echo "🔗 ${R2_PUBLIC_BASE_URL}/${KEY}"
+
+      # Stop the sampler and surface the result. `always()` so we still capture the trace when the
+      # build FAILS (e.g. an OOM kill) — that's exactly the run we most want the memory profile for.
+      - name: Resource usage report
+        if: always()
+        run: |
+          kill "$(cat "$RUNNER_TEMP/mem_sampler.pid" 2>/dev/null)" 2>/dev/null || true
+          LOG="$RUNNER_TEMP/mem_usage.log"
+          if [ ! -s "$LOG" ]; then echo "no sampler log found"; exit 0; fi
+          {
+            echo '### 🍏 iOS build — VM resource usage (6 GB guest)'
+            echo '```'
+            awk 'NR>1{
+                   if($4>mxswap)mxswap=$4
+                   if(NR==2||$2<mnfree)mnfree=$2
+                   if($3>mxcomp)mxcomp=$3
+                   if($5>mxload)mxload=$5
+                 }
+                 END{
+                   printf "peak swap used : %s MB\nmin free       : %s MB\npeak compressed: %s MB\npeak load1     : %s\nsamples (~15s) : %d\n",
+                          mxswap+0, mnfree+0, mxcomp+0, mxload+0, NR-1
+                 }' "$LOG"
+            echo '--- trace tail ---'
+            tail -30 "$LOG"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          cp "$LOG" mem_usage.log
+
+      - name: Upload resource trace
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ios-resource-usage
+          path: mem_usage.log
+          if-no-files-found: ignore

--- a/.github/workflows/mobile_distribute.yml
+++ b/.github/workflows/mobile_distribute.yml
@@ -215,10 +215,98 @@ jobs:
           fi
 
   # iOS leg, step 1: build the unsigned Godot export and publish it to R2 (no Apple creds).
-  ios-build:
-    name: 🍏 iOS → R2 (unsigned export)
+  # Before paying for a WarpBuild rebuild, check whether the self-hosted iOS runner already produced
+  # (or is producing) the unsigned export for THIS exact commit in R2 (ios_self_hosted.yml uploads it
+  # on every push). If so, skip the rebuild and sign that artifact directly (ios-dispatch). Mirrors
+  # android-notify's R2 poll + fail-fast.
+  ios-resolve:
+    name: 🍏 iOS — resolve (reuse existing export?)
     needs: prepare
     if: needs.prepare.outputs.should_build == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    outputs:
+      reuse: ${{ steps.resolve.outputs.reuse }}
+      build_version: ${{ steps.resolve.outputs.build_version }}
+    env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.MOBILE_ARTIFACTS_R2_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.MOBILE_ARTIFACTS_R2_SECRET_ACCESS_KEY }}
+      AWS_ENDPOINT_URL: ${{ secrets.MOBILE_ARTIFACTS_R2_ENDPOINT }}
+      AWS_S3_BUCKET: ${{ secrets.MOBILE_ARTIFACTS_R2_BUCKET }}
+      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+      SLACK_CHANNEL:   ${{ secrets.SLACK_CHANNEL_ID }}
+      SLACK_TS:        ${{ needs.prepare.outputs.slack_ts }}
+      REF:         ${{ needs.prepare.outputs.ref }}
+      SHA:         ${{ needs.prepare.outputs.sha }}
+      SAFE_BRANCH: ${{ needs.prepare.outputs.safe_branch }}
+      GH_TOKEN:    ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Validate required secrets
+        run: |
+          MISSING=""
+          [ -z "$AWS_S3_BUCKET" ] && MISSING="$MISSING MOBILE_ARTIFACTS_R2_BUCKET"
+          [ -z "$AWS_ENDPOINT_URL" ] && MISSING="$MISSING MOBILE_ARTIFACTS_R2_ENDPOINT"
+          [ -z "$AWS_ACCESS_KEY_ID" ] && MISSING="$MISSING MOBILE_ARTIFACTS_R2_ACCESS_KEY_ID"
+          if [ -n "$MISSING" ]; then echo "❌ Missing required secrets:$MISSING"; exit 1; fi
+          echo "✅ Required secrets present"
+
+      - name: Resolve reuse vs build
+        id: resolve
+        run: |
+          KEY="ios/${SAFE_BRANCH}/${SHA}/export.tar.gz"
+          echo "Looking for an existing unsigned export at s3://${AWS_S3_BUCKET}/${KEY}"
+          echo "(produced by the self-hosted iOS runner — ios_self_hosted.yml — for this commit)"
+          have_export() { aws s3api head-object --bucket "$AWS_S3_BUCKET" --key "$KEY" --endpoint-url "$AWS_ENDPOINT_URL" >/dev/null 2>&1; }
+
+          reuse=false
+          if have_export; then
+            echo "✅ Export already present — reusing it (no WarpBuild rebuild)."
+            reuse=true
+          else
+            # The self-hosted build for this commit may still be in flight (~12 min). Poll for it,
+            # but fail fast (→ build on CI) the moment that run concludes without a usable export.
+            DEADLINE=$(( $(date +%s) + 20 * 60 ))
+            while true; do
+              if have_export; then echo "✅ Export appeared — reusing it."; reuse=true; break; fi
+              CONCLUSION=$(gh run list --repo "${{ github.repository }}" --workflow ios_self_hosted.yml \
+                --limit 100 --json headSha,conclusion \
+                --jq "first(.[] | select(.headSha==\"$SHA\")) | .conclusion // empty" 2>/dev/null || true)
+              case "$CONCLUSION" in
+                failure|cancelled|skipped|timed_out|success)
+                  echo "ℹ️  self-hosted run for $SHA concluded '$CONCLUSION' with no usable export → building on CI."
+                  break ;;
+              esac
+              if [ "$(date +%s)" -ge "$DEADLINE" ]; then
+                echo "ℹ️  timed out waiting for the self-hosted export → building on CI."
+                break
+              fi
+              sleep 30
+            done
+          fi
+          echo "reuse=$reuse" >> "$GITHUB_OUTPUT"
+
+          # In the reuse path nobody runs the lib build that writes .build.version, so reconstruct it
+          # deterministically (matches lib/build.rs: <lib-version>-<short-sha>-<prod|staging>).
+          LIB_VERSION=$(grep -m1 '^version' lib/Cargo.toml | sed -E 's/.*"([^"]+)".*/\1/')
+          if [ "$REF" = "release" ]; then SUFFIX="prod"; else SUFFIX="staging"; fi
+          echo "build_version=${LIB_VERSION}-${SHA:0:7}-${SUFFIX}" >> "$GITHUB_OUTPUT"
+          echo "→ reuse=$reuse · build_version=${LIB_VERSION}-${SHA:0:7}-${SUFFIX}"
+
+      - name: Slack — iOS reuse decision
+        if: env.SLACK_TS != ''
+        run: |
+          if [ "${{ steps.resolve.outputs.reuse }}" = "true" ]; then
+            bash .github/scripts/slack-reply.sh "♻️ iOS — found an existing export for this commit; skipping the CI rebuild."
+          else
+            bash .github/scripts/slack-reply.sh "🔨 iOS — no existing export; building on CI."
+          fi
+
+  ios-build:
+    name: 🍏 iOS → R2 (unsigned export)
+    needs: [prepare, ios-resolve]
+    if: needs.prepare.outputs.should_build == 'true' && needs.ios-resolve.outputs.reuse == 'false'
     uses: ./.github/workflows/ios_r2_artifact.yml
     with:
       ref: ${{ needs.prepare.outputs.ref }}
@@ -233,15 +321,64 @@ jobs:
       whats_new: ${{ github.event.inputs.whats_new }}
     secrets: inherit
 
-  # ios-build now also fires the deploy handoff. If it fails or is cancelled, godot-asc-deploy
-  # never runs, so nothing would move the root card off BUILDING — this finalizes it. It can't
-  # clobber the deploy repo's own root update (the deploy didn't run).
+  # Reuse path: an unsigned export for this commit already exists in R2 (built by the self-hosted
+  # runner), so skip WarpBuild and hand off to godot-asc-deploy directly with the same payload.
+  ios-dispatch:
+    name: 🍏 iOS — dispatch (reuse existing export)
+    needs: [prepare, ios-resolve]
+    if: needs.prepare.outputs.should_build == 'true' && needs.ios-resolve.outputs.reuse == 'true'
+    runs-on: ubuntu-latest
+    env:
+      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+      SLACK_CHANNEL:   ${{ secrets.SLACK_CHANNEL_ID }}
+      SLACK_TS:        ${{ needs.prepare.outputs.slack_ts }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      # Same idempotent-per-SHA allocator the build path uses → returns the SAME number the
+      # self-hosted build already allocated for this commit (sets DCL_BUILD_NUMBER).
+      - name: Compute build number
+        uses: ./.github/actions/compute-build-number
+        with:
+          sha: ${{ needs.prepare.outputs.sha }}
+          secret: ${{ secrets.BUILD_NUMBER_SECRET }}
+          allocated-by: ios
+
+      - name: Dispatch godot-asc-deploy (sign & upload to TestFlight)
+        uses: ./.github/actions/dispatch-asc-deploy
+        with:
+          gh-token: ${{ secrets.ASC_DEPLOY_DISPATCH_TOKEN }}
+          ref: ${{ needs.prepare.outputs.ref }}
+          sha: ${{ needs.prepare.outputs.sha }}
+          whats_new: ${{ github.event.inputs.whats_new }}
+          pr_number: ${{ needs.prepare.outputs.pr_number }}
+          slack_ts: ${{ needs.prepare.outputs.slack_ts }}
+          build_version: ${{ needs.ios-resolve.outputs.build_version }}
+          build_number: ${{ env.DCL_BUILD_NUMBER }}
+          triggered_by: ${{ needs.prepare.outputs.triggered_by }}
+
+      - name: Slack — handed off (reused export)
+        if: success() && env.SLACK_TS != ''
+        run: |
+          bash .github/scripts/slack-reply.sh "♻️🤝 iOS — reused export, handed off to the signing pipeline (godot-asc-deploy)."
+
+      - name: Slack — handoff failed
+        if: failure() && env.SLACK_TS != ''
+        run: |
+          bash .github/scripts/slack-reply.sh "❌ iOS — failed to hand off to the signing pipeline (check ASC_DEPLOY_DISPATCH_TOKEN)."
+
+  # iOS hands off the deploy from either ios-build (rebuild path) or ios-dispatch (reuse path). If
+  # resolve, build, or dispatch fails/cancels, godot-asc-deploy never runs, so nothing would move
+  # the root card off BUILDING — this finalizes it. A skipped leg (the path not taken) is ignored.
+  # It can't clobber the deploy repo's own root update (the deploy didn't run).
   root-failed:
     name: 🛑 Finalize root (failed/cancelled)
-    needs: [prepare, ios-build]
+    needs: [prepare, ios-resolve, ios-build, ios-dispatch]
     if: >-
-      always() && needs.prepare.outputs.should_build == 'true' &&
-      (needs.ios-build.result == 'failure' || needs.ios-build.result == 'cancelled')
+      always() && needs.prepare.outputs.should_build == 'true' && (
+        needs.ios-resolve.result == 'failure' || needs.ios-resolve.result == 'cancelled' ||
+        needs.ios-build.result == 'failure' || needs.ios-build.result == 'cancelled' ||
+        needs.ios-dispatch.result == 'failure' || needs.ios-dispatch.result == 'cancelled' )
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -257,10 +394,13 @@ jobs:
           COMMIT: ${{ needs.prepare.outputs.commit_short }}
           COMMIT_URL: ${{ github.server_url }}/${{ github.repository }}/commit/${{ needs.prepare.outputs.sha }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          IOS_RESOLVE_RESULT: ${{ needs.ios-resolve.result }}
           IOS_BUILD_RESULT: ${{ needs.ios-build.result }}
+          IOS_DISPATCH_RESULT: ${{ needs.ios-dispatch.result }}
         run: |
           # Don't set ANDROID_LINE — merge-on-read preserves whatever the Android leg wrote.
-          if [ "$IOS_BUILD_RESULT" = "cancelled" ]; then
+          # Pick whichever leg actually failed; the path not taken is 'skipped' and ignored.
+          if [ "$IOS_RESOLVE_RESULT" = "cancelled" ] || [ "$IOS_BUILD_RESULT" = "cancelled" ] || [ "$IOS_DISPATCH_RESULT" = "cancelled" ]; then
             export STATUS="cancelled"; export IOS_LINE="⚠️ cancelled"
           else
             export STATUS="failed"; export IOS_LINE="❌ build/handoff failed"

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -11,13 +11,39 @@ pub const PROTOC_BASE_URL: &str =
 
 pub const GODOT_ENGINE_RELEASES_BASE_URL: &str = "https://godot-engine-releases.dclexplorer.com/";
 
-pub const GODOT4_BIN_BASE_URL: &str =
-    "https://godot-engine-releases.dclexplorer.com/4.6.2.stable/editors/";
-
 pub const GODOT_CURRENT_VERSION: &str = "4.6.2";
 
-pub const GODOT4_EXPORT_TEMPLATES_BASE_URL: &str =
-    "https://godot-engine-releases.dclexplorer.com/4.6.2.stable/compressed-templates/";
+/// Short commit SHA (first 9 chars) of the godotengine fork this stable build was compiled from.
+/// Must match the `gh.<sha>` segment printed by `godot4_bin --version`
+/// (e.g. `4.6.2.stable.gh.6ddcadb64 - Protocol Squad`) and the SHA-tagged release path published
+/// by the godot-engine-releases pipeline. Bump it in lockstep with a new fork publish: it busts the
+/// local download cache (keys embed it) and pins the immutable per-SHA release URLs below.
+pub const GODOT_BUILD_SHA: &str = "6ddcadb64";
+
+/// Release tag identifying a specific fork build — `<version>.stable.gh.<sha>`, mirroring the
+/// `--version` string. Single source for the release URL path segment, the on-disk template SHA
+/// marker, and the installed-binary version validation.
+pub fn godot_release_tag() -> String {
+    format!("{GODOT_CURRENT_VERSION}.stable.gh.{GODOT_BUILD_SHA}")
+}
+
+/// Editor (binary) base URL for the pinned stable fork build, e.g.
+/// `https://godot-engine-releases.dclexplorer.com/4.6.2.stable.gh.6ddcadb64/editors/`.
+pub fn godot_editor_base_url() -> String {
+    format!(
+        "{GODOT_ENGINE_RELEASES_BASE_URL}{}/editors/",
+        godot_release_tag()
+    )
+}
+
+/// Compressed-templates base URL for the pinned stable fork build, e.g.
+/// `https://godot-engine-releases.dclexplorer.com/4.6.2.stable.gh.6ddcadb64/compressed-templates/`.
+pub fn godot_templates_base_url() -> String {
+    format!(
+        "{GODOT_ENGINE_RELEASES_BASE_URL}{}/compressed-templates/",
+        godot_release_tag()
+    )
+}
 
 /// Sanitizes a git branch name for use in the release artifact URL path.
 /// Slashes (e.g. `fix/foo`) are replaced with dashes (`fix-foo`) to match how

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -217,11 +217,30 @@ fn check_sentry_addon_installation() -> bool {
 }
 
 fn check_godot_installation() {
-    if crate::helpers::is_tool_installed("godot") {
-        print_message(MessageType::Success, "Godot binary found");
-    } else {
-        print_message(MessageType::Warning, "Godot binary not found");
-        println!("  Run: cargo run -- install");
+    use crate::install_dependency::GodotBinaryStatus;
+    match crate::install_dependency::validate_installed_godot_binary() {
+        GodotBinaryStatus::Ok => print_message(
+            MessageType::Success,
+            &format!(
+                "Godot binary found — {}",
+                crate::consts::godot_release_tag()
+            ),
+        ),
+        GodotBinaryStatus::Mismatch { found } => print_message(
+            MessageType::Error,
+            &format!(
+                "Godot binary mismatch: expected {}, found {found} — run: cargo run -- install",
+                crate::consts::godot_release_tag()
+            ),
+        ),
+        GodotBinaryStatus::Missing => {
+            print_message(MessageType::Warning, "Godot binary not found");
+            println!("  Run: cargo run -- install");
+        }
+        GodotBinaryStatus::Unverifiable(e) => print_message(
+            MessageType::Warning,
+            &format!("Godot binary present but unverifiable: {e}"),
+        ),
     }
 
     // Check export templates per platform

--- a/src/export.rs
+++ b/src/export.rs
@@ -3,9 +3,9 @@ use zip::ZipArchive;
 
 use crate::{
     consts::{
-        godot_templates_base_url_for_branch, sanitize_branch_for_url, EXPORTS_FOLDER,
-        GODOT4_EXPORT_TEMPLATES_BASE_URL, GODOT_CURRENT_VERSION, GODOT_PLATFORM_FILES,
-        GODOT_PROJECT_FOLDER,
+        godot_release_tag, godot_templates_base_url, godot_templates_base_url_for_branch,
+        sanitize_branch_for_url, EXPORTS_FOLDER, GODOT_BUILD_SHA, GODOT_CURRENT_VERSION,
+        GODOT_PLATFORM_FILES, GODOT_PROJECT_FOLDER,
     },
     helpers::get_exe_extension,
     install_dependency::{
@@ -279,6 +279,7 @@ pub fn export(
 ) -> Result<(), anyhow::Error> {
     print_section("Exporting Project");
 
+    crate::install_dependency::warn_if_godot_mismatch();
     let program = get_godot_path();
 
     // Make exports directory if it doesn't exist
@@ -510,11 +511,31 @@ pub fn prepare_templates(
 
     let templates_base_url = match branch {
         Some(b) => godot_templates_base_url_for_branch(b),
-        None => GODOT4_EXPORT_TEMPLATES_BASE_URL.to_string(),
+        None => godot_templates_base_url(),
     };
 
+    let expected_tag = godot_release_tag();
     for template in &templates {
         if let Some(files) = file_map.get(template.as_str()) {
+            // Skip-guard: on a non-branch install, if our per-platform SHA marker matches the
+            // expected release tag AND every template file is present, the (potentially multi-GB —
+            // iOS `ios.zip` ≈ 2 GB) download + re-extract is redundant, so skip it entirely. Godot's
+            // own `version.txt` only carries the version (no SHA), hence our own marker. Branch
+            // builds are never marked/skipped (their fork SHA isn't tracked at const time).
+            let marker = Path::new(&dest_path).join(format!(".dcl_build_sha_{template}"));
+            let marker_ok = branch.is_none()
+                && fs::read_to_string(&marker)
+                    .map(|s| s.trim() == expected_tag)
+                    .unwrap_or(false);
+            let all_present = files.iter().all(|f| Path::new(&dest_path).join(f).exists());
+            if marker_ok && all_present {
+                print_message(
+                    MessageType::Info,
+                    &format!("{template} templates already at {expected_tag} — skipping download"),
+                );
+                continue;
+            }
+
             for file in files {
                 println!("Downloading file for {}: {}", template, file);
 
@@ -524,9 +545,15 @@ pub fn prepare_templates(
                         "{GODOT_CURRENT_VERSION}.branch-{}.{file}.export-templates.zip",
                         sanitize_branch_for_url(b)
                     ),
-                    None => format!("{GODOT_CURRENT_VERSION}.{file}.export-templates.zip"),
+                    None => format!(
+                        "{GODOT_CURRENT_VERSION}-{GODOT_BUILD_SHA}.{file}.export-templates.zip"
+                    ),
                 };
                 download_and_extract_zip(url.as_str(), dest_path.as_str(), cache_key(cache_id))?;
+            }
+            // Stamp the SHA marker after a successful extract so the next run can skip.
+            if branch.is_none() {
+                let _ = fs::write(&marker, &expected_tag);
             }
         } else {
             println!("No files mapped for template: {}", template);

--- a/src/install_dependency.rs
+++ b/src/install_dependency.rs
@@ -19,8 +19,9 @@ use crate::platform::{
 use crate::ui::{create_spinner, print_message, print_section, MessageType};
 
 use crate::consts::{
-    godot_editor_base_url_for_branch, sanitize_branch_for_url, BIN_FOLDER, GODOT4_BIN_BASE_URL,
-    GODOT_CURRENT_VERSION, PROTOC_BASE_URL, RUST_LIB_PROJECT_FOLDER,
+    godot_editor_base_url, godot_editor_base_url_for_branch, godot_release_tag,
+    sanitize_branch_for_url, BIN_FOLDER, GODOT_BUILD_SHA, GODOT_CURRENT_VERSION, PROTOC_BASE_URL,
+    RUST_LIB_PROJECT_FOLDER,
 };
 
 fn create_directory_all(path: &Path) -> io::Result<()> {
@@ -41,9 +42,7 @@ fn get_protocol_url() -> Result<String, anyhow::Error> {
         return Ok(url.to_string());
     }
 
-    let manifest_url = format!(
-        "https://registry.npmjs.org/@dcl/protocol/{PROTOCOL_NPM_DIST_TAG}"
-    );
+    let manifest_url = format!("https://registry.npmjs.org/@dcl/protocol/{PROTOCOL_NPM_DIST_TAG}");
     let manifest: serde_json::Value = Client::new().get(&manifest_url).send()?.json()?;
     manifest
         .get("dist")
@@ -258,7 +257,7 @@ fn get_godot_url(branch: Option<&str>) -> Option<String> {
 
     let base_url = match branch {
         Some(b) => godot_editor_base_url_for_branch(b),
-        None => GODOT4_BIN_BASE_URL.to_string(),
+        None => godot_editor_base_url(),
     };
 
     Some(format!("{base_url}{os_url}"))
@@ -299,6 +298,73 @@ pub fn get_godot_executable_path() -> Option<String> {
     }?;
 
     Some(os_url)
+}
+
+/// Status of the locally-installed Godot editor binary relative to the pinned
+/// `GODOT_CURRENT_VERSION` + `GODOT_BUILD_SHA`.
+#[derive(Debug)]
+pub enum GodotBinaryStatus {
+    /// Installed and matches the expected version + fork SHA.
+    Ok,
+    /// Installed but reports a different version/SHA (`found` = raw `--version` line).
+    Mismatch { found: String },
+    /// No binary at `BinPaths::godot_bin()`.
+    Missing,
+    /// Present but its version couldn't be determined (couldn't exec, or unrecognized output).
+    Unverifiable(String),
+}
+
+/// Parse a Godot `--version` line of the form `"{version}.stable.gh.{sha} - {label}"` into
+/// `(version, sha)`. Returns `None` for any line lacking the `.stable.gh.` marker (e.g. branch or
+/// custom builds whose SHA we don't pin). OS-independent — the format comes from Godot's
+/// `VERSION_FULL_NAME` and is identical across platforms.
+pub fn parse_godot_version(line: &str) -> Option<(String, String)> {
+    let token = line.split_whitespace().next()?; // first token; drops the " - <label>" suffix
+    let (version, rest) = token.split_once(".stable.gh.")?;
+    let sha = rest.split('.').next()?; // tolerate any trailing segments
+    Some((version.to_string(), sha.to_string()))
+}
+
+/// Run the installed `godot4_bin --version` and compare against `GODOT_CURRENT_VERSION` +
+/// `GODOT_BUILD_SHA`. Always validates the HOST editor binary (never the cross-compiled export
+/// templates — those are covered by the per-platform SHA marker in `prepare_templates`).
+pub fn validate_installed_godot_binary() -> GodotBinaryStatus {
+    let bin = BinPaths::godot_bin(); // .bin/godot/godot4_bin — same file is_tool_installed checks
+    if !bin.exists() {
+        return GodotBinaryStatus::Missing;
+    }
+    let output = match std::process::Command::new(&bin).arg("--version").output() {
+        Ok(o) => o,
+        Err(e) => return GodotBinaryStatus::Unverifiable(e.to_string()),
+    };
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let line = stdout.lines().find(|l| l.contains(".stable")).unwrap_or("");
+    match parse_godot_version(line) {
+        Some((v, sha)) if v == GODOT_CURRENT_VERSION && sha == GODOT_BUILD_SHA => {
+            GodotBinaryStatus::Ok
+        }
+        Some(_) => GodotBinaryStatus::Mismatch {
+            found: line.trim().to_string(),
+        },
+        None => {
+            GodotBinaryStatus::Unverifiable(format!("unrecognized --version output: {stdout:?}"))
+        }
+    }
+}
+
+/// Warn (non-fatal) if the installed Godot binary doesn't match the pinned version+SHA. Used as a
+/// pre-`run` / pre-`export` guard. Intentionally a warning, never an error: `run`/`export` carry no
+/// `--branch` context, so a developer on a branch build would always "mismatch" the const SHA.
+pub fn warn_if_godot_mismatch() {
+    if let GodotBinaryStatus::Mismatch { found } = validate_installed_godot_binary() {
+        print_message(
+            MessageType::Warning,
+            &format!(
+                "Installed Godot is {found}, expected {} — run `cargo run -- install` to refresh",
+                godot_release_tag()
+            ),
+        );
+    }
 }
 
 fn install_android_tools() -> Result<(), anyhow::Error> {
@@ -546,15 +612,43 @@ pub fn install(
         print_message(MessageType::Success, "protoc already installed");
     }
 
-    // Check if Godot is already installed
-    if !crate::helpers::is_tool_installed("godot") {
+    // (Re)install Godot if missing OR if the present binary doesn't match the pinned version+SHA.
+    // A stale binary (same version, different fork SHA) is replaced; the SHA-tagged cache key below
+    // guarantees a cache miss so the fresh fork build is fetched, not the stale cached zip. Branch
+    // builds use existence-only (their fork SHA isn't tracked at const time).
+    let needs_godot = match (branch, validate_installed_godot_binary()) {
+        (Some(_), GodotBinaryStatus::Missing) => true,
+        (Some(_), _) => false,
+        (None, GodotBinaryStatus::Ok) => false,
+        (None, GodotBinaryStatus::Missing) => true,
+        (None, GodotBinaryStatus::Mismatch { found }) => {
+            print_message(
+                MessageType::Warning,
+                &format!(
+                    "Godot binary is {found}, expected {} — re-downloading",
+                    godot_release_tag()
+                ),
+            );
+            true
+        }
+        (None, GodotBinaryStatus::Unverifiable(e)) => {
+            // Present but can't self-report (e.g. can't exec the host binary). Don't loop-redownload
+            // the same artifact — warn and keep it.
+            print_message(
+                MessageType::Warning,
+                &format!("Could not verify Godot binary ({e}); leaving as-is"),
+            );
+            false
+        }
+    };
+    if needs_godot {
         print_section("Installing Godot Engine");
         let godot_cache_key = match branch {
             Some(b) => format!(
                 "{GODOT_CURRENT_VERSION}.branch-{}.executable.zip",
                 sanitize_branch_for_url(b)
             ),
-            None => format!("{GODOT_CURRENT_VERSION}.executable.zip"),
+            None => format!("{GODOT_CURRENT_VERSION}-{GODOT_BUILD_SHA}.executable.zip"),
         };
         download_and_extract_zip(
             get_godot_url(branch).unwrap().as_str(),
@@ -574,7 +668,10 @@ pub fn install(
         fs::copy(program_path, dest_program_path)?;
         print_message(MessageType::Success, "Godot binary installed");
     } else {
-        print_message(MessageType::Success, "Godot binary already installed");
+        print_message(
+            MessageType::Success,
+            "Godot binary already installed (version verified)",
+        );
     }
 
     if !PathBuf::from(GODOT_SENTRY_ADDON_FOLDER).exists() {
@@ -620,4 +717,37 @@ pub fn install(
     println!("{}", next_steps);
 
     Ok(())
+}
+
+#[cfg(test)]
+mod godot_version_tests {
+    use super::parse_godot_version;
+
+    #[test]
+    fn parses_stable_gh_build() {
+        assert_eq!(
+            parse_godot_version("4.6.2.stable.gh.9ee6af7ab - Protocol Squad"),
+            Some(("4.6.2".to_string(), "9ee6af7ab".to_string()))
+        );
+    }
+
+    #[test]
+    fn tolerates_trailing_newline_and_crlf() {
+        assert_eq!(
+            parse_godot_version("4.6.2.stable.gh.9ee6af7ab - Protocol Squad\n"),
+            Some(("4.6.2".to_string(), "9ee6af7ab".to_string()))
+        );
+        assert_eq!(
+            parse_godot_version("4.6.2.stable.gh.9ee6af7ab - Protocol Squad\r\n"),
+            Some(("4.6.2".to_string(), "9ee6af7ab".to_string()))
+        );
+    }
+
+    #[test]
+    fn rejects_non_gh_builds() {
+        // Branch / custom builds without the `.stable.gh.` marker are not pinned.
+        assert_eq!(parse_godot_version("4.6.2.stable.custom_build"), None);
+        assert_eq!(parse_godot_version("4.6.2.stable"), None);
+        assert_eq!(parse_godot_version(""), None);
+    }
 }

--- a/src/run.rs
+++ b/src/run.rs
@@ -25,6 +25,7 @@ pub fn run(
     client_tests: bool,
     use_tuned_glibc: bool,
 ) -> anyhow::Result<()> {
+    crate::install_dependency::warn_if_godot_mismatch();
     let program = get_godot_path();
     println!("extras: {:?}", extras);
 


### PR DESCRIPTION
## Summary

Overhaul of the iOS / mobile build & distribution pipeline, built on a self-hosted iOS runner:
Godot-fork SHA pinning, reliable R2 `latest` pointers, and build-label export reuse.

### 1. Self-hosted iOS runner — `ios_self_hosted.yml`
Builds the iOS app (Rust lib + Godot export) on a self-hosted macOS runner on every push/PR and
uploads the unsigned export to R2. Persistent incremental build cache (`clean: false`) + a
lightweight RAM/CPU sampler that surfaces peak VM usage in the run Summary (the 6 GB guest survives
the cold build with ~0 swap).

### 2. Godot fork pinned by build SHA — `xtask` (consts/install/export/doctor/run)
The Godot editor/templates download is pinned to an **immutable per-SHA release path**
(`<ver>.stable.gh.<sha>`) that matches the binary's own `--version`, so a fork rebuild under the same
version can't serve a stale cached artifact. Adds `--version` validation
(`parse_godot_version` / `validate_installed_godot_binary`, used by `install` / `doctor` + a
non-fatal `run`/`export` guard), SHA-tagged download cache keys, and a per-platform template
skip-guard that avoids the multi-GB iOS template re-download when already at the pinned tag.

### 3. R2 `latest` via server-side copy — `ios_self_hosted.yml`, `ios_r2_artifact.yml`, `android_builds.yml`
Update the branch `latest` pointer with a low-level `aws s3api copy-object` (+ re-upload fallback)
instead of re-uploading the bytes. R2 rejects the managed `aws s3 cp` server-side copy (it sends
GetObjectTagging / `x-amz-tagging-directive`, both NotImplemented).

### 4. Build-label reuses the self-hosted export — `mobile_distribute.yml`, `ios_r2_artifact.yml`, new `dispatch-asc-deploy` composite
When the `build` label fires, `ios-resolve` checks R2 for an unsigned export the self-hosted runner
already produced for that commit (head-object + bounded poll + fail-fast on the run's conclusion).
If present → `ios-dispatch` hands off to godot-asc-deploy directly, **skipping the WarpBuild
rebuild**; otherwise → the WarpBuild `ios-build` path, as today. The `dispatch-asc-deploy` composite
factors the handoff so both paths share it. Concurrency tweak: a `labeled` event no longer cancels
the in-flight `synchronize` self-hosted build, so its export stays reusable.

### Cross-repo dependency
Requires `decentraland/godotengine@4.6.2` to publish under the SHA-tagged release path (commit
`6ddcadb642` → `…/4.6.2.stable.gh.6ddcadb64/…`). `GODOT_BUILD_SHA` pins that build.

### Verification
- Rust: `cargo check` clean · `parse_godot_version` unit tests pass · clippy clean.
- Workflows: YAML validated. The R2 `latest` server-side copy and the build-label reuse re-validate
  on the first real CI run after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
