### PR TITLE
Forward-port 1.10.1 hotfixes to main

### DIFF
--- a/godot/src/decentraland_components/avatar/avatar.gd
+++ b/godot/src/decentraland_components/avatar/avatar.gd
@@ -663,6 +663,11 @@ func _apply_nickname_visibility() -> void:
 		# _update_nameplate_2d() positions/shows when allowed; hide now if gated off.
 		_nametag_gate_visible = not should_hide
 		if should_hide and nickname_ui != null:
+			# Hard reset alpha too: NameplateLayer.update() recomputes visibility from
+			# move_toward()'d alpha every frame, so a plain hide() would be undone and the
+			# stale tag would linger as a ~6-frame fade-out. Zeroing alpha makes the hide
+			# instant; the gate reopening fades it back in cleanly from 0.
+			nickname_ui.modulate.a = 0.0
 			nickname_ui.hide()
 		return
 	if should_hide:

--- a/godot/src/decentraland_components/avatar/nameplate_layer.gd
+++ b/godot/src/decentraland_components/avatar/nameplate_layer.gd
@@ -70,6 +70,11 @@ static func attach(avatar) -> void:
 	avatar.nickname_quad.visible = false
 	ui.set_anchors_preset(Control.PRESET_TOP_LEFT)
 	ui.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	# Start fully transparent: update() drives alpha with move_toward(), so a tag can
+	# only ever fade IN from invisible once the gate opens with real data. Without this
+	# the scene-default content (e.g. the "NPC#" placeholder) would fade out from the
+	# inherited modulate.a≈1.0 during the first frames after spawn.
+	ui.modulate.a = 0.0
 	ui.hide()
 	get_root().add_child(ui)
 

--- a/godot/src/mobile/joystick/virtual_joystick.gd
+++ b/godot/src/mobile/joystick/virtual_joystick.gd
@@ -137,6 +137,16 @@ func _on_gui_input(event: InputEvent) -> void:
 		return
 	if event is InputEventScreenTouch:
 		if event.pressed:
+			# Pressing the joystick zone must hand keyboard/GUI focus back to the
+			# explorer. Player movement is gated on ui_root having focus
+			# (player.gd zeroes input_dir when not explorer_has_focus), but any
+			# panel we came from (e.g. the profile passport's buttons) leaves focus
+			# on itself. Because the joystick consumes its own touches, they never
+			# reach mobile_camera_input, which is the only other place that regrabs
+			# focus — so without this the joystick animates but the avatar won't
+			# move after dismissing such a panel (#2361).
+			if not Global.explorer_has_focus():
+				Global.explorer_grab_focus()
 			if touch_index != -1:
 				return
 			if joystick_mode == JoystickMode.FIXED and not _is_point_inside_base(event.position):

--- a/godot/src/ui/components/molecules/snap_carousel/ftue_screen.gd
+++ b/godot/src/ui/components/molecules/snap_carousel/ftue_screen.gd
@@ -5,6 +5,7 @@ signal jump_in(parcel_position: Vector2i, realm_str: String)
 signal jump_in_world(realm_str: String)
 
 var _places: Array[Dictionary] = []
+var _cards_loaded: bool = false
 
 @onready var carousel: Control = %SnapCarousel
 @onready var label_title: Label = %Label_Title
@@ -45,10 +46,11 @@ func _on_items_loaded(places: Array[Dictionary]) -> void:
 
 
 func _on_all_cards_loaded() -> void:
+	_cards_loaded = true
 	label_title.show()
-	hbox_creator.show()
 	title_skeleton.hide()
 	creator_skeleton.hide()
+	_update_creator(carousel.selected_index)
 
 
 func _on_card_changed(index: int) -> void:
@@ -56,10 +58,27 @@ func _on_card_changed(index: int) -> void:
 		return
 	var place: Dictionary = _places[index]
 	label_title.text = place.get("title", "")
-	var creator: String = place.get("contact_name", "")
-	if creator.is_empty():
-		creator = place.get("owner", "")
+	_update_creator(index)
+
+
+# Show the "by <creator>" row only when the place has a real creator name.
+# The destinations API returns `contact_name: null` for worlds/places without
+# one (e.g. the Kickoff world), and the only other identifier is the raw 0x
+# `owner` address. Assigning that null to a typed String used to crash
+# _on_card_changed (leaking the "Creator" placeholder); the raw-owner fallback
+# only printed a wallet address. Hide the whole row instead when there's no name.
+func _update_creator(index: int) -> void:
+	if index < 0 or index >= _places.size():
+		hbox_creator.hide()
+		return
+	var raw = _places[index].get("contact_name")
+	var creator := "" if raw == null else str(raw)
+	if creator.strip_edges().is_empty():
+		hbox_creator.hide()
+		return
 	label_creator.text = creator
+	if _cards_loaded:
+		hbox_creator.show()
 
 
 func _on_card_tapped(_index: int) -> void:

--- a/lib/src/godot_classes/dcl_floating_islands_manager.rs
+++ b/lib/src/godot_classes/dcl_floating_islands_manager.rs
@@ -183,17 +183,26 @@ impl DclFloatingIslandsManager {
             self.candidates.insert((coord.x, coord.y), cfg);
         }
 
-        // Stale active parcels whose corner configuration changed must be
-        // rebuilt — otherwise we'd be left with cliff/overhang geometry that
-        // no longer matches the surrounding scenes (T-junctions, overhangs
-        // pointing at a now-loaded neighbor, etc.). Drop them now and let
-        // `tick_culling` re-enqueue with the fresh config.
+        // Reconcile the active set against the new candidate set:
+        //   * still a candidate, but corner config changed -> rebuild it, else
+        //     we'd keep cliff/overhang geometry that no longer matches the
+        //     surrounding scenes (T-junctions, overhangs pointing at a
+        //     now-loaded neighbor, etc.);
+        //   * no longer a candidate at all -> destroy it. This is the parcel
+        //     that just stopped being empty (a freshly-loaded scene now covers
+        //     it) or an island left over from a location we teleported away
+        //     from. `tick_culling` only ever destroys by *distance*, so an
+        //     orphan within view distance of the player would otherwise linger
+        //     forever — rendering on top of the scene we just teleported onto.
+        // Either way the parcel is dropped here; `tick_culling` re-enqueues any
+        // still-valid candidate with its fresh config.
         let stale_actives: Vec<(i32, i32)> = self
             .active
             .iter()
             .filter_map(|(coord, data)| match self.candidates.get(coord) {
                 Some(new_cfg) if new_cfg != &data.config => Some(*coord),
-                _ => None,
+                Some(_) => None,
+                None => Some(*coord),
             })
             .collect();
         for coord in stale_actives {

--- a/lib/src/scene_runner/components/avatar_shape.rs
+++ b/lib/src/scene_runner/components/avatar_shape.rs
@@ -177,6 +177,12 @@ pub fn update_avatar_shape(scene: &mut Scene, crdt_state: &mut SceneCrdtState) {
                     .unwrap();
 
                     new_avatar_shape.set("skip_process", &true.to_variant());
+                    // Flag it as an AvatarShape *before* add_child fires _ready, so the
+                    // nameplate gate can apply the "scene NPC with no real name -> hide"
+                    // rule from frame one. Otherwise _ready runs with is_avatar_shape=false
+                    // (it's only delivered by the deferred async_update_avatar below) and
+                    // the default "NPC" tag flashes on screen until that deferred call lands.
+                    new_avatar_shape.set("is_avatar_shape", &true.to_variant());
                     new_avatar_shape.set_name("AvatarShape");
                     node_3d.add_child(&new_avatar_shape.clone().upcast::<Node>());
 


### PR DESCRIPTION
Forward-ports the hotfixes from the **1.10.1** release onto `main`, so they aren't lost in the next release cycle. These currently live only on the release line — `main` does not have them.

Commits (same SHAs as on the release branch — no re-duplication):
- `0dbf2240da` fix(floating-islands): destroy island tiles that leave the candidate set
- `36376eadc0` fix(nametags): stop NPC# 2D nameplate flash on AvatarShape spawn
- `61511b86c3` fix(ftue): hide creator row when place has no contact_name
- `06f393a3bb` fix(mobile): regrab explorer focus on joystick press

Companion to #2412 (`release-1.10.1` → `release`).

> Note: `06f393a3bb` (mobile focus) is currently on this branch and heading to `main`, but is **not** on `release-1.10.1` yet — add it there too if the release should ship it.