### PR TITLE
ci: map any release* branch to the prod version suffix

### DIFF
--- a/.github/actions/set-prod-flag/action.yml
+++ b/.github/actions/set-prod-flag/action.yml
@@ -1,9 +1,9 @@
 name: Set Prod Flag
-description: Set PROD_FLAG environment variable based on the current branch (--prod for release, --staging for main and other branches)
+description: Set PROD_FLAG environment variable based on the current branch (--prod for any release* branch, --staging for main and other branches)
 
 inputs:
   ref:
-    description: 'Override ref to check (defaults to github.ref). Accepts both refs/heads/release and bare release formats.'
+    description: 'Override ref to check (defaults to github.ref). Accepts both refs/heads/release* and bare release* formats.'
     required: false
     default: ''
 
@@ -17,13 +17,19 @@ runs:
         if [ -z "$REF" ]; then
           REF="${{ github.ref }}"
         fi
-        if [ "$REF" = "refs/heads/release" ] || [ "$REF" = "release" ]; then
-          echo "PROD_FLAG=--prod" >> $GITHUB_ENV
-          echo "Running on release branch - setting PROD_FLAG=--prod (ref=$REF)"
-        else
-          echo "PROD_FLAG=--staging" >> $GITHUB_ENV
-          echo "Running on $REF - setting PROD_FLAG=--staging"
-        fi
+        # Any branch whose name starts with "release" is a prod build
+        # (e.g. release, release-1.10, release/1.10). Accepts both the
+        # refs/heads/<branch> and bare <branch> forms.
+        case "$REF" in
+          refs/heads/release* | release*)
+            echo "PROD_FLAG=--prod" >> $GITHUB_ENV
+            echo "Running on a release* branch - setting PROD_FLAG=--prod (ref=$REF)"
+            ;;
+          *)
+            echo "PROD_FLAG=--staging" >> $GITHUB_ENV
+            echo "Running on $REF - setting PROD_FLAG=--staging"
+            ;;
+        esac
     - name: Set branch name for Sentry tags
       shell: bash
       run: |

--- a/.github/workflows/mobile_distribute.yml
+++ b/.github/workflows/mobile_distribute.yml
@@ -291,7 +291,7 @@ jobs:
           # In the reuse path nobody runs the lib build that writes .build.version, so reconstruct it
           # deterministically (matches lib/build.rs: <lib-version>-<short-sha>-<prod|staging>).
           LIB_VERSION=$(grep -m1 '^version' lib/Cargo.toml | sed -E 's/.*"([^"]+)".*/\1/')
-          if [ "$REF" = "release" ]; then SUFFIX="prod"; else SUFFIX="staging"; fi
+          case "$REF" in release*) SUFFIX="prod";; *) SUFFIX="staging";; esac
           echo "build_version=${LIB_VERSION}-${SHA:0:7}-${SUFFIX}" >> "$GITHUB_OUTPUT"
           echo "→ reuse=$reuse · build_version=${LIB_VERSION}-${SHA:0:7}-${SUFFIX}"
 


### PR DESCRIPTION
## What

Make **any branch whose name starts with `release`** (e.g. `release`, `release-1.10`, `release/1.10`) bake the `-prod` environment suffix into the version string — not just the exact branch named `release`.

## Why

The branch→env decision lives in two places, both of which used an **exact** string match against `release`:

1. **`.github/actions/set-prod-flag/action.yml`** — the single source used by every platform build (windows/macos/linux/android/ios). It sets `PROD_FLAG=--prod|--staging`, which `src/main.rs` turns into `DECENTRALAND_PROD_BUILD`, which `lib/build.rs` bakes as the `-prod`/`-staging`/`-dev` suffix in `GODOT_EXPLORER_VERSION`.
2. **`.github/workflows/mobile_distribute.yml`** — reconstructs `build_version` deterministically in the iOS reuse path (must mirror `lib/build.rs`).

Because both only matched `release` exactly, a release cut like `release-1.10` would silently produce `-staging`.

## Change

Swap the exact comparison for a `release*` prefix match in both spots, accepting both the `refs/heads/<branch>` and bare `<branch>` forms.

- `set-prod-flag`: `if [ "$REF" = "release" ]…` → `case "$REF" in refs/heads/release* | release*)`
- `mobile_distribute.yml`: `if [ "$REF" = "release" ]…` → `case "$REF" in release*)`

The xtask (`src/main.rs`) and `lib/build.rs` need no change — they already just honor whatever `--prod`/`--staging` flag CI passes.

## Out of scope (left as exact `release` match on purpose)

These gate **store/registry publishing**, not the version suffix, so they were intentionally left untouched:
- `android_builds.yml` / `mobile_distribute.yml` Play Store AAB upload (`ref == 'main' || ref == 'release'`)
- `docker_build_test.yml` Docker `latest` tag/publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)