### PR TITLE
ci(ios): guard reused exports against a superseded store build number

### DIFF
--- a/.github/workflows/ios_r2_artifact.yml
+++ b/.github/workflows/ios_r2_artifact.yml
@@ -246,6 +246,23 @@ jobs:
             --copy-source "${AWS_S3_BUCKET}/${KEY}" --endpoint-url "$AWS_ENDPOINT_URL" >/dev/null \
             || aws s3 cp export.tar.gz "s3://${AWS_S3_BUCKET}/${LATEST_KEY}" --endpoint-url "$AWS_ENDPOINT_URL"
 
+          # Sidecar: record the build number this export was BAKED with, right next to the tarball.
+          # The deploy orchestrator (mobile_distribute ios-resolve) compares it against a fresh
+          # allocation before reusing this export — if the allocator has since bumped the number
+          # (a store shipped past it), the export is stale and must be rebuilt, not reused/shipped.
+          if [ -n "${DCL_BUILD_NUMBER:-}" ]; then
+            BUILD_NUMBER_KEY="ios/${SAFE_BRANCH}/${SHA}/build_number.txt"
+            LATEST_BUILD_NUMBER_KEY="ios/${SAFE_BRANCH}/latest/build_number.txt"
+            printf '%s' "$DCL_BUILD_NUMBER" > build_number.txt
+            echo "🔢 Writing build_number sidecar ($DCL_BUILD_NUMBER) → s3://${AWS_S3_BUCKET}/${BUILD_NUMBER_KEY}"
+            aws s3 cp build_number.txt "s3://${AWS_S3_BUCKET}/${BUILD_NUMBER_KEY}" --endpoint-url "$AWS_ENDPOINT_URL"
+            aws s3api copy-object --bucket "$AWS_S3_BUCKET" --key "$LATEST_BUILD_NUMBER_KEY" \
+              --copy-source "${AWS_S3_BUCKET}/${BUILD_NUMBER_KEY}" --endpoint-url "$AWS_ENDPOINT_URL" >/dev/null \
+              || aws s3 cp build_number.txt "s3://${AWS_S3_BUCKET}/${LATEST_BUILD_NUMBER_KEY}" --endpoint-url "$AWS_ENDPOINT_URL"
+          else
+            echo "ℹ️  DCL_BUILD_NUMBER unset — no build_number sidecar (fork PR / allocator skipped)."
+          fi
+
           echo "✅ Unsigned export uploaded to R2 (sha=${SHA}, branch=${SAFE_BRANCH})"
           echo "🔗 ${R2_PUBLIC_BASE_URL}/${KEY}"
 

--- a/.github/workflows/mobile_distribute.yml
+++ b/.github/workflows/mobile_distribute.yml
@@ -241,6 +241,11 @@ jobs:
       SHA:         ${{ needs.prepare.outputs.sha }}
       SAFE_BRANCH: ${{ needs.prepare.outputs.safe_branch }}
       GH_TOKEN:    ${{ secrets.GITHUB_TOKEN }}
+      # Build-number allocator: used to check whether a reusable export's baked number is still
+      # current before reusing it (see the reuse-vs-build step). workers.dev route — the custom
+      # domain edge-blocks datacenter CI IPs. Empty secret (fork PR) → the check is skipped.
+      ALLOCATOR_URL:       https://godot-build-number-allocator.mateo-a2b.workers.dev
+      BUILD_NUMBER_SECRET: ${{ secrets.BUILD_NUMBER_SECRET }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
@@ -286,6 +291,31 @@ jobs:
               sleep 30
             done
           fi
+          # Monotonic guard: an export is only safe to reuse while its BAKED build number is still the
+          # one the allocator assigns for this commit. If a store has since shipped past that number
+          # the allocator refreshes it (returns a higher one) — reusing the old export would ship a
+          # superseded CFBundleVersion (TestFlight rejects it) or desync it from the baked version
+          # string. When that happens, force a rebuild so the fresh number gets baked in.
+          if [ "$reuse" = "true" ] && [ -n "${BUILD_NUMBER_SECRET:-}" ]; then
+            SIDECAR_KEY="ios/${SAFE_BRANCH}/${SHA}/build_number.txt"
+            BAKED=$(aws s3 cp "s3://${AWS_S3_BUCKET}/${SIDECAR_KEY}" - --endpoint-url "$AWS_ENDPOINT_URL" 2>/dev/null | tr -dc '0-9' || true)
+            ALLOC=$(curl -fsS -X POST "${ALLOCATOR_URL%/}/build-numbers/allocate" \
+              -H 'content-type: application/json' -H "authorization: Bearer ${BUILD_NUMBER_SECRET}" \
+              -d "$(printf '{"sha":"%s","allocatedBy":"ios"}' "$SHA")" 2>/dev/null \
+              | grep -oE '"buildNumber"[[:space:]]*:[[:space:]]*[0-9]+' | tr -dc '0-9' || true)
+            if [ -z "$BAKED" ]; then
+              echo "⚠️  No build_number sidecar for this export → rebuilding to bake a current number."
+              reuse=false
+            elif [ -z "$ALLOC" ]; then
+              echo "⚠️  Could not reach the allocator to verify — reusing anyway (asc-deploy fails loud if the number is behind)."
+            elif [ "$BAKED" != "$ALLOC" ]; then
+              echo "♻️→🔨 Export baked build $BAKED, but the allocator now assigns $ALLOC (superseded on a store) → rebuilding."
+              reuse=false
+            else
+              echo "✅ Reusable export's build number ($BAKED) is still current (allocator: $ALLOC)."
+            fi
+          fi
+
           echo "reuse=$reuse" >> "$GITHUB_OUTPUT"
 
           # In the reuse path nobody runs the lib build that writes .build.version, so reconstruct it


### PR DESCRIPTION
## Why

Part of **#2425**. The `godot-build-number-allocator` is becoming store-aware: when a store ships past a commit, it re-allocates a **higher** number for that commit. The iOS **reuse path** must honor that — otherwise it hands godot-asc-deploy an export baked with a now-stale `CFBundleVersion`, which TestFlight rejects (or which desyncs from the baked version string).

## What

- **`ios_r2_artifact.yml`** — after uploading the export, write a `build_number.txt` sidecar next to it in R2 (`ios/<branch>/<sha>/build_number.txt` + the `latest` pointer) recording the number the export was baked with. Skipped cleanly when `DCL_BUILD_NUMBER` is unset (fork PR / allocator skipped).
- **`mobile_distribute.yml` (`ios-resolve`)** — before reusing an export, fetch its sidecar and compare it against a fresh allocation:
  - sidecar missing → rebuild (bake a current number),
  - allocator unreachable → reuse anyway (godot-asc-deploy fails loud if it's behind),
  - sidecar ≠ allocation (superseded) → **rebuild**,
  - equal → safe to reuse.

## Depends on

- Allocator store-aware behavior: dcl-regenesislabs/godot-build-number-allocator#1
- godot-asc-deploy reporting + fail-loud: decentraland/godot-asc-deploy#3

Safe to merge in any order: the guard only forces a rebuild when the allocator returns a *different* number, which can't happen until the allocator PR is deployed and reporting starts. Until then it's a no-op (numbers always match).

## Testing

YAML lint passes for both workflows. No Rust/GDScript touched.

## Related

- Tracking issue: #2425
- Allocator PR: https://github.com/dcl-regenesislabs/godot-build-number-allocator/pull/1
- godot-asc-deploy PR: https://github.com/decentraland/godot-asc-deploy/pull/3

🤖 Generated with [Claude Code](https://claude.com/claude-code)