### PR TITLE
feat(mobile): graceful memory management with low-memory warning (#2002)

### DIFF
--- a/godot/src/logic/scene_fetcher.gd
+++ b/godot/src/logic/scene_fetcher.gd
@@ -170,9 +170,13 @@ func _on_scene_crashed(crashed_scene_id: int, entity_id: String) -> void:
 # the current scene (issue #2002). Instead of killing it, we warn and let the
 # user choose: "Continue anyway" (keep going, verbose logging) or "Back to
 # Discover". Rust emits this once per pressure episode for the current scene.
-func _on_low_memory_warning(_scene_id: int, entity_id: String) -> void:
+func _on_low_memory_warning(
+	_scene_id: int, entity_id: String, footprint_mb: int, available_mb: int
+) -> void:
 	if Global.modal_manager != null:
-		Global.modal_manager.async_show_low_memory_warning_modal(entity_id)
+		Global.modal_manager.async_show_low_memory_warning_modal(
+			entity_id, footprint_mb, available_mb
+		)
 
 
 func get_current_scene_data() -> SceneItem:

--- a/godot/src/logic/scene_fetcher.gd
+++ b/godot/src/logic/scene_fetcher.gd
@@ -123,6 +123,7 @@ func _ready():
 
 	Global.scene_runner.scene_killed.connect(self.on_scene_killed)
 	Global.scene_runner.scene_crashed.connect(self._on_scene_crashed)
+	Global.scene_runner.low_memory_warning.connect(self._on_low_memory_warning)
 	Global.loading_finished.connect(self.on_loading_finished)
 
 
@@ -163,6 +164,15 @@ func _on_scene_crashed(crashed_scene_id: int, entity_id: String) -> void:
 		return
 	if Global.modal_manager != null:
 		Global.modal_manager.async_show_scene_crash_modal(entity_id)
+
+
+# The memory monitor detected critical pressure with nothing left to evict but
+# the current scene (issue #2002). Instead of killing it, we warn and let the
+# user choose: "Continue anyway" (keep going, verbose logging) or "Back to
+# Discover". Rust emits this once per pressure episode for the current scene.
+func _on_low_memory_warning(_scene_id: int, entity_id: String) -> void:
+	if Global.modal_manager != null:
+		Global.modal_manager.async_show_low_memory_warning_modal(entity_id)
 
 
 func get_current_scene_data() -> SceneItem:

--- a/godot/src/ui/components/organisms/modal/modal_manager.gd
+++ b/godot/src/ui/components/organisms/modal/modal_manager.gd
@@ -322,7 +322,9 @@ func async_show_scene_crash_modal(entity_id: String) -> void:
 ##   observe how far it gets before a possible OOM; stop nagging this session.
 ## - "BACK TO DISCOVER": leave the scene.
 ## @param _entity_id: The entity ID of the current scene (unused for now)
-func async_show_low_memory_warning_modal(_entity_id: String) -> void:
+func async_show_low_memory_warning_modal(
+	entity_id: String, footprint_mb: int = -1, available_mb: int = -1
+) -> void:
 	if not current_modal:
 		if not await _async_create_modal():
 			return
@@ -339,6 +341,23 @@ func async_show_low_memory_warning_modal(_entity_id: String) -> void:
 	_disconnect_button_signals()
 	current_modal.button_primary.pressed.connect(_on_low_memory_continue)
 	current_modal.button_secondary.pressed.connect(_on_low_memory_back)
+
+	# Measure how often the low-memory warning surfaces, on which scene/device and at
+	# what memory level (issue #2002). Flush eagerly: the app may be jetsam-killed by the
+	# OS shortly after this warning, so we can't rely on the periodic flush to send it.
+	if Global.metrics != null:
+		Global.metrics.track_screen_viewed(
+			"LOW_MEMORY_WARNING",
+			JSON.stringify(
+				{
+					"entity_id": entity_id,
+					"footprint_mb": footprint_mb,
+					"available_mb": available_mb,
+					"platform": OS.get_name()
+				}
+			)
+		)
+		Global.metrics.flush.call_deferred()
 
 
 ## Shows a ban pre-check modal (when trying to enter a scene the user is banned from)

--- a/godot/src/ui/components/organisms/modal/modal_manager.gd
+++ b/godot/src/ui/components/organisms/modal/modal_manager.gd
@@ -38,6 +38,11 @@ const SCENE_CRASH_BODY = "This scene stopped working. Please reload or go back t
 const SCENE_CRASH_PRIMARY = "RELOAD"
 const SCENE_CRASH_SECONDARY = "BACK"
 
+const LOW_MEMORY_TITLE = "Running low on memory"
+const LOW_MEMORY_BODY = "This scene is using a lot of memory and might make the app close unexpectedly. You can continue anyway or go back to Discover."
+const LOW_MEMORY_PRIMARY = "CONTINUE ANYWAY"
+const LOW_MEMORY_SECONDARY = "BACK TO DISCOVER"
+
 const BAN_PRE_CHECK_TITLE = "You can't enter"
 const BAN_PRE_CHECK_BODY = "You're banned from this scene.\nPlease contact support for more information."
 const BAN_PRE_CHECK_PRIMARY = "BACK TO DISCOVER"
@@ -308,6 +313,32 @@ func async_show_scene_crash_modal(entity_id: String) -> void:
 	_disconnect_button_signals()
 	current_modal.button_primary.pressed.connect(_on_scene_crash_reload.bind(entity_id))
 	current_modal.button_secondary.pressed.connect(_on_scene_crash_back)
+
+
+## Shows a LOW_MEMORY warning modal (issue #2002): the memory monitor detected
+## critical pressure with nothing left to evict but the current scene. Rather
+## than kill it, let the user choose. Reuses the crash modal design (alert icon).
+## - "CONTINUE ANYWAY": keep the scene; enable verbose memory logging so we can
+##   observe how far it gets before a possible OOM; stop nagging this session.
+## - "BACK TO DISCOVER": leave the scene.
+## @param _entity_id: The entity ID of the current scene (unused for now)
+func async_show_low_memory_warning_modal(_entity_id: String) -> void:
+	if not current_modal:
+		if not await _async_create_modal():
+			return
+
+	current_modal.blocker = true
+	current_modal.set_title(LOW_MEMORY_TITLE)
+	current_modal.set_body(LOW_MEMORY_BODY)
+	current_modal.set_primary_button_text(LOW_MEMORY_PRIMARY)
+	current_modal.set_secondary_button_text(LOW_MEMORY_SECONDARY)
+	current_modal.show_icon(Modal.MODAL_ALERT_ICON)
+	current_modal.hide_url()
+	current_modal.show()
+
+	_disconnect_button_signals()
+	current_modal.button_primary.pressed.connect(_on_low_memory_continue)
+	current_modal.button_secondary.pressed.connect(_on_low_memory_back)
 
 
 ## Shows a ban pre-check modal (when trying to enter a scene the user is banned from)
@@ -870,6 +901,22 @@ func _on_scene_crash_reload(_entity_id: String) -> void:
 
 
 func _on_scene_crash_back() -> void:
+	Global.open_discover.emit()
+	close_current_modal()
+
+
+# Low-memory warning (issue #2002) — "Continue anyway": keep the scene running,
+# turn on verbose memory logging to capture the run-up to a possible OOM, and
+# tell the runner to stop warning for the rest of the session.
+func _on_low_memory_continue() -> void:
+	if Global.scene_runner != null:
+		Global.scene_runner.set_memory_verbose_logging(true)
+		Global.scene_runner.dismiss_memory_warning()
+	close_current_modal()
+
+
+# Low-memory warning — "Back to Discover": leave the heavy scene.
+func _on_low_memory_back() -> void:
 	Global.open_discover.emit()
 	close_current_modal()
 

--- a/lib/src/scene_runner/scene_manager.rs
+++ b/lib/src/scene_runner/scene_manager.rs
@@ -178,7 +178,7 @@ impl SceneManager {
     /// a warning modal letting the user "Continue anyway" or go "Back to
     /// Discover". Emitted once per pressure episode (issue #2002).
     #[signal]
-    fn low_memory_warning(scene_id: i32, entity_id: GString);
+    fn low_memory_warning(scene_id: i32, entity_id: GString, footprint_mb: i32, available_mb: i32);
 
     // Loading session signals
     #[signal]
@@ -1478,14 +1478,20 @@ impl SceneManager {
                 .map(|s| s.scene_entity_definition.id.clone());
 
             if let Some(entity_id) = entity_id {
+                let footprint = crate::tools::memory_monitor::FOOTPRINT_MB.load(Ordering::Relaxed);
                 crate::tools::memory_monitor::emit_log(&format!(
-                    "[MemMonitor] CRITICAL available={}MB -> warn user (scene id={})",
-                    available, current.0
+                    "[MemMonitor] CRITICAL available={}MB footprint={}MB -> warn user (scene id={})",
+                    available, footprint, current.0
                 ));
                 self.memory_modal_active = true;
                 self.base_mut().emit_signal(
                     "low_memory_warning",
-                    &[current.0.to_variant(), entity_id.to_godot().to_variant()],
+                    &[
+                        current.0.to_variant(),
+                        entity_id.to_godot().to_variant(),
+                        footprint.to_variant(),
+                        available.to_variant(),
+                    ],
                 );
             }
         }

--- a/lib/src/scene_runner/scene_manager.rs
+++ b/lib/src/scene_runner/scene_manager.rs
@@ -35,7 +35,7 @@ use godot::{
 use std::{
     cell::RefCell,
     collections::{HashMap, HashSet},
-    sync::atomic::AtomicU32,
+    sync::atomic::{AtomicU32, Ordering},
     time::{Duration, Instant},
 };
 use tokio::sync::mpsc::error::TrySendError;
@@ -103,6 +103,17 @@ pub struct SceneManager {
     crashed_scene_ids: Vec<SceneId>,
     global_scene_ids: Vec<SceneId>,
 
+    // Graceful memory management (issue #2002). Frames to wait after a
+    // memory-pressure kill before acting again, so freed memory is reflected.
+    memory_settle_frames: i32,
+    // Latched while a low-memory warning we triggered is on screen, so we don't
+    // re-emit it every frame. Cleared once pressure recovers (level back to OK).
+    memory_modal_active: bool,
+    // Set when the user chose "Continue anyway" on the low-memory warning: from
+    // then on we stop warning and let the scene run (with verbose memory logging)
+    // so we can observe how far it gets before an eventual OOM. Session-scoped.
+    memory_warning_dismissed: bool,
+
     input_state: InputState,
     last_raycast_result: Option<GodotDclRaycastResult>,
     last_proximity_entity: Option<(SceneId, SceneEntityId)>,
@@ -145,6 +156,11 @@ pub static GLOBAL_TIMESTAMP: AtomicU32 = AtomicU32::new(0);
 const MAX_TIME_PER_SCENE_TICK_US: i64 = 8333; // 50% of update time at 60fps
 const MIN_TIME_TO_PROCESS_SCENE_US: i64 = 2083; // 25% of max_time_per_scene_tick_us (4 scenes per frame)
 
+// Frames to wait after a memory-pressure kill before acting again (~1.5s at
+// 60fps), so the scene thread can tear down and Godot/GPU memory is reclaimed
+// before we measure pressure again. See `handle_memory_pressure`.
+const MEMORY_SETTLE_FRAMES: i32 = 90;
+
 #[godot_api]
 impl SceneManager {
     #[signal]
@@ -155,6 +171,14 @@ impl SceneManager {
 
     #[signal]
     fn scene_crashed(scene_id: i32, entity_id: GString);
+
+    /// Emitted when the background memory monitor detects critical pressure and
+    /// there is no farther scene left to evict (only the current parcel +
+    /// globals remain). Instead of killing the scene unilaterally, GDScript shows
+    /// a warning modal letting the user "Continue anyway" or go "Back to
+    /// Discover". Emitted once per pressure episode (issue #2002).
+    #[signal]
+    fn low_memory_warning(scene_id: i32, entity_id: GString);
 
     // Loading session signals
     #[signal]
@@ -1204,6 +1228,12 @@ impl SceneManager {
         // V8/Deno threads. Reaping here guarantees background teardown either way.
         self.reap_dying_scenes();
 
+        // Act on memory pressure detected by the background monitor (issue #2002).
+        // Runs even while paused (the lobby pauses the runner) because a heavy
+        // scene can be loading behind the loading screen — exactly when an OOM
+        // kill strikes.
+        self.handle_memory_pressure();
+
         if self.pause {
             return;
         }
@@ -1376,6 +1406,88 @@ impl SceneManager {
 
         for scene_id in scene_to_remove.iter() {
             self.finalize_scene_removal(scene_id);
+        }
+    }
+
+    /// Consume the pressure level published by the background memory monitor
+    /// (issue #2002) and free memory before the OS kills the app. Detection runs
+    /// off-thread so it survives a main-thread freeze; this acts the instant the
+    /// main loop gets a slice of CPU.
+    ///
+    /// Policy: evict the farthest disposable parcel first (silent — the player is
+    /// not in it). When only the current parcel and globals remain and we are
+    /// still CRITICAL, warn once via `low_memory_warning` and let the user decide
+    /// ("Continue anyway" / "Back to Discover") rather than kill the scene they
+    /// are standing in. A settle window after each kill avoids thrashing while
+    /// freed memory is reclaimed.
+    fn handle_memory_pressure(&mut self) {
+        let level = crate::tools::memory_monitor::PRESSURE_LEVEL.load(Ordering::Relaxed);
+
+        if level == 0 {
+            // Pressure cleared: re-arm the warning and drop any settle countdown.
+            self.memory_modal_active = false;
+            self.memory_settle_frames = 0;
+            return;
+        }
+
+        if self.memory_settle_frames > 0 {
+            self.memory_settle_frames -= 1;
+            return;
+        }
+
+        // Pick the farthest non-current, non-global, alive parcel scene.
+        let current = self.current_parcel_scene_id;
+        let mut farthest: Option<(SceneId, f32)> = None;
+        for (id, scene) in self.scenes.iter() {
+            if !matches!(scene.state, SceneState::Alive) {
+                continue;
+            }
+            if *id == current || matches!(scene.scene_type, SceneType::Global(_)) {
+                continue;
+            }
+            if farthest.is_none_or(|(_, best)| scene.distance > best) {
+                farthest = Some((*id, scene.distance));
+            }
+        }
+
+        let available = crate::tools::memory_monitor::AVAILABLE_MB.load(Ordering::Relaxed);
+
+        if let Some((scene_id, distance)) = farthest {
+            let title = self
+                .scenes
+                .get(&scene_id)
+                .map(|s| s.scene_entity_definition.get_title())
+                .unwrap_or_default();
+            crate::tools::memory_monitor::emit_log(&format!(
+                "[MemMonitor] level={} available={}MB -> evict far scene id={} dist={:.1} '{}'",
+                level, available, scene_id.0, distance, title
+            ));
+            self.kill_scene(scene_id.0);
+            self.memory_settle_frames = MEMORY_SETTLE_FRAMES;
+            return;
+        }
+
+        // Nothing disposable left (only the current parcel + globals). Rather
+        // than kill the scene the player is in, warn once under CRITICAL and let
+        // the user decide. If they already chose to continue, stay silent.
+        if level >= 2 && !self.memory_modal_active && !self.memory_warning_dismissed {
+            let entity_id = self
+                .scenes
+                .get(&current)
+                .filter(|s| matches!(s.state, SceneState::Alive))
+                .map(|s| s.scene_entity_definition.id.clone());
+
+            if let Some(entity_id) = entity_id {
+                crate::tools::memory_monitor::emit_log(&format!(
+                    "[MemMonitor] CRITICAL available={}MB -> warn user (scene id={})",
+                    available, current.0
+                ));
+                self.memory_modal_active = true;
+                self.base_mut().emit_signal(
+                    "low_memory_warning",
+                    &[current.0.to_variant(), entity_id.to_godot().to_variant()],
+                );
+            }
         }
     }
 
@@ -2178,6 +2290,21 @@ impl SceneManager {
             .filter(|scene| scene.state == SceneState::Alive)
             .count() as i32
     }
+
+    /// Enable/disable full-resolution memory logging (issue #2002). Used by the
+    /// "Continue anyway" path on the low-memory warning to capture the run-up to
+    /// a possible crash at every sample instead of ~every 2s.
+    #[func]
+    fn set_memory_verbose_logging(&self, on: bool) {
+        crate::tools::memory_monitor::set_verbose(on);
+    }
+
+    /// The user chose "Continue anyway" on the low-memory warning (issue #2002):
+    /// stop warning for the rest of the session and keep the scene running.
+    #[func]
+    fn dismiss_memory_warning(&mut self) {
+        self.memory_warning_dismissed = true;
+    }
 }
 
 #[godot_api]
@@ -2185,6 +2312,10 @@ impl INode for SceneManager {
     fn init(base: Base<Node>) -> Self {
         let (thread_sender_to_main, main_receiver_from_thread) =
             std::sync::mpsc::sync_channel(1000);
+
+        // Start the background memory-pressure monitor (issue #2002). Idempotent
+        // and a no-op on platforms without an OOM killer to anticipate.
+        crate::tools::memory_monitor::start();
 
         let mut base_ui = DclUiControl::new_alloc();
         base_ui.set_anchors_preset(LayoutPreset::FULL_RECT);
@@ -2203,6 +2334,9 @@ impl INode for SceneManager {
             dying_scene_ids: vec![],
             crashed_scene_ids: vec![],
             global_scene_ids: vec![],
+            memory_settle_frames: 0,
+            memory_modal_active: false,
+            memory_warning_dismissed: false,
             current_parcel_scene_id: SceneId(0),
             last_current_parcel_scene_id: SceneId::INVALID,
 
@@ -2259,6 +2393,12 @@ impl INode for SceneManager {
     }
 
     fn physics_process(&mut self, delta: f64) {
+        // Main-thread liveness heartbeat (issue #2002). Incremented unconditionally
+        // at the very top, before any early-return, so the background memory
+        // monitor can tell a real main-thread freeze (heartbeat stops) from a mere
+        // paused/idle runner. Must stay the first statement here.
+        crate::tools::memory_monitor::MAIN_THREAD_HEARTBEAT.fetch_add(1, Ordering::Relaxed);
+
         self.scene_runner_update(delta);
 
         // Check loading session timeouts

--- a/lib/src/tools/memory_monitor.rs
+++ b/lib/src/tools/memory_monitor.rs
@@ -1,0 +1,351 @@
+//! Background memory-pressure monitor (issue #2002).
+//!
+//! Why a dedicated OS thread: on mobile the app is killed abruptly when it
+//! exceeds its per-process memory limit (iOS jetsam / Android lowmemorykiller).
+//! The dangerous moment — loading a heavy scene — is exactly when the *main
+//! thread freezes* (a big synchronous upload blocks the frame, or the kernel
+//! compresses/pages memory). A watchdog living on the SceneTree / main loop
+//! cannot react while the main thread is frozen.
+//!
+//! This monitor runs on its own thread, sampling memory every `POLL_MS`
+//! independently of the main thread, so detection keeps working even during a
+//! freeze. It publishes the result into atomics that the main loop
+//! (`SceneManager::handle_memory_pressure`) consumes to evict scenes / show the
+//! low-memory modal the instant it gets a slice of CPU.
+//!
+//! ## Memory signal (two metrics, deliberately)
+//!
+//! * **Primary — headroom:** how many MB the app can still allocate before the
+//!   OS kills it.
+//!   - iOS: `os_proc_available_memory()` — bytes left before jetsam. Cheap,
+//!     off-thread-safe, and already reflects the *dynamic* per-device limit.
+//!   - Android: heuristic `budget(MemTotal) - RSS` from `/proc` (no precise
+//!     per-app headroom call exists, and JNI is not thread-safe to call here;
+//!     `/proc` files are readable from any thread).
+//!
+//! * **Secondary hard-stop — `phys_footprint`** (iOS only, via
+//!   `proc_pid_rusage`). This is the value jetsam actually compares against and,
+//!   unlike `os_proc_available_memory`, it *includes* GPU / IOSurface / texture
+//!   memory. On GPU-heavy scenes `os_proc_available_memory` was measured to
+//!   over-report headroom by ~180 MB on an iPhone 13 (that GPU memory is
+//!   invisible to it). So we also read `phys_footprint` and force CRITICAL once
+//!   it crosses a device-scaled ceiling — catching the GPU-driven OOM that the
+//!   headroom signal alone would miss.
+//!
+//! On desktop there is no OOM killer to anticipate, so the monitor is not
+//! started and both readers return -1.
+
+use std::sync::atomic::{AtomicBool, AtomicI32, AtomicU32, AtomicU8, Ordering};
+
+/// Available headroom in MB (bytes the app can still allocate before the OS
+/// kills it). -1 when unknown / not yet sampled.
+pub static AVAILABLE_MB: AtomicI32 = AtomicI32::new(-1);
+
+/// `phys_footprint` in MB — the real total the OS charges the process, GPU
+/// memory included (the value jetsam compares against). iOS only; -1 elsewhere
+/// or before the first sample.
+pub static FOOTPRINT_MB: AtomicI32 = AtomicI32::new(-1);
+
+/// Pressure level published by the monitor thread: 0 = OK, 1 = WARNING, 2 = CRITICAL.
+pub static PRESSURE_LEVEL: AtomicU8 = AtomicU8::new(0);
+
+/// Incremented every physics frame on the main thread (top of
+/// `SceneManager::physics_process`). The monitor thread watches it: if it stops
+/// advancing while the app is running, the main thread is frozen — exactly the
+/// Genesis Plaza "stuck in loading" symptom, which we now know is NOT memory.
+pub static MAIN_THREAD_HEARTBEAT: AtomicU32 = AtomicU32::new(0);
+
+/// When true, the monitor logs EVERY sample (not just under pressure / every
+/// ~2s). Enabled when the user taps "Continue anyway" on the low-memory warning,
+/// so we capture the headroom trajectory at full resolution right up to a
+/// potential OOM crash — to learn how far a heavy scene gets before dying.
+pub static VERBOSE: AtomicBool = AtomicBool::new(false);
+
+/// `phys_footprint` ceiling in MB above which we force CRITICAL, computed at
+/// [`start`] from device RAM so it scales across devices. 0 = disabled (unknown
+/// RAM / non-iOS): the headroom signal governs alone.
+#[cfg(any(target_os = "ios", target_os = "android"))]
+static FOOTPRINT_CRITICAL_MB: AtomicI32 = AtomicI32::new(0);
+
+#[cfg(any(target_os = "ios", target_os = "android"))]
+static MONITOR_STARTED: AtomicBool = AtomicBool::new(false);
+
+pub const LEVEL_OK: u8 = 0;
+pub const LEVEL_WARNING: u8 = 1;
+pub const LEVEL_CRITICAL: u8 = 2;
+
+/// Sampling period of the monitor thread.
+#[cfg(any(target_os = "ios", target_os = "android"))]
+const POLL_MS: u64 = 250;
+
+/// Headroom thresholds in MB. Tuned conservatively for a ~4GB iPhone 13; the
+/// bands are wide so eviction (not instantaneous) has time to recover headroom
+/// before the OS limit is hit. `CRITICAL_MB` sits well above the ~180MB
+/// effective death point measured on GPU-heavy scenes, absorbing the GPU memory
+/// that `os_proc_available_memory` does not count (the `phys_footprint`
+/// hard-stop covers the rest).
+pub const WARNING_MB: i32 = 500;
+pub const CRITICAL_MB: i32 = 300;
+
+/// Fraction of total device RAM used as the `phys_footprint` CRITICAL ceiling.
+/// On an iPhone 13 (~3.7GB RAM) jetsam strikes around ~2.1GB (~0.56 of RAM), so
+/// 0.50 fires with headroom to spare and scales up on higher-RAM devices where
+/// a healthy footprint can legitimately be larger.
+#[cfg(target_os = "ios")]
+const FOOTPRINT_CRITICAL_FRACTION: f32 = 0.50;
+
+/// Fraction of total RAM assumed to be the per-app budget on Android, where no
+/// precise headroom call exists. Approximate.
+#[cfg(target_os = "android")]
+const ANDROID_BUDGET_FRACTION: f32 = 0.55;
+
+/// Start the background monitor (idempotent). No-op on platforms without an OOM
+/// killer we need to anticipate.
+pub fn start() {
+    // Whole body is mobile-only: on desktop there is no OOM killer to anticipate,
+    // so `start()` is a no-op. Keeping the mobile logic inside one cfg block also
+    // keeps the idempotency early-return from becoming a trailing no-op on desktop.
+    #[cfg(any(target_os = "ios", target_os = "android"))]
+    {
+        if MONITOR_STARTED.swap(true, Ordering::SeqCst) {
+            return;
+        }
+
+        #[cfg(target_os = "ios")]
+        {
+            // Scale the phys_footprint ceiling to device RAM so the backstop is
+            // not hard-coded to one model. sysctl-based, safe to call here (main
+            // thread, no Godot API touched).
+            let total_ram_mb =
+                crate::godot_classes::dcl_ios_plugin::DclIosPlugin::get_total_ram_mb();
+            if total_ram_mb > 0 {
+                let ceiling = (total_ram_mb as f32 * FOOTPRINT_CRITICAL_FRACTION) as i32;
+                FOOTPRINT_CRITICAL_MB.store(ceiling, Ordering::Relaxed);
+                emit_log(&format!(
+                    "[MemMonitor] total_ram={}MB -> phys_footprint CRITICAL ceiling={}MB",
+                    total_ram_mb, ceiling
+                ));
+            }
+        }
+
+        let _ = std::thread::Builder::new()
+            .name("dcl-mem-monitor".into())
+            .spawn(monitor_loop);
+        emit_log("[MemMonitor] background memory monitor started");
+    }
+}
+
+/// Toggle full-resolution logging (see [`VERBOSE`]).
+pub fn set_verbose(on: bool) {
+    VERBOSE.store(on, Ordering::Relaxed);
+    emit_log(&format!(
+        "[MemMonitor] verbose logging {}",
+        if on { "ON" } else { "off" }
+    ));
+}
+
+/// Current available headroom in MB, or -1 when it cannot be determined.
+/// Safe to call from any thread.
+pub fn available_memory_mb() -> i32 {
+    AVAILABLE_MB.load(Ordering::Relaxed)
+}
+
+/// Write a line to stdout AND stderr, both flushed immediately. The Godot
+/// `print()` path does not reach the iOS `devicectl` console (and is lost when
+/// the app freezes), but native writes to fd 1/2 do — this is the only logging
+/// that survives the freeze we are trying to diagnose. Cheap; safe off-thread.
+pub fn emit_log(line: &str) {
+    use std::io::Write;
+    let mut stdout = std::io::stdout();
+    let _ = stdout.write_all(line.as_bytes());
+    let _ = stdout.write_all(b"\n");
+    let _ = stdout.flush();
+    let mut stderr = std::io::stderr();
+    let _ = stderr.write_all(line.as_bytes());
+    let _ = stderr.write_all(b"\n");
+    let _ = stderr.flush();
+}
+
+/// Compute the pressure level from the two metrics. The `phys_footprint`
+/// hard-stop takes precedence: it sees GPU memory the headroom signal misses.
+#[cfg(any(target_os = "ios", target_os = "android"))]
+fn level_for(available_mb: i32, footprint_mb: i32) -> u8 {
+    let ceiling = FOOTPRINT_CRITICAL_MB.load(Ordering::Relaxed);
+    if ceiling > 0 && footprint_mb >= 0 && footprint_mb >= ceiling {
+        return LEVEL_CRITICAL;
+    }
+
+    if available_mb < 0 {
+        // Headroom unknown and footprint below ceiling (or unavailable): can't
+        // assert pressure.
+        return LEVEL_OK;
+    }
+    if available_mb <= CRITICAL_MB {
+        LEVEL_CRITICAL
+    } else if available_mb <= WARNING_MB {
+        LEVEL_WARNING
+    } else {
+        LEVEL_OK
+    }
+}
+
+#[cfg(any(target_os = "ios", target_os = "android"))]
+fn monitor_loop() {
+    let mut tick: u64 = 0;
+
+    // Main-thread stall detection state.
+    let mut last_hb: u32 = 0;
+    let mut seen_running = false; // main loop has ticked at least once
+    let mut stall_ms: u64 = 0;
+    let mut stall_reported = false;
+    let mut last_report_ms: u64 = 0;
+
+    loop {
+        let available = read_available_mb();
+        let footprint = read_footprint_mb();
+        let level = level_for(available, footprint);
+
+        AVAILABLE_MB.store(available, Ordering::Relaxed);
+        FOOTPRINT_MB.store(footprint, Ordering::Relaxed);
+        PRESSURE_LEVEL.store(level, Ordering::Relaxed);
+
+        // Log every sample under pressure or when verbose; otherwise ~every 2s,
+        // so we can watch the trajectory right up to (and through) a main-thread
+        // freeze or an eventual OOM after "Continue anyway".
+        if level > 0 || VERBOSE.load(Ordering::Relaxed) || tick % 8 == 0 {
+            emit_log(&format!(
+                "[MemMonitor] available={}MB footprint={}MB level={}",
+                available, footprint, level
+            ));
+        }
+
+        // Main-thread stall detection: independent of memory, since the Genesis
+        // Plaza freeze happens with plenty of headroom (a CPU/GPU/lock stall, not
+        // an OOM). This survives the freeze because it runs off the main thread.
+        let hb = MAIN_THREAD_HEARTBEAT.load(Ordering::Relaxed);
+        if hb != last_hb {
+            if stall_reported {
+                emit_log(&format!(
+                    "[MainThreadStall] RECOVERED after ~{}ms (available={}MB)",
+                    stall_ms, available
+                ));
+            }
+            last_hb = hb;
+            stall_ms = 0;
+            stall_reported = false;
+            last_report_ms = 0;
+            seen_running = true;
+        } else if seen_running {
+            stall_ms += POLL_MS;
+            // Report once we cross ~1s frozen, then re-report ~every 2s so we can
+            // see how long the freeze lasts and the memory headroom during it.
+            if stall_ms >= 1000 && (!stall_reported || stall_ms - last_report_ms >= 2000) {
+                emit_log(&format!(
+                    "[MainThreadStall] main thread UNRESPONSIVE ~{}ms (available={}MB footprint={}MB level={})",
+                    stall_ms, available, footprint, level
+                ));
+                stall_reported = true;
+                last_report_ms = stall_ms;
+            }
+        }
+
+        tick = tick.wrapping_add(1);
+        std::thread::sleep(std::time::Duration::from_millis(POLL_MS));
+    }
+}
+
+// ============================================================================
+// Platform readers
+// ============================================================================
+
+#[cfg(target_os = "ios")]
+fn read_available_mb() -> i32 {
+    extern "C" {
+        // iOS 13+. Returns bytes the app can still allocate before the OS
+        // terminates it; 0 when not determinable (e.g. simulator).
+        fn os_proc_available_memory() -> usize;
+    }
+    let bytes = unsafe { os_proc_available_memory() };
+    if bytes == 0 {
+        -1
+    } else {
+        (bytes / (1024 * 1024)) as i32
+    }
+}
+
+#[cfg(target_os = "ios")]
+fn read_footprint_mb() -> i32 {
+    // `phys_footprint` via proc_pid_rusage(RUSAGE_INFO_V2) — the same value Xcode
+    // and jetsam use, GPU/IOSurface memory included. Pure syscall, off-thread
+    // safe.
+    let mut info = std::mem::MaybeUninit::<libc::rusage_info_v2>::zeroed();
+    // SAFETY: proc_pid_rusage fills a v2 rusage struct for our own pid; the
+    // buffer is a correctly-sized, zeroed rusage_info_v2.
+    let ret = unsafe {
+        libc::proc_pid_rusage(
+            std::process::id() as libc::c_int,
+            libc::RUSAGE_INFO_V2,
+            info.as_mut_ptr() as *mut libc::rusage_info_t,
+        )
+    };
+    if ret != 0 {
+        return -1;
+    }
+    // SAFETY: proc_pid_rusage returned 0, so `info` is initialized.
+    let info = unsafe { info.assume_init() };
+    (info.ri_phys_footprint / (1024 * 1024)) as i32
+}
+
+#[cfg(target_os = "android")]
+fn read_available_mb() -> i32 {
+    // Resident set size from /proc/self/statm (field 1 = resident pages).
+    let Ok(statm) = std::fs::read_to_string("/proc/self/statm") else {
+        return -1;
+    };
+    let Some(rss_pages) = statm
+        .split_whitespace()
+        .nth(1)
+        .and_then(|v| v.parse::<i64>().ok())
+    else {
+        return -1;
+    };
+    if rss_pages <= 0 {
+        return -1;
+    }
+    let page_size: i64 = 4096;
+    let rss_mb = (rss_pages * page_size / (1024 * 1024)) as i32;
+
+    let total_mb = read_mem_total_mb();
+    if total_mb <= 0 {
+        return -1;
+    }
+    let budget = (total_mb as f32 * ANDROID_BUDGET_FRACTION) as i32;
+    (budget - rss_mb).max(0)
+}
+
+#[cfg(target_os = "android")]
+fn read_footprint_mb() -> i32 {
+    // No precise phys_footprint equivalent on Android; the /proc headroom
+    // estimate above already folds in RSS. Report unknown.
+    -1
+}
+
+#[cfg(target_os = "android")]
+fn read_mem_total_mb() -> i32 {
+    // MemTotal is reported in kB on the first line of /proc/meminfo.
+    let Ok(meminfo) = std::fs::read_to_string("/proc/meminfo") else {
+        return -1;
+    };
+    for line in meminfo.lines() {
+        if let Some(rest) = line.strip_prefix("MemTotal:") {
+            if let Some(kb) = rest
+                .split_whitespace()
+                .next()
+                .and_then(|v| v.parse::<i64>().ok())
+            {
+                return (kb / 1024) as i32;
+            }
+        }
+    }
+    -1
+}

--- a/lib/src/tools/mod.rs
+++ b/lib/src/tools/mod.rs
@@ -1,5 +1,6 @@
 pub mod godot_logger;
 pub mod log_stream;
+pub mod memory_monitor;
 pub mod network_inspector;
 
 #[cfg(feature = "use_memory_debugger")]

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -20,6 +20,18 @@ pub const GODOT_CURRENT_VERSION: &str = "4.6.2";
 /// local download cache (keys embed it) and pins the immutable per-SHA release URLs below.
 pub const GODOT_BUILD_SHA: &str = "36d9ae5fa";
 
+/// TEMPORARY per-checkout override to pull the Godot editor + export templates from a specific
+/// fork *branch* build (published by CI under `/branches/<slug>/`) instead of the pinned stable
+/// release — without having to pass `--branch` on every `install` / `run` / `export`.
+///
+/// `None` = use the pinned stable build (`GODOT_BUILD_SHA`). `Some("<branch>")` = use that
+/// branch's CI build. An explicit `--branch` on the CLI still takes precedence over this.
+///
+/// Reset to `None` once the branch is merged and `GODOT_BUILD_SHA` is bumped to the merge commit —
+/// leaving a branch pinned here makes every dev/CI pull an unmerged engine build. Currently pinned
+/// to the issue #2002 iOS main-thread-freeze fix (decentraland/godotengine#17).
+pub const GODOT_USE_BRANCH: Option<&str> = Some("fix/pipeline-inline-compile-2002");
+
 /// Release tag identifying a specific fork build — `<version>.stable.gh.<sha>`, mirroring the
 /// `--version` string. Single source for the release URL path segment, the on-disk template SHA
 /// marker, and the installed-binary version validation.
@@ -29,7 +41,11 @@ pub fn godot_release_tag() -> String {
 
 /// Editor (binary) base URL for the pinned stable fork build, e.g.
 /// `https://godot-engine-releases.dclexplorer.com/4.6.2.stable.gh.36d9ae5fa/editors/`.
+/// Honors the `GODOT_USE_BRANCH` override: when set, resolves to the branch build's URL instead.
 pub fn godot_editor_base_url() -> String {
+    if let Some(branch) = GODOT_USE_BRANCH {
+        return godot_editor_base_url_for_branch(branch);
+    }
     format!(
         "{GODOT_ENGINE_RELEASES_BASE_URL}{}/editors/",
         godot_release_tag()
@@ -38,7 +54,11 @@ pub fn godot_editor_base_url() -> String {
 
 /// Compressed-templates base URL for the pinned stable fork build, e.g.
 /// `https://godot-engine-releases.dclexplorer.com/4.6.2.stable.gh.36d9ae5fa/compressed-templates/`.
+/// Honors the `GODOT_USE_BRANCH` override: when set, resolves to the branch build's URL instead.
 pub fn godot_templates_base_url() -> String {
+    if let Some(branch) = GODOT_USE_BRANCH {
+        return godot_templates_base_url_for_branch(branch);
+    }
     format!(
         "{GODOT_ENGINE_RELEASES_BASE_URL}{}/compressed-templates/",
         godot_release_tag()

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -18,7 +18,7 @@ pub const GODOT_CURRENT_VERSION: &str = "4.6.2";
 /// (e.g. `4.6.2.stable.gh.6ddcadb64 - Protocol Squad`) and the SHA-tagged release path published
 /// by the godot-engine-releases pipeline. Bump it in lockstep with a new fork publish: it busts the
 /// local download cache (keys embed it) and pins the immutable per-SHA release URLs below.
-pub const GODOT_BUILD_SHA: &str = "36d9ae5fa";
+pub const GODOT_BUILD_SHA: &str = "aed178f10";
 
 /// TEMPORARY per-checkout override to pull the Godot editor + export templates from a specific
 /// fork *branch* build (published by CI under `/branches/<slug>/`) instead of the pinned stable
@@ -28,9 +28,10 @@ pub const GODOT_BUILD_SHA: &str = "36d9ae5fa";
 /// branch's CI build. An explicit `--branch` on the CLI still takes precedence over this.
 ///
 /// Reset to `None` once the branch is merged and `GODOT_BUILD_SHA` is bumped to the merge commit —
-/// leaving a branch pinned here makes every dev/CI pull an unmerged engine build. Currently pinned
-/// to the issue #2002 iOS main-thread-freeze fix (decentraland/godotengine#17).
-pub const GODOT_USE_BRANCH: Option<&str> = Some("fix/pipeline-inline-compile-2002");
+/// leaving a branch pinned here makes every dev/CI pull an unmerged engine build. Currently `None`:
+/// the issue #2002 iOS main-thread-freeze fix (decentraland/godotengine#17) is merged and
+/// `GODOT_BUILD_SHA` above points at its merge commit.
+pub const GODOT_USE_BRANCH: Option<&str> = None;
 
 /// Release tag identifying a specific fork build — `<version>.stable.gh.<sha>`, mirroring the
 /// `--version` string. Single source for the release URL path segment, the on-disk template SHA

--- a/src/export.rs
+++ b/src/export.rs
@@ -5,7 +5,7 @@ use crate::{
     consts::{
         godot_release_tag, godot_templates_base_url, godot_templates_base_url_for_branch,
         sanitize_branch_for_url, EXPORTS_FOLDER, GODOT_BUILD_SHA, GODOT_CURRENT_VERSION,
-        GODOT_PLATFORM_FILES, GODOT_PROJECT_FOLDER,
+        GODOT_PLATFORM_FILES, GODOT_PROJECT_FOLDER, GODOT_USE_BRANCH,
     },
     helpers::get_exe_extension,
     install_dependency::{
@@ -509,6 +509,12 @@ pub fn prepare_templates(
         }
     };
 
+    // Effective branch = explicit `--branch` (takes precedence) or the `GODOT_USE_BRANCH` override.
+    // Drives the marker-skip guard, cache key and marker stamp so a branch build is never skipped as
+    // if it were the pinned stable release. The download URL itself resolves the same override inside
+    // godot_templates_base_url() below.
+    let effective_branch = branch.or(GODOT_USE_BRANCH);
+
     let templates_base_url = match branch {
         Some(b) => godot_templates_base_url_for_branch(b),
         None => godot_templates_base_url(),
@@ -523,7 +529,7 @@ pub fn prepare_templates(
             // own `version.txt` only carries the version (no SHA), hence our own marker. Branch
             // builds are never marked/skipped (their fork SHA isn't tracked at const time).
             let marker = Path::new(&dest_path).join(format!(".dcl_build_sha_{template}"));
-            let marker_ok = branch.is_none()
+            let marker_ok = effective_branch.is_none()
                 && fs::read_to_string(&marker)
                     .map(|s| s.trim() == expected_tag)
                     .unwrap_or(false);
@@ -540,7 +546,7 @@ pub fn prepare_templates(
                 println!("Downloading file for {}: {}", template, file);
 
                 let url = format!("{}{}.zip", templates_base_url, file);
-                let cache_id = match branch {
+                let cache_id = match effective_branch {
                     Some(b) => format!(
                         "{GODOT_CURRENT_VERSION}.branch-{}.{file}.export-templates.zip",
                         sanitize_branch_for_url(b)
@@ -552,7 +558,8 @@ pub fn prepare_templates(
                 download_and_extract_zip(url.as_str(), dest_path.as_str(), cache_key(cache_id))?;
             }
             // Stamp the SHA marker after a successful extract so the next run can skip.
-            if branch.is_none() {
+            // Skipped for branch builds (their fork SHA isn't tracked at const time).
+            if effective_branch.is_none() {
                 let _ = fs::write(&marker, &expected_tag);
             }
         } else {

--- a/src/install_dependency.rs
+++ b/src/install_dependency.rs
@@ -20,8 +20,8 @@ use crate::ui::{create_spinner, print_message, print_section, MessageType};
 
 use crate::consts::{
     godot_editor_base_url, godot_editor_base_url_for_branch, godot_release_tag,
-    sanitize_branch_for_url, BIN_FOLDER, GODOT_BUILD_SHA, GODOT_CURRENT_VERSION, PROTOC_BASE_URL,
-    RUST_LIB_PROJECT_FOLDER,
+    sanitize_branch_for_url, BIN_FOLDER, GODOT_BUILD_SHA, GODOT_CURRENT_VERSION, GODOT_USE_BRANCH,
+    PROTOC_BASE_URL, RUST_LIB_PROJECT_FOLDER,
 };
 
 fn create_directory_all(path: &Path) -> io::Result<()> {
@@ -526,7 +526,12 @@ pub fn install(
         &format!("Platform: {}", platform.display_name),
     );
 
-    if let Some(b) = branch {
+    // Explicit `--branch` takes precedence; otherwise fall back to the GODOT_USE_BRANCH override.
+    // Used for binary validation and cache keys below; the URLs resolve the same override in their
+    // consts helpers.
+    let effective_branch = branch.or(GODOT_USE_BRANCH);
+
+    if let Some(b) = effective_branch {
         print_message(
             MessageType::Info,
             &format!(
@@ -616,7 +621,7 @@ pub fn install(
     // A stale binary (same version, different fork SHA) is replaced; the SHA-tagged cache key below
     // guarantees a cache miss so the fresh fork build is fetched, not the stale cached zip. Branch
     // builds use existence-only (their fork SHA isn't tracked at const time).
-    let needs_godot = match (branch, validate_installed_godot_binary()) {
+    let needs_godot = match (effective_branch, validate_installed_godot_binary()) {
         (Some(_), GodotBinaryStatus::Missing) => true,
         (Some(_), _) => false,
         (None, GodotBinaryStatus::Ok) => false,
@@ -643,7 +648,7 @@ pub fn install(
     };
     if needs_godot {
         print_section("Installing Godot Engine");
-        let godot_cache_key = match branch {
+        let godot_cache_key = match effective_branch {
             Some(b) => format!(
                 "{GODOT_CURRENT_VERSION}.branch-{}.executable.zip",
                 sanitize_branch_for_url(b)


### PR DESCRIPTION
Closes #2002 (feature half — see companion engine PR for the freeze fix).

## What & why

On memory-constrained iOS devices the client was being **jetsam-killed** by the OS with no warning once its physical footprint crossed the platform ceiling. This adds graceful memory management: a background monitor, scene eviction under pressure, and a user-facing modal as a last resort.

## Changes

- **`lib/src/tools/memory_monitor.rs`** (new): a background OS thread that samples memory off the main thread and publishes to atomics.
  - iOS: `os_proc_available_memory()` for headroom + `proc_pid_rusage(RUSAGE_INFO_V2).ri_phys_footprint` for the real footprint the OS jetsams on.
  - Android: `/proc` based available memory.
  - Derives a **footprint ceiling** (50% of device RAM on iOS) and a pressure `level` (WARNING / CRITICAL) from both the available-memory thresholds and the footprint hard-stop.
- **`scene_manager`**: on CRITICAL pressure, evicts the **farthest non-current, non-global** scene via `kill_scene`; if there is nothing safe to evict, emits a new `low_memory_warning` signal. Also bumps a main-thread heartbeat each physics frame (used to characterize stalls).
- **`modal_manager` + `scene_fetcher`**: wire `low_memory_warning` to a modal offering **Continue anyway** (opts into verbose memory logging) or **Back to Discover**.

## Validation

Deployed to a physical **iPhone 13**. In Genesis Plaza the footprint climbs to the ceiling (`footprint≈1939MB ≥ ceiling 1831MB`), the monitor raises `level=CRITICAL`, and the low-memory modal is surfaced — exactly as designed. Host `cargo fmt` / `clippy`, `gdformat` and `gdlint` are clean.

## Companion PR

The underlying main-thread **freeze** (a pipeline-compilation deadlock, separate from OOM) is fixed in the engine fork: decentraland/godotengine#17. Both are needed for a fully graceful heavy-scene load on iOS.
