### PR TITLE
fix: WebSocket readyState=OPEN for Colyseus (#2430) + transport hardening & tests

### DIFF
--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -22,6 +22,11 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
 
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
       - name: Install gdtoolkit 4
         run: pip3 install git+https://github.com/dcl-regenesislabs/godot-gdscript-toolkit.git
 
@@ -34,3 +39,6 @@ jobs:
       - name: cargo fmt
         working-directory: lib
         run: cargo fmt --all -- --check
+
+      - name: WebSocket JS shim unit tests
+        run: node --test lib/src/dcl/js/js_modules/ws.test.cjs

--- a/lib/src/dcl/js/js_modules/ws.js
+++ b/lib/src/dcl/js/js_modules/ws.js
@@ -24,12 +24,13 @@ class WebSocket {
         this._readyState = WebSocket.CONNECTING
         this._protocol = ""
         this._bufferedAmount = 0
-        this._listeners = {
-            open: new Set(),
-            message: new Set(),
-            close: new Set(),
-            error: new Set(),
-        }
+        // Null-prototype so inherited names ('toString', '__proto__', ...) passed
+        // to addEventListener/dispatchEvent are ignored instead of matching.
+        this._listeners = Object.create(null)
+        this._listeners.open = new Set()
+        this._listeners.message = new Set()
+        this._listeners.close = new Set()
+        this._listeners.error = new Set()
 
         this._internal_ws_id = Deno.core.ops.op_ws_create(url, protocols ?? [])
 
@@ -206,7 +207,9 @@ class WebSocket {
                 type: "close",
                 code: typeof code === 'number' ? code : 1006,
                 reason: reason ?? "",
-                wasClean: code === 1000,
+                // A numeric code means a close frame was received, i.e. a clean
+                // closing handshake (any code, not just 1000).
+                wasClean: typeof code === 'number',
             })
         }
 
@@ -229,8 +232,11 @@ class WebSocket {
                     // Transition to OPEN so `readyState` reports OPEN. Libraries
                     // that gate sends on `readyState === WebSocket.OPEN` (e.g.
                     // Colyseus `isOpen`) would otherwise buffer/drop every message.
-                    self._readyState = WebSocket.OPEN
-                    self._emit("open", { type: "open" })
+                    // Ignore if the scene already called close() while CONNECTING.
+                    if (self._readyState === WebSocket.CONNECTING) {
+                        self._readyState = WebSocket.OPEN
+                        self._emit("open", { type: "open" })
+                    }
                     break
                 case "Closed":
                     fireClose(data.code, data.reason)

--- a/lib/src/dcl/js/js_modules/ws.js
+++ b/lib/src/dcl/js/js_modules/ws.js
@@ -46,10 +46,14 @@
 //   }
 
 class WebSocket {
-    static CLOSED = 1
+    // WHATWG WebSocket `readyState` values. These MUST match the standard
+    // (CONNECTING=0, OPEN=1, CLOSING=2, CLOSED=3): scenes and libraries such as
+    // Colyseus compare `ws.readyState === WebSocket.OPEN` to decide whether it is
+    // safe to send. Using non-standard values here silently breaks them.
+    static CONNECTING = 0
+    static OPEN = 1
     static CLOSING = 2
-    static CONNECTING = 3
-    static OPEN = 4
+    static CLOSED = 3
 
     constructor(url, protocols) {
         this.url = url
@@ -76,6 +80,23 @@ class WebSocket {
 
     get readyState() {
         return this._readyState
+    }
+
+    // The spec exposes the state constants on instances too, not just the class.
+    get CONNECTING() {
+        return WebSocket.CONNECTING
+    }
+
+    get OPEN() {
+        return WebSocket.OPEN
+    }
+
+    get CLOSING() {
+        return WebSocket.CLOSING
+    }
+
+    get CLOSED() {
+        return WebSocket.CLOSED
     }
 
     get binaryType() {
@@ -113,16 +134,39 @@ class WebSocket {
         }
     }
 
-    // TODO: add code and reason
+    // TODO: forward `code` and `reason` to the peer in the close frame.
     close(code, reason) {
-        if (this._readyState != WebSocket.CLOSED) {
-            Deno.core.ops.op_ws_send(this._internal_ws_id, { "type": "Close" })
-            this._readyState = WebSocket.CLOSED
+        if (this._readyState === WebSocket.CLOSING || this._readyState === WebSocket.CLOSED) {
+            return
         }
+        this._readyState = WebSocket.CLOSING
+        Deno.core.ops.op_ws_send(this._internal_ws_id, { "type": "Close" }).catch(console.error)
     }
 
     async _poll() {
         const self = this
+
+        // Deliver the close event exactly once. Per the WHATWG spec an error is
+        // always followed by a close, and a connection must never emit `close`
+        // more than once. Default to 1006 (abnormal closure) when no close frame
+        // was received so libraries can distinguish a drop from a clean leave.
+        let closeFired = false
+        function fireClose(code, reason) {
+            if (closeFired) {
+                return
+            }
+            closeFired = true
+            self._readyState = WebSocket.CLOSED
+            if (typeof self.onclose === 'function') {
+                self.onclose({
+                    type: "close",
+                    code: typeof code === 'number' ? code : 1006,
+                    reason: reason ?? "",
+                    wasClean: code === 1000,
+                })
+            }
+        }
+
         async function poll_from_native() {
             const data = await Deno.core.ops.op_ws_poll(self._internal_ws_id)
 
@@ -138,14 +182,16 @@ class WebSocket {
                     }
                     break
                 case "Connected":
+                    // Transition to OPEN so `readyState` reports OPEN. Libraries
+                    // that gate sends on `readyState === WebSocket.OPEN` (e.g.
+                    // Colyseus `isOpen`) would otherwise buffer/drop every message.
+                    self._readyState = WebSocket.OPEN
                     if (typeof self.onopen === 'function') {
                         self.onopen({ type: "open" })
                     }
                     break
                 case "Closed":
-                    if (typeof self.onclose === 'function') {
-                        self.onclose({ type: "close" })
-                    }
+                    fireClose(data.code, data.reason)
                     return false;
                 default:
                     throw new Error("unreached")
@@ -161,13 +207,16 @@ class WebSocket {
                 }
             }
         } catch (err) {
-            if (typeof this.onerror === 'function') {
-                this.onerror(err)
+            if (typeof self.onerror === 'function') {
+                self.onerror(err)
             }
+            // Abnormal closure: no close frame was received from the peer.
+            fireClose(1006, "")
         }
 
-        this._readyState = WebSocket.CLOSED
-        Deno.core.ops.op_ws_cleanup(this._internal_ws_id)
+        // Safety net: guarantee a single close event on any exit path.
+        fireClose(1006, "")
+        Deno.core.ops.op_ws_cleanup(self._internal_ws_id)
     }
 }
 

--- a/lib/src/dcl/js/js_modules/ws.js
+++ b/lib/src/dcl/js/js_modules/ws.js
@@ -1,49 +1,11 @@
 
 // /// --- WebSocket ---
-
-// interface Event {
-//     readonly type: string
-//   }
-
-//   interface MessageEvent extends Event {
-//     /**
-//      * Returns the data of the message.
-//      */
-//     readonly data: any
-//   }
-
-//   interface CloseEvent extends Event {
-//     readonly code: number
-//     readonly reason: string
-//     readonly wasClean: boolean
-//   }
-
-//   interface WebSocket {
-//     readonly bufferedAmount: number
-//     readonly extensions: string
-//     onclose: ((this: WebSocket, ev: CloseEvent) => any) | null
-//     onerror: ((this: WebSocket, ev: Event) => any) | null
-//     onmessage: ((this: WebSocket, ev: MessageEvent) => any) | null
-//     onopen: ((this: WebSocket, ev: Event) => any) | null
-//     readonly protocol: string
-//     readonly readyState: number
-//     readonly url: string
-//     close(code?: number, reason?: string): void
-//     send(data: string): void
-//     readonly CLOSED: number
-//     readonly CLOSING: number
-//     readonly CONNECTING: number
-//     readonly OPEN: number
-//   }
-
-//   declare var WebSocket: {
-//     prototype: WebSocket
-//     new (url: string, protocols?: string | string[]): WebSocket
-//     readonly CLOSED: number
-//     readonly CLOSING: number
-//     readonly CONNECTING: number
-//     readonly OPEN: number
-//   }
+//
+// A WHATWG-ish WebSocket implementation backed by the native `op_ws_*` ops.
+// It supports both the `on*` handler properties and addEventListener, reports
+// the standard readyState values, delivers binary frames as ArrayBuffer (to
+// match binaryType === 'arraybuffer'), and threads close code/reason in both
+// directions.
 
 class WebSocket {
     // WHATWG WebSocket `readyState` values. These MUST match the standard
@@ -60,22 +22,27 @@ class WebSocket {
         this.protocols = protocols
 
         this._readyState = WebSocket.CONNECTING
+        this._protocol = ""
+        this._bufferedAmount = 0
+        this._listeners = {
+            open: new Set(),
+            message: new Set(),
+            close: new Set(),
+            error: new Set(),
+        }
 
-        this._internal_ws_id = Deno.core.ops.op_ws_create(
-            url, protocols ?? []
-        )
+        this._internal_ws_id = Deno.core.ops.op_ws_create(url, protocols ?? [])
 
         this.onclose = null
         this.onerror = null
         this.onmessage = null
         this.onopen = null
 
-        this._poll().then(console.warn).catch(console.error)
+        this._poll().catch(console.error)
     }
 
-    // There is no send buffer here
     get bufferedAmount() {
-        return 0
+        return this._bufferedAmount
     }
 
     get readyState() {
@@ -109,9 +76,9 @@ class WebSocket {
         }
     }
 
-    // TODO: implement
+    // The subprotocol the server selected during the handshake (empty if none).
     get protocol() {
-        return ""
+        return this._protocol
     }
 
     // TODO: implement
@@ -119,28 +86,106 @@ class WebSocket {
         return ""
     }
 
+    addEventListener(type, listener) {
+        const set = this._listeners[type]
+        if (set && typeof listener === 'function') {
+            set.add(listener)
+        }
+    }
+
+    removeEventListener(type, listener) {
+        const set = this._listeners[type]
+        if (set) {
+            set.delete(listener)
+        }
+    }
+
+    dispatchEvent(event) {
+        this._emit(event.type, event)
+        return true
+    }
+
+    // Dispatch to the matching `on<type>` handler and any addEventListener
+    // listeners, isolating handler exceptions.
+    _emit(type, event) {
+        const handler = this["on" + type]
+        if (typeof handler === 'function') {
+            try {
+                handler.call(this, event)
+            } catch (err) {
+                console.error(err)
+            }
+        }
+        const set = this._listeners[type]
+        if (set) {
+            for (const listener of set) {
+                try {
+                    listener.call(this, event)
+                } catch (err) {
+                    console.error(err)
+                }
+            }
+        }
+    }
+
     send(data) {
+        if (this._readyState === WebSocket.CONNECTING) {
+            // Matches the browser: sending before the socket is open is an error.
+            throw new Error("InvalidStateError: still in CONNECTING state")
+        }
+        if (this._readyState !== WebSocket.OPEN) {
+            // CLOSING / CLOSED: per spec the data is silently discarded.
+            return
+        }
+
+        let payload
+        let size
         if (typeof data === 'string') {
-            Deno.core.ops.op_ws_send(this._internal_ws_id, { "type": "Text", data }).then().catch(console.error)
-        } else if (typeof data === 'object' && data instanceof Uint8Array) {
-            Deno.core.ops.op_ws_send(this._internal_ws_id, { "type": "Binary", data: Array.from(data) }).then().catch(console.error)
-        } else if (typeof data === 'object' && data instanceof ArrayBuffer) {
-            Deno.core.ops.op_ws_send(this._internal_ws_id, { "type": "Binary", data: Array.from(new Uint8Array(data)) }).then().catch(console.error)
+            payload = { "type": "Text", data }
+            size = data.length
+        } else if (data instanceof ArrayBuffer) {
+            payload = { "type": "Binary", data: Array.from(new Uint8Array(data)) }
+            size = data.byteLength
+        } else if (ArrayBuffer.isView(data)) {
+            // Uint8Array and any other typed-array / DataView view.
+            const view = new Uint8Array(data.buffer, data.byteOffset, data.byteLength)
+            payload = { "type": "Binary", data: Array.from(view) }
+            size = data.byteLength
         } else if (Array.isArray(data)) {
-            Deno.core.ops.op_ws_send(this._internal_ws_id, { "type": "Binary", data }).then().catch(console.error)
+            payload = { "type": "Binary", data }
+            size = data.length
         } else {
             console.error(`Unsupported data type: ${typeof data}`, data)
             throw new Error("Unsupported data type")
         }
+
+        // Best-effort bufferedAmount: bytes handed to the native queue that have
+        // not been accepted yet. Lets scenes throttle with the standard idiom.
+        this._bufferedAmount += size
+        const settle = () => {
+            this._bufferedAmount -= size
+        }
+        Deno.core.ops.op_ws_send(this._internal_ws_id, payload).then(settle).catch((err) => {
+            settle()
+            console.error(err)
+        })
     }
 
-    // TODO: forward `code` and `reason` to the peer in the close frame.
     close(code, reason) {
         if (this._readyState === WebSocket.CLOSING || this._readyState === WebSocket.CLOSED) {
             return
         }
+        if (code !== undefined && code !== 1000 && !(code >= 3000 && code <= 4999)) {
+            throw new Error("InvalidAccessError: close code must be 1000 or in the range 3000-4999")
+        }
         this._readyState = WebSocket.CLOSING
-        Deno.core.ops.op_ws_send(this._internal_ws_id, { "type": "Close" }).catch(console.error)
+        Deno.core.ops
+            .op_ws_send(this._internal_ws_id, {
+                "type": "Close",
+                code: code ?? null,
+                reason: reason ?? null,
+            })
+            .catch(console.error)
     }
 
     async _poll() {
@@ -157,14 +202,12 @@ class WebSocket {
             }
             closeFired = true
             self._readyState = WebSocket.CLOSED
-            if (typeof self.onclose === 'function') {
-                self.onclose({
-                    type: "close",
-                    code: typeof code === 'number' ? code : 1006,
-                    reason: reason ?? "",
-                    wasClean: code === 1000,
-                })
-            }
+            self._emit("close", {
+                type: "close",
+                code: typeof code === 'number' ? code : 1006,
+                reason: reason ?? "",
+                wasClean: code === 1000,
+            })
         }
 
         async function poll_from_native() {
@@ -172,27 +215,26 @@ class WebSocket {
 
             switch (data.type) {
                 case "BinaryData":
-                    if (typeof self.onmessage === 'function') {
-                        self.onmessage({ type: "binary", data: new Uint8Array(data.data) })
-                    }
+                    // Deliver a real ArrayBuffer, matching binaryType.
+                    self._emit("message", {
+                        type: "message",
+                        data: new Uint8Array(data.data).buffer,
+                    })
                     break
                 case "TextData":
-                    if (typeof self.onmessage === 'function') {
-                        self.onmessage({ type: "text", data: data.data })
-                    }
+                    self._emit("message", { type: "message", data: data.data })
                     break
                 case "Connected":
+                    self._protocol = data.protocol ?? ""
                     // Transition to OPEN so `readyState` reports OPEN. Libraries
                     // that gate sends on `readyState === WebSocket.OPEN` (e.g.
                     // Colyseus `isOpen`) would otherwise buffer/drop every message.
                     self._readyState = WebSocket.OPEN
-                    if (typeof self.onopen === 'function') {
-                        self.onopen({ type: "open" })
-                    }
+                    self._emit("open", { type: "open" })
                     break
                 case "Closed":
                     fireClose(data.code, data.reason)
-                    return false;
+                    return false
                 default:
                     throw new Error("unreached")
             }
@@ -207,9 +249,11 @@ class WebSocket {
                 }
             }
         } catch (err) {
-            if (typeof self.onerror === 'function') {
-                self.onerror(err)
-            }
+            self._emit("error", {
+                type: "error",
+                error: err,
+                message: String((err && err.message) || err),
+            })
             // Abnormal closure: no close frame was received from the peer.
             fireClose(1006, "")
         }
@@ -222,8 +266,17 @@ class WebSocket {
 
 class RestrictedWebSocket extends WebSocket {
     constructor(url, protocols) {
-        const previewMode = true // TODO: this should be exposed from Deno.env
-        const canUseWebsocket = true // TODO: this should be exposed from Deno.env
+        // Default to permissive (preview) if the realm info is unavailable, so a
+        // missing op can never break WebSocket entirely.
+        let previewMode = true
+        try {
+            previewMode = !!Deno.core.ops.op_get_realm().isPreview
+        } catch (_err) {
+            previewMode = true
+        }
+        // TODO: gate on the scene's declared USE_WEBSOCKET permission once a
+        // permission model exists in the client (fetch.js has the same gap).
+        const canUseWebsocket = true
 
         if (url.toString().toLowerCase().substr(0, 4) !== 'wss:') {
             if (previewMode) {
@@ -231,12 +284,12 @@ class RestrictedWebSocket extends WebSocket {
                     "⚠️ Warning: can't connect to unsafe WebSocket (ws) server in deployed scenes, consider upgrading to wss."
                 )
             } else {
-                throw new Error("Can't connect to unsafe WebSocket server")
+                throw new Error("Can't connect to unsafe WebSocket server, please upgrade to wss.")
             }
         }
 
         if (!canUseWebsocket) {
-            throw new Error("This scene doesn't have allowed to use WebSocket")
+            throw new Error("This scene is not allowed to use WebSocket")
         }
 
         let realProtocols = []

--- a/lib/src/dcl/js/js_modules/ws.test.cjs
+++ b/lib/src/dcl/js/js_modules/ws.test.cjs
@@ -1,13 +1,14 @@
 // Unit tests for the JS-side WebSocket shim (ws.js).
 //
-// These cover the half of the fix for issue #2430 that lives purely in
-// JavaScript and is therefore NOT reachable from the Rust `ws_poll` tests:
-// the readyState state machine, the on*-handler dispatch, and the
-// single-shot `fireClose` logic (code/reason/wasClean mapping).
+// These cover the parts of the shim that are NOT reachable from the Rust
+// `ws_poll` tests: the readyState state machine (the #2430 fix), event
+// dispatch through both `on*` handlers and addEventListener, the single-shot
+// `fireClose` logic, binary delivery as ArrayBuffer, subprotocol reporting,
+// and send()/close() validation.
 //
 // The shim only talks to the native layer through `Deno.core.ops`, so we stub
-// those four ops and script the sequence of `op_ws_poll` results the native
-// task would produce. No npm dependencies — Node's built-in test runner only.
+// those ops and script the sequence of `op_ws_poll` results the native task
+// would produce. No npm dependencies — Node's built-in test runner only.
 //
 // Run with:  node --test lib/src/dcl/js/js_modules/ws.test.cjs
 
@@ -22,27 +23,37 @@ const { WebSocket } = require("./ws.js");
  * Install stub ops that replay `pollScript` (an array of `op_ws_poll` results)
  * and record everything sent. Returns the recording `log`.
  *
- * A script item of `{ __throw: true }` makes `op_ws_poll` reject (simulating a
- * native error). When the script is exhausted, `op_ws_poll` never resolves,
- * mirroring an idle-but-open socket.
+ * A script item of `{ __throw: true }` makes `op_ws_poll` reject. When the
+ * script is exhausted, `op_ws_poll` never resolves (an idle-but-open socket).
  */
+// Unique id per install so a socket left polling by an earlier test (its
+// _poll loop never stops) cannot steal this test's scripted events: the ops
+// only serve the current id and hang for any foreign one.
+let nextSocketId = 0;
+
 function installOps(pollScript) {
+  const id = ++nextSocketId;
   const log = { created: [], sent: [], cleaned: 0 };
   let i = 0;
   globalThis.Deno = {
     core: {
       ops: {
+        op_get_realm() {
+          return { isPreview: true };
+        },
         op_ws_create(url, protocols) {
           log.created.push({ url, protocols });
-          return 1;
+          return id;
         },
-        op_ws_send(_id, data) {
-          log.sent.push(data);
+        op_ws_send(sid, data) {
+          if (sid === id) {
+            log.sent.push(data);
+          }
           return Promise.resolve();
         },
-        async op_ws_poll(_id) {
-          if (i >= pollScript.length) {
-            return await new Promise(() => {}); // idle: no more native events
+        async op_ws_poll(sid) {
+          if (sid !== id || i >= pollScript.length) {
+            return await new Promise(() => {}); // foreign/exhausted: idle
           }
           const item = pollScript[i++];
           if (item && item.__throw) {
@@ -98,7 +109,17 @@ test("Connected transitions readyState to OPEN and fires onopen once", async () 
   assert.equal(WebSocket.OPEN, 1, "OPEN must equal the spec value 1");
 });
 
-test("TextData is delivered to onmessage", async () => {
+test("Connected reports the negotiated subprotocol", async () => {
+  installOps([
+    { type: "Connected", protocol: "json" },
+    { type: "Closed", code: 1000, reason: "" },
+  ]);
+  const ws = new WebSocket("wss://example.org/");
+  await closed(ws);
+  assert.equal(ws.protocol, "json");
+});
+
+test("TextData is delivered to onmessage as a string", async () => {
   installOps([
     { type: "Connected" },
     { type: "TextData", data: "hello" },
@@ -109,10 +130,12 @@ test("TextData is delivered to onmessage", async () => {
   ws.onmessage = (m) => messages.push(m);
 
   await closed(ws);
-  assert.deepEqual(messages, [{ type: "text", data: "hello" }]);
+  assert.equal(messages.length, 1);
+  assert.equal(messages[0].type, "message");
+  assert.equal(messages[0].data, "hello");
 });
 
-test("BinaryData is delivered to onmessage as a Uint8Array", async () => {
+test("BinaryData is delivered to onmessage as an ArrayBuffer", async () => {
   installOps([
     { type: "Connected" },
     { type: "BinaryData", data: [1, 2, 3, 255] },
@@ -124,9 +147,43 @@ test("BinaryData is delivered to onmessage as a Uint8Array", async () => {
 
   await closed(ws);
   assert.equal(messages.length, 1);
-  assert.equal(messages[0].type, "binary");
-  assert.ok(messages[0].data instanceof Uint8Array);
-  assert.deepEqual(Array.from(messages[0].data), [1, 2, 3, 255]);
+  assert.ok(messages[0].data instanceof ArrayBuffer, "binary data must be an ArrayBuffer");
+  assert.deepEqual(Array.from(new Uint8Array(messages[0].data)), [1, 2, 3, 255]);
+});
+
+test("addEventListener fires alongside the on* handlers", async () => {
+  installOps([
+    { type: "Connected" },
+    { type: "TextData", data: "hi" },
+    { type: "Closed", code: 1000, reason: "" },
+  ]);
+  const ws = new WebSocket("wss://example.org/");
+
+  const seen = { open: 0, message: 0, close: 0 };
+  ws.addEventListener("open", () => (seen.open += 1));
+  ws.addEventListener("message", () => (seen.message += 1));
+  ws.addEventListener("close", () => (seen.close += 1));
+
+  await new Promise((resolve) => {
+    ws.onclose = () => resolve();
+  });
+  assert.deepEqual(seen, { open: 1, message: 1, close: 1 });
+});
+
+test("removeEventListener detaches a listener", async () => {
+  installOps([
+    { type: "Connected" },
+    { type: "TextData", data: "hi" },
+    { type: "Closed", code: 1000, reason: "" },
+  ]);
+  const ws = new WebSocket("wss://example.org/");
+  let count = 0;
+  const listener = () => (count += 1);
+  ws.addEventListener("message", listener);
+  ws.removeEventListener("message", listener);
+
+  await closed(ws);
+  assert.equal(count, 0, "removed listener must not fire");
 });
 
 test("clean close maps code/reason/wasClean and reaches CLOSED once", async () => {
@@ -144,7 +201,6 @@ test("clean close maps code/reason/wasClean and reaches CLOSED once", async () =
   assert.equal(e.reason, "bye");
   assert.equal(e.wasClean, true);
   assert.equal(ws.readyState, WebSocket.CLOSED);
-  // Give any stray extra close a chance to (incorrectly) fire.
   await new Promise((r) => setTimeout(r, 30));
   assert.equal(closeCount, 1, "onclose must fire exactly once");
 });
@@ -163,8 +219,12 @@ test("a native poll error fires onerror then exactly one onclose(1006)", async (
   const ws = new WebSocket("wss://example.org/");
 
   const order = [];
+  let errorEvent;
   let closeEvent;
-  ws.onerror = () => order.push("error");
+  ws.onerror = (e) => {
+    order.push("error");
+    errorEvent = e;
+  };
   const done = new Promise((resolve) => {
     ws.onclose = (e) => {
       order.push("close");
@@ -176,6 +236,7 @@ test("a native poll error fires onerror then exactly one onclose(1006)", async (
   await done;
   await new Promise((r) => setTimeout(r, 30));
   assert.deepEqual(order, ["error", "close"], "error must precede a single close");
+  assert.equal(errorEvent.type, "error");
   assert.equal(closeEvent.code, 1006);
   assert.equal(ws.readyState, WebSocket.CLOSED);
 });
@@ -197,19 +258,25 @@ test("send() coerces string/Uint8Array/ArrayBuffer into the native shapes", asyn
   ]);
 });
 
-test("close() is idempotent: sends one Close and transitions to CLOSING", async () => {
-  const log = installOps([{ type: "Connected" }, { type: "Closed", code: 1000, reason: "" }]);
+test("send() before OPEN throws InvalidStateError", () => {
+  installOps([]);
+  const ws = new WebSocket("wss://example.org/");
+  assert.equal(ws.readyState, WebSocket.CONNECTING);
+  assert.throws(() => ws.send("too early"), /InvalidStateError/);
+});
+
+test("close() validates the code and forwards code/reason; is idempotent", async () => {
+  const log = installOps([{ type: "Connected" }, { type: "Closed", code: 4001, reason: "kick" }]);
   const ws = new WebSocket("wss://example.org/");
 
-  let stateAfterFirstClose;
-  ws.onopen = () => {
-    ws.close();
-    stateAfterFirstClose = ws.readyState;
-    ws.close(); // second call must be a no-op
-  };
+  // Reserved/invalid application codes are rejected.
+  assert.throws(() => ws.close(1001), /InvalidAccessError/);
+
+  ws.close(4001, "kick");
+  assert.equal(ws.readyState, WebSocket.CLOSING);
+  ws.close(4002, "again"); // must be a no-op once CLOSING
 
   await closed(ws);
-  const closeSends = log.sent.filter((s) => s.type === "Close");
-  assert.equal(closeSends.length, 1, "close() must enqueue exactly one Close");
-  assert.equal(stateAfterFirstClose, WebSocket.CLOSING);
+  const closes = log.sent.filter((s) => s.type === "Close");
+  assert.deepEqual(closes, [{ type: "Close", code: 4001, reason: "kick" }]);
 });

--- a/lib/src/dcl/js/js_modules/ws.test.cjs
+++ b/lib/src/dcl/js/js_modules/ws.test.cjs
@@ -265,6 +265,38 @@ test("send() before OPEN throws InvalidStateError", () => {
   assert.throws(() => ws.send("too early"), /InvalidStateError/);
 });
 
+test("close() during CONNECTING is not reverted to OPEN by a later Connected", async () => {
+  installOps([{ type: "Connected" }, { type: "Closed", code: 1000, reason: "" }]);
+  const ws = new WebSocket("wss://example.org/");
+  assert.equal(ws.readyState, WebSocket.CONNECTING);
+
+  let openFired = false;
+  ws.onopen = () => {
+    openFired = true;
+  };
+  ws.close(1000);
+  assert.equal(ws.readyState, WebSocket.CLOSING);
+
+  await closed(ws);
+  assert.equal(openFired, false, "onopen must not fire after close() during CONNECTING");
+  assert.equal(ws.readyState, WebSocket.CLOSED);
+});
+
+test("a clean close with a non-1000 code reports wasClean=true", async () => {
+  installOps([{ type: "Connected" }, { type: "Closed", code: 4001, reason: "kick" }]);
+  const ws = new WebSocket("wss://example.org/");
+  const e = await closed(ws);
+  assert.equal(e.code, 4001);
+  assert.equal(e.wasClean, true, "a received close frame (numeric code) is a clean close");
+});
+
+test("addEventListener/dispatchEvent ignore inherited type names safely", () => {
+  installOps([]);
+  const ws = new WebSocket("wss://example.org/");
+  assert.doesNotThrow(() => ws.addEventListener("toString", () => {}));
+  assert.doesNotThrow(() => ws.dispatchEvent({ type: "__proto__" }));
+});
+
 test("close() validates the code and forwards code/reason; is idempotent", async () => {
   const log = installOps([{ type: "Connected" }, { type: "Closed", code: 4001, reason: "kick" }]);
   const ws = new WebSocket("wss://example.org/");

--- a/lib/src/dcl/js/js_modules/ws.test.cjs
+++ b/lib/src/dcl/js/js_modules/ws.test.cjs
@@ -1,0 +1,215 @@
+// Unit tests for the JS-side WebSocket shim (ws.js).
+//
+// These cover the half of the fix for issue #2430 that lives purely in
+// JavaScript and is therefore NOT reachable from the Rust `ws_poll` tests:
+// the readyState state machine, the on*-handler dispatch, and the
+// single-shot `fireClose` logic (code/reason/wasClean mapping).
+//
+// The shim only talks to the native layer through `Deno.core.ops`, so we stub
+// those four ops and script the sequence of `op_ws_poll` results the native
+// task would produce. No npm dependencies — Node's built-in test runner only.
+//
+// Run with:  node --test lib/src/dcl/js/js_modules/ws.test.cjs
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+// Load the shim once; its methods read `globalThis.Deno` lazily (at call time),
+// so each test can install its own scripted ops before constructing a socket.
+const { WebSocket } = require("./ws.js");
+
+/**
+ * Install stub ops that replay `pollScript` (an array of `op_ws_poll` results)
+ * and record everything sent. Returns the recording `log`.
+ *
+ * A script item of `{ __throw: true }` makes `op_ws_poll` reject (simulating a
+ * native error). When the script is exhausted, `op_ws_poll` never resolves,
+ * mirroring an idle-but-open socket.
+ */
+function installOps(pollScript) {
+  const log = { created: [], sent: [], cleaned: 0 };
+  let i = 0;
+  globalThis.Deno = {
+    core: {
+      ops: {
+        op_ws_create(url, protocols) {
+          log.created.push({ url, protocols });
+          return 1;
+        },
+        op_ws_send(_id, data) {
+          log.sent.push(data);
+          return Promise.resolve();
+        },
+        async op_ws_poll(_id) {
+          if (i >= pollScript.length) {
+            return await new Promise(() => {}); // idle: no more native events
+          }
+          const item = pollScript[i++];
+          if (item && item.__throw) {
+            throw new Error(item.message || "native poll failure");
+          }
+          return item;
+        },
+        op_ws_cleanup(_id) {
+          log.cleaned += 1;
+        },
+      },
+    },
+  };
+  return log;
+}
+
+/** Resolve once `onclose` fires (or reject on timeout). */
+function closed(ws) {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error("onclose never fired")), 2000);
+    ws.onclose = (e) => {
+      clearTimeout(timer);
+      resolve(e);
+    };
+  });
+}
+
+test("constants use the WHATWG spec values", () => {
+  installOps([]);
+  assert.equal(WebSocket.CONNECTING, 0);
+  assert.equal(WebSocket.OPEN, 1);
+  assert.equal(WebSocket.CLOSING, 2);
+  assert.equal(WebSocket.CLOSED, 3);
+});
+
+// The exact regression guard for issue #2430: after the native "Connected"
+// event, readyState MUST report OPEN, otherwise Colyseus's
+// `isOpen = readyState === WebSocket.OPEN` stays false and buffers every send.
+test("Connected transitions readyState to OPEN and fires onopen once", async () => {
+  installOps([{ type: "Connected" }, { type: "Closed", code: 1000, reason: "" }]);
+  const ws = new WebSocket("wss://example.org/");
+
+  let openCount = 0;
+  let stateInOnOpen;
+  ws.onopen = () => {
+    openCount += 1;
+    stateInOnOpen = ws.readyState;
+  };
+
+  await closed(ws);
+  assert.equal(openCount, 1, "onopen must fire exactly once");
+  assert.equal(stateInOnOpen, WebSocket.OPEN, "readyState must be OPEN inside onopen");
+  assert.equal(WebSocket.OPEN, 1, "OPEN must equal the spec value 1");
+});
+
+test("TextData is delivered to onmessage", async () => {
+  installOps([
+    { type: "Connected" },
+    { type: "TextData", data: "hello" },
+    { type: "Closed", code: 1000, reason: "" },
+  ]);
+  const ws = new WebSocket("wss://example.org/");
+  const messages = [];
+  ws.onmessage = (m) => messages.push(m);
+
+  await closed(ws);
+  assert.deepEqual(messages, [{ type: "text", data: "hello" }]);
+});
+
+test("BinaryData is delivered to onmessage as a Uint8Array", async () => {
+  installOps([
+    { type: "Connected" },
+    { type: "BinaryData", data: [1, 2, 3, 255] },
+    { type: "Closed", code: 1000, reason: "" },
+  ]);
+  const ws = new WebSocket("wss://example.org/");
+  const messages = [];
+  ws.onmessage = (m) => messages.push(m);
+
+  await closed(ws);
+  assert.equal(messages.length, 1);
+  assert.equal(messages[0].type, "binary");
+  assert.ok(messages[0].data instanceof Uint8Array);
+  assert.deepEqual(Array.from(messages[0].data), [1, 2, 3, 255]);
+});
+
+test("clean close maps code/reason/wasClean and reaches CLOSED once", async () => {
+  installOps([{ type: "Connected" }, { type: "Closed", code: 1000, reason: "bye" }]);
+  const ws = new WebSocket("wss://example.org/");
+
+  let closeCount = 0;
+  const e = await new Promise((resolve) => {
+    ws.onclose = (ev) => {
+      closeCount += 1;
+      resolve(ev);
+    };
+  });
+  assert.equal(e.code, 1000);
+  assert.equal(e.reason, "bye");
+  assert.equal(e.wasClean, true);
+  assert.equal(ws.readyState, WebSocket.CLOSED);
+  // Give any stray extra close a chance to (incorrectly) fire.
+  await new Promise((r) => setTimeout(r, 30));
+  assert.equal(closeCount, 1, "onclose must fire exactly once");
+});
+
+test("abnormal close (no code) defaults to 1006 / wasClean=false", async () => {
+  installOps([{ type: "Connected" }, { type: "Closed" }]);
+  const ws = new WebSocket("wss://example.org/");
+  const e = await closed(ws);
+  assert.equal(e.code, 1006);
+  assert.equal(e.wasClean, false);
+  assert.equal(ws.readyState, WebSocket.CLOSED);
+});
+
+test("a native poll error fires onerror then exactly one onclose(1006)", async () => {
+  installOps([{ type: "Connected" }, { __throw: true, message: "boom" }]);
+  const ws = new WebSocket("wss://example.org/");
+
+  const order = [];
+  let closeEvent;
+  ws.onerror = () => order.push("error");
+  const done = new Promise((resolve) => {
+    ws.onclose = (e) => {
+      order.push("close");
+      closeEvent = e;
+      resolve();
+    };
+  });
+
+  await done;
+  await new Promise((r) => setTimeout(r, 30));
+  assert.deepEqual(order, ["error", "close"], "error must precede a single close");
+  assert.equal(closeEvent.code, 1006);
+  assert.equal(ws.readyState, WebSocket.CLOSED);
+});
+
+test("send() coerces string/Uint8Array/ArrayBuffer into the native shapes", async () => {
+  const log = installOps([{ type: "Connected" }, { type: "Closed", code: 1000, reason: "" }]);
+  const ws = new WebSocket("wss://example.org/");
+  ws.onopen = () => {
+    ws.send("hi");
+    ws.send(new Uint8Array([1, 2, 3]));
+    ws.send(new Uint8Array([9, 9]).buffer);
+  };
+
+  await closed(ws);
+  assert.deepEqual(log.sent, [
+    { type: "Text", data: "hi" },
+    { type: "Binary", data: [1, 2, 3] },
+    { type: "Binary", data: [9, 9] },
+  ]);
+});
+
+test("close() is idempotent: sends one Close and transitions to CLOSING", async () => {
+  const log = installOps([{ type: "Connected" }, { type: "Closed", code: 1000, reason: "" }]);
+  const ws = new WebSocket("wss://example.org/");
+
+  let stateAfterFirstClose;
+  ws.onopen = () => {
+    ws.close();
+    stateAfterFirstClose = ws.readyState;
+    ws.close(); // second call must be a no-op
+  };
+
+  await closed(ws);
+  const closeSends = log.sent.filter((s) => s.type === "Close");
+  assert.equal(closeSends.length, 1, "close() must enqueue exactly one Close");
+  assert.equal(stateAfterFirstClose, WebSocket.CLOSING);
+});

--- a/lib/src/dcl/js/websocket/mod.rs
+++ b/lib/src/dcl/js/websocket/mod.rs
@@ -299,3 +299,288 @@ fn op_ws_cleanup(state: &mut OpState, res_id: u32) -> Result<(), AnyError> {
 
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    //! Integration tests for the native `ws_poll` transport task, exercised
+    //! against a local `tokio-tungstenite` server. These lock down the
+    //! transport behaviour scenes rely on — connect, text/binary round-trip,
+    //! message ordering, ping/pong, close-code propagation and connection
+    //! failure — and guard against regressions of the Colyseus WebSocket bug
+    //! (#2430), whose sibling defect was the close code/reason being dropped.
+    //!
+    //! Run with: `cargo test -p dclgodot websocket`
+
+    use std::future::Future;
+    use std::time::Duration;
+
+    use futures_util::{SinkExt, StreamExt};
+    use tokio::net::TcpListener;
+    use tokio_tungstenite::tungstenite::protocol::frame::coding::CloseCode;
+    use tokio_tungstenite::tungstenite::protocol::CloseFrame;
+    use tokio_tungstenite::tungstenite::Message;
+    use tokio_tungstenite::WebSocketStream;
+
+    use super::{ws_poll, WsReceiveData, WsSendData};
+
+    type ServerWs = WebSocketStream<tokio::net::TcpStream>;
+
+    /// Bind an ephemeral local server, accept ONE connection, run `handler`,
+    /// and return the `ws://` URL to dial.
+    async fn serve<F, Fut>(handler: F) -> String
+    where
+        F: FnOnce(ServerWs) -> Fut + Send + 'static,
+        Fut: Future<Output = ()> + Send + 'static,
+    {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let ws = tokio_tungstenite::accept_async(stream).await.unwrap();
+            handler(ws).await;
+        });
+        format!("ws://{addr}/")
+    }
+
+    struct Client {
+        to_native: tokio::sync::mpsc::Sender<WsSendData>,
+        from_native: tokio::sync::mpsc::Receiver<WsReceiveData>,
+    }
+
+    /// Wire up the JS<->native channels the same way `op_ws_create` does and
+    /// spawn the real `ws_poll` task.
+    fn connect(url: String) -> Client {
+        let (to_native, rx_send) = tokio::sync::mpsc::channel(100);
+        let (tx_recv, from_native) = tokio::sync::mpsc::channel(100);
+        tokio::spawn(ws_poll(url, vec![], rx_send, tx_recv));
+        Client {
+            to_native,
+            from_native,
+        }
+    }
+
+    /// Await the next native->JS event, failing the test on timeout/close.
+    async fn next(c: &mut Client) -> WsReceiveData {
+        tokio::time::timeout(Duration::from_secs(5), c.from_native.recv())
+            .await
+            .expect("timed out waiting for a native event")
+            .expect("native->JS channel closed unexpectedly")
+    }
+
+    /// A server that echoes text/binary frames and stops on close.
+    async fn echo_server(mut ws: ServerWs) {
+        while let Some(Ok(m)) = ws.next().await {
+            match m {
+                Message::Text(_) | Message::Binary(_) => {
+                    if ws.send(m).await.is_err() {
+                        break;
+                    }
+                }
+                Message::Close(_) => break,
+                _ => {}
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn reports_connected_first() {
+        let url = serve(echo_server).await;
+        let mut c = connect(url);
+        assert!(
+            matches!(next(&mut c).await, WsReceiveData::Connected),
+            "the first native event must be Connected"
+        );
+        c.to_native.send(WsSendData::Close).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn echoes_text() {
+        let url = serve(echo_server).await;
+        let mut c = connect(url);
+        assert!(matches!(next(&mut c).await, WsReceiveData::Connected));
+
+        c.to_native
+            .send(WsSendData::Text {
+                data: "hello world".into(),
+            })
+            .await
+            .unwrap();
+
+        match next(&mut c).await {
+            WsReceiveData::TextData(s) => assert_eq!(s, "hello world"),
+            _ => panic!("expected TextData echo"),
+        }
+    }
+
+    #[tokio::test]
+    async fn echoes_binary() {
+        let url = serve(echo_server).await;
+        let mut c = connect(url);
+        assert!(matches!(next(&mut c).await, WsReceiveData::Connected));
+
+        let payload = vec![0u8, 1, 2, 3, 255, 254, 42];
+        c.to_native
+            .send(WsSendData::Binary {
+                data: payload.clone(),
+            })
+            .await
+            .unwrap();
+
+        match next(&mut c).await {
+            WsReceiveData::BinaryData(b) => assert_eq!(b, payload),
+            _ => panic!("expected BinaryData echo"),
+        }
+    }
+
+    #[tokio::test]
+    async fn preserves_order_under_burst() {
+        let url = serve(echo_server).await;
+        let mut c = connect(url);
+        assert!(matches!(next(&mut c).await, WsReceiveData::Connected));
+
+        for i in 0..50 {
+            c.to_native
+                .send(WsSendData::Text {
+                    data: format!("msg-{i}"),
+                })
+                .await
+                .unwrap();
+        }
+        for i in 0..50 {
+            match next(&mut c).await {
+                WsReceiveData::TextData(s) => assert_eq!(s, format!("msg-{i}")),
+                _ => panic!("expected in-order TextData"),
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn round_trips_large_binary() {
+        let url = serve(echo_server).await;
+        let mut c = connect(url);
+        assert!(matches!(next(&mut c).await, WsReceiveData::Connected));
+
+        let payload: Vec<u8> = (0..1_000_000).map(|i| (i % 251) as u8).collect();
+        c.to_native
+            .send(WsSendData::Binary {
+                data: payload.clone(),
+            })
+            .await
+            .unwrap();
+
+        match next(&mut c).await {
+            WsReceiveData::BinaryData(b) => assert_eq!(b, payload),
+            _ => panic!("expected large BinaryData echo"),
+        }
+    }
+
+    #[tokio::test]
+    async fn responds_to_server_ping_with_pong() {
+        let (tx, rx) = tokio::sync::oneshot::channel::<Vec<u8>>();
+        let url = serve(|mut ws: ServerWs| async move {
+            ws.send(Message::Ping(vec![9, 8, 7])).await.unwrap();
+            let mut tx = Some(tx);
+            while let Some(Ok(m)) = ws.next().await {
+                if let Message::Pong(p) = m {
+                    if let Some(tx) = tx.take() {
+                        let _ = tx.send(p);
+                    }
+                    break;
+                }
+            }
+        })
+        .await;
+
+        let mut c = connect(url);
+        assert!(matches!(next(&mut c).await, WsReceiveData::Connected));
+
+        // The client must auto-pong; the ping must not surface to the JS side.
+        let pong = tokio::time::timeout(Duration::from_secs(5), rx)
+            .await
+            .expect("server never received a pong")
+            .expect("pong channel dropped");
+        assert_eq!(
+            pong,
+            vec![9, 8, 7],
+            "pong payload must echo the ping payload"
+        );
+    }
+
+    /// Regression test for #2430's sibling defect: the server's close code and
+    /// reason must survive all the way to the native->JS boundary.
+    #[tokio::test]
+    async fn server_close_propagates_code_and_reason() {
+        let url = serve(|mut ws: ServerWs| async move {
+            ws.send(Message::Close(Some(CloseFrame {
+                code: CloseCode::Away, // 1001
+                reason: "going away".into(),
+            })))
+            .await
+            .unwrap();
+            // Drive the close handshake to completion.
+            while let Some(Ok(_)) = ws.next().await {}
+        })
+        .await;
+
+        let mut c = connect(url);
+        loop {
+            match next(&mut c).await {
+                WsReceiveData::Connected => continue,
+                WsReceiveData::Close(Some(frame)) => {
+                    assert_eq!(u16::from(frame.code), 1001, "close code must be preserved");
+                    assert_eq!(frame.reason, "going away", "close reason must be preserved");
+                    break;
+                }
+                WsReceiveData::Close(None) => panic!("close frame lost its code/reason"),
+                _ => panic!("unexpected event before close"),
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn client_close_is_seen_by_server() {
+        let (tx, rx) = tokio::sync::oneshot::channel::<()>();
+        let url = serve(|mut ws: ServerWs| async move {
+            loop {
+                match ws.next().await {
+                    Some(Ok(Message::Close(_))) | Some(Err(_)) | None => break,
+                    Some(Ok(_)) => {}
+                }
+            }
+            let _ = tx.send(());
+        })
+        .await;
+
+        let mut c = connect(url);
+        assert!(matches!(next(&mut c).await, WsReceiveData::Connected));
+        c.to_native.send(WsSendData::Close).await.unwrap();
+
+        tokio::time::timeout(Duration::from_secs(5), rx)
+            .await
+            .expect("server never observed the client close")
+            .expect("close-signal channel dropped");
+    }
+
+    #[tokio::test]
+    async fn connect_failure_returns_err_without_connected() {
+        // Accept the TCP connection then drop it before completing the
+        // WebSocket handshake -> deterministic handshake failure.
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            if let Ok((stream, _)) = listener.accept().await {
+                drop(stream);
+            }
+        });
+
+        let (_to_native, rx_send) = tokio::sync::mpsc::channel(100);
+        let (tx_recv, mut from_native) = tokio::sync::mpsc::channel(100);
+
+        let res = ws_poll(format!("ws://{addr}/"), vec![], rx_send, tx_recv).await;
+        assert!(res.is_err(), "a failed handshake must return Err");
+        assert!(
+            from_native.try_recv().is_err(),
+            "no Connected event may be emitted on connection failure"
+        );
+    }
+}

--- a/lib/src/dcl/js/websocket/mod.rs
+++ b/lib/src/dcl/js/websocket/mod.rs
@@ -36,7 +36,7 @@ struct WsState {
 #[serde(tag = "type")]
 enum WsPoll {
     Connected,
-    Closed,
+    Closed { code: Option<u16>, reason: String },
     BinaryData { data: Vec<u8> },
     TextData { data: String },
 }
@@ -251,11 +251,11 @@ async fn op_ws_poll(op_state: Rc<RefCell<OpState>>, res_id: u32) -> Result<WsPol
         Some(WsReceiveData::Connected) => Ok(WsPoll::Connected),
         Some(WsReceiveData::Error(err)) => Err(err),
         Some(WsReceiveData::Close(data)) => {
-            if let Some(_data) = data {
-                Ok(WsPoll::Closed)
-            } else {
-                Ok(WsPoll::Closed)
-            }
+            let (code, reason) = match data {
+                Some(frame) => (Some(u16::from(frame.code)), frame.reason.into_owned()),
+                None => (None, String::new()),
+            };
+            Ok(WsPoll::Closed { code, reason })
         }
         None => Err(anyhow::Error::msg("none")),
     };

--- a/lib/src/dcl/js/websocket/mod.rs
+++ b/lib/src/dcl/js/websocket/mod.rs
@@ -14,8 +14,10 @@ pub fn ops() -> Vec<OpDecl> {
 
 /// Give up on the opening handshake after this long.
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(30);
-/// Give up on a single frame write after this long (wedged/adversarial peer).
-const WRITE_TIMEOUT: Duration = Duration::from_secs(30);
+/// Backstop against a wedged/adversarial peer that never drains our writes.
+/// Kept generous so a legitimately-progressing large send over a slow link is
+/// not aborted mid-transfer.
+const WRITE_TIMEOUT: Duration = Duration::from_secs(120);
 /// After we initiate close, wait at most this long for the peer's close frame
 /// before tearing the socket down so it can never wedge in CLOSING.
 const CLOSE_HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(5);

--- a/lib/src/dcl/js/websocket/mod.rs
+++ b/lib/src/dcl/js/websocket/mod.rs
@@ -1,21 +1,43 @@
+use std::time::Duration;
 use std::{cell::RefCell, collections::HashMap, rc::Rc};
 
 use deno_core::{error::AnyError, op2, OpDecl, OpState};
 use futures_util::{SinkExt, StreamExt};
 use http::{HeaderName, HeaderValue};
 use serde::{Deserialize, Serialize};
-use tokio_tungstenite::tungstenite::{client::IntoClientRequest, protocol::CloseFrame};
+use tokio_tungstenite::tungstenite::protocol::{CloseFrame, WebSocketConfig};
+use tokio_tungstenite::tungstenite::{client::IntoClientRequest, Message};
 
 pub fn ops() -> Vec<OpDecl> {
     vec![op_ws_create(), op_ws_cleanup(), op_ws_send(), op_ws_poll()]
 }
 
+/// Give up on the opening handshake after this long.
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(30);
+/// Give up on a single frame write after this long (wedged/adversarial peer).
+const WRITE_TIMEOUT: Duration = Duration::from_secs(30);
+/// After we initiate close, wait at most this long for the peer's close frame
+/// before tearing the socket down so it can never wedge in CLOSING.
+const CLOSE_HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(5);
+/// Reject inbound messages/frames larger than this.
+const MAX_MESSAGE_SIZE: usize = 16 << 20; // 16 MiB
+const MAX_FRAME_SIZE: usize = 16 << 20; // 16 MiB
+/// Backstop against a scene opening sockets in a loop and leaking them.
+const MAX_CONNECTIONS_PER_SCENE: usize = 50;
+
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(tag = "type")]
 enum WsSendData {
-    Binary { data: Vec<u8> },
-    Text { data: String },
-    Close,
+    Binary {
+        data: Vec<u8>,
+    },
+    Text {
+        data: String,
+    },
+    Close {
+        code: Option<u16>,
+        reason: Option<String>,
+    },
 }
 
 enum WsReceiveData {
@@ -23,7 +45,7 @@ enum WsReceiveData {
     TextData(String),
     Error(AnyError),
     Close(Option<CloseFrame<'static>>),
-    Connected,
+    Connected { protocol: Option<String> },
 }
 
 struct WsState {
@@ -35,10 +57,21 @@ struct WsState {
 #[derive(Serialize)]
 #[serde(tag = "type")]
 enum WsPoll {
-    Connected,
+    Connected { protocol: Option<String> },
     Closed { code: Option<u16>, reason: String },
     BinaryData { data: Vec<u8> },
     TextData { data: String },
+}
+
+/// Write a frame with a bounded timeout so a wedged peer cannot pin us forever.
+async fn write<S>(ws_send: &mut S, message: Message) -> Result<(), ()>
+where
+    S: futures_util::Sink<Message> + Unpin,
+{
+    match tokio::time::timeout(WRITE_TIMEOUT, ws_send.send(message)).await {
+        Ok(Ok(())) => Ok(()),
+        _ => Err(()),
+    }
 }
 
 async fn ws_poll(
@@ -74,120 +107,133 @@ async fn ws_poll(
         HeaderValue::from_static("*/*"),
     );
 
-    tracing::debug!("request to {:?}", http_request);
+    let config = WebSocketConfig {
+        max_message_size: Some(MAX_MESSAGE_SIZE),
+        max_frame_size: Some(MAX_FRAME_SIZE),
+        ..Default::default()
+    };
 
-    let connection_result = tokio_tungstenite::connect_async(http_request).await;
-
-    let (ws_stream, _) = match connection_result {
-        Ok(connection_result) => connection_result,
-        Err(err) => match err {
+    let connect = tokio_tungstenite::connect_async_with_config(http_request, Some(config), false);
+    let (ws_stream, response) = match tokio::time::timeout(CONNECT_TIMEOUT, connect).await {
+        Err(_) => return Err(anyhow::Error::msg("connection timed out")),
+        Ok(Err(err)) => match err {
             tokio_tungstenite::tungstenite::Error::Http(http_err) => {
                 let body_error = http_err
                     .body()
                     .as_ref()
                     .map(|body| String::from_utf8_lossy(body));
-                return Err(anyhow::Error::msg(format!("http error: {:?}", body_error)));
+                return Err(anyhow::Error::msg(format!("http error: {body_error:?}")));
             }
             err => {
                 tracing::error!("error connecting to {:?}: {:?}", url, err);
                 return Err(err.into());
             }
         },
+        Ok(Ok(value)) => value,
     };
     tracing::debug!("connected to {:?}", url);
-    sender.send(WsReceiveData::Connected).await?;
 
-    tracing::debug!("status sent");
+    // Report the subprotocol the server actually selected (if any).
+    let protocol = response
+        .headers()
+        .get("sec-websocket-protocol")
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s.to_string());
+    sender.send(WsReceiveData::Connected { protocol }).await?;
+
     let (mut ws_send, mut read) = ws_stream.split();
 
-    let sender_a = sender.clone();
+    // Close-handshake deadline: starts effectively-never and is armed the moment
+    // we initiate a close, so a peer that ignores our close cannot wedge us.
+    let close_deadline = tokio::time::sleep(Duration::from_secs(60 * 60 * 24 * 365));
+    tokio::pin!(close_deadline);
+    let mut closing = false;
 
-    // make local channel
-    let (int_sender, mut int_receiver) = tokio::sync::mpsc::channel(5);
-
-    tokio::join!(
-        async move {
-            loop {
-                // With select approach
-                let final_data: Option<tokio_tungstenite::tungstenite::Message>;
-                let mut critical_cond = false;
-
-                tokio::select! {
-                    to_send = receiver.recv() => {
-                        final_data = match to_send {
-                            Some(WsSendData::Binary { data }) => Some(tokio_tungstenite::tungstenite::Message::Binary(data)),
-                            Some(WsSendData::Text { data }) => Some(tokio_tungstenite::tungstenite::Message::Text(data)),
-                            Some(WsSendData::Close) => None,
-                            None => {
-                                critical_cond = true;
-                                None
-                            }
-                        };
-
-                    },
-                    to_send = int_receiver.recv() => {
-                        final_data = to_send;
+    loop {
+        tokio::select! {
+            // App -> socket. Stop accepting new app data once we are closing.
+            to_send = receiver.recv(), if !closing => {
+                match to_send {
+                    Some(WsSendData::Binary { data }) => {
+                        if write(&mut ws_send, Message::Binary(data)).await.is_err() {
+                            break;
+                        }
                     }
-                };
-
-                if let Some(data) = final_data {
-                    if ws_send.send(data).await.is_err() {
-                        break;
+                    Some(WsSendData::Text { data }) => {
+                        if write(&mut ws_send, Message::Text(data)).await.is_err() {
+                            break;
+                        }
                     }
-                } else {
-                    if critical_cond {
-                        let _ = sender_a
-                            .send(WsReceiveData::Error(anyhow::Error::msg("none from sender")))
-                            .await;
-                    }
-                    let _ = ws_send.close().await;
-                    break;
-                }
-            }
-        },
-        async move {
-            loop {
-                let data_received = read.next().await;
-                tracing::debug!("receiving {:?}", data_received);
-                let result = match data_received {
-                    Some(Ok(tokio_tungstenite::tungstenite::Message::Frame(_data))) => {
-                        tracing::error!("unsupported frame type");
-                        Some(())
-                    }
-                    Some(Ok(tokio_tungstenite::tungstenite::Message::Binary(data))) => {
-                        sender.send(WsReceiveData::BinaryData(data)).await.ok()
-                    }
-                    Some(Ok(tokio_tungstenite::tungstenite::Message::Text(data))) => {
-                        sender.send(WsReceiveData::TextData(data)).await.ok()
-                    }
-                    Some(Ok(tokio_tungstenite::tungstenite::Message::Ping(data))) => int_sender
-                        .send(tokio_tungstenite::tungstenite::Message::Pong(data))
-                        .await
-                        .ok(),
-                    Some(Ok(tokio_tungstenite::tungstenite::Message::Pong(_data))) => Some(()),
-                    Some(Ok(tokio_tungstenite::tungstenite::Message::Close(data))) => {
-                        let _ = sender.send(WsReceiveData::Close(data)).await;
-                        None
-                    }
-                    Some(Err(err)) => {
-                        let _ = sender.send(WsReceiveData::Error(err.into())).await;
-                        None
+                    Some(WsSendData::Close { code, reason }) => {
+                        let frame = code.map(|code| CloseFrame {
+                            code: code.into(),
+                            reason: reason.unwrap_or_default().into(),
+                        });
+                        let _ = write(&mut ws_send, Message::Close(frame)).await;
+                        closing = true;
+                        close_deadline
+                            .as_mut()
+                            .reset(tokio::time::Instant::now() + CLOSE_HANDSHAKE_TIMEOUT);
                     }
                     None => {
-                        let _ = sender
-                            .send(WsReceiveData::Error(anyhow::Error::msg(
-                                "data receiver closed",
-                            )))
-                            .await;
-                        None
+                        // JS side went away without close(): shut the socket down.
+                        let _ = ws_send.close().await;
+                        break;
                     }
-                };
-                if result.is_none() {
-                    break;
                 }
             }
+
+            // Socket -> app.
+            data_received = read.next() => {
+                match data_received {
+                    Some(Ok(Message::Binary(data))) => {
+                        if sender.send(WsReceiveData::BinaryData(data)).await.is_err() {
+                            break;
+                        }
+                    }
+                    Some(Ok(Message::Text(data))) => {
+                        if sender.send(WsReceiveData::TextData(data)).await.is_err() {
+                            break;
+                        }
+                    }
+                    // tokio-tungstenite auto-responds to Ping (and flushes the Pong
+                    // while reading), so no manual Pong is needed here.
+                    Some(Ok(Message::Ping(_))) | Some(Ok(Message::Pong(_))) => {}
+                    Some(Ok(Message::Close(frame))) => {
+                        let _ = sender.send(WsReceiveData::Close(frame)).await;
+                        let _ = ws_send.close().await;
+                        break;
+                    }
+                    // Raw frames are not produced by the Stream API; ignore defensively.
+                    Some(Ok(Message::Frame(_))) => {}
+                    Some(Err(err)) => {
+                        let _ = sender.send(WsReceiveData::Error(err.into())).await;
+                        break;
+                    }
+                    None => {
+                        // Stream ended. Expected if we asked to close; otherwise
+                        // it is an abnormal drop the scene should hear about.
+                        if closing {
+                            let _ = sender.send(WsReceiveData::Close(None)).await;
+                        } else {
+                            let _ = sender
+                                .send(WsReceiveData::Error(anyhow::Error::msg(
+                                    "connection closed",
+                                )))
+                                .await;
+                        }
+                        break;
+                    }
+                }
+            }
+
+            // The peer never completed the close handshake in time.
+            _ = &mut close_deadline, if closing => {
+                let _ = sender.send(WsReceiveData::Close(None)).await;
+                break;
+            }
         }
-    );
+    }
     Ok(())
 }
 
@@ -206,9 +252,11 @@ fn op_ws_create(
         });
     }
 
-    let (ws_resource_id, recv_send_data, send_ondata) = {
+    let (ws_resource_id, recv_send_data, send_ondata, over_cap) = {
         let mut state = op_state.borrow_mut();
         let ws_state = state.borrow_mut::<WsState>();
+        // Count live connections before allocating a new id.
+        let over_cap = ws_state.ws_sender.len() >= MAX_CONNECTIONS_PER_SCENE;
         ws_state.counter += 1;
 
         let id = ws_state.counter;
@@ -218,12 +266,25 @@ fn op_ws_create(
         ws_state.ws_receiver.insert(id, receiver);
         ws_state.ws_sender.insert(id, sender);
 
-        (id, recv_send_data, send_ondata)
+        (id, recv_send_data, send_ondata, over_cap)
     };
 
     tokio::spawn(async move {
-        let result = ws_poll(url, protocols, recv_send_data, send_ondata.clone()).await;
-        tracing::info!("websocket task finished with result: {:?}", result);
+        if over_cap {
+            let _ = send_ondata
+                .send(WsReceiveData::Error(anyhow::Error::msg(
+                    "too many WebSocket connections open for this scene",
+                )))
+                .await;
+        } else {
+            let result = ws_poll(url, protocols, recv_send_data, send_ondata.clone()).await;
+            tracing::info!("websocket task finished with result: {:?}", result);
+            // A connection failure returns Err without ever emitting Connected;
+            // surface it so the JS side can fire `onerror` before `onclose`.
+            if let Err(err) = result {
+                let _ = send_ondata.send(WsReceiveData::Error(err)).await;
+            }
+        }
         let _ = send_ondata.send(WsReceiveData::Close(None)).await;
     });
 
@@ -248,7 +309,7 @@ async fn op_ws_poll(op_state: Rc<RefCell<OpState>>, res_id: u32) -> Result<WsPol
     let data = match receiver.recv().await {
         Some(WsReceiveData::BinaryData(data)) => Ok(WsPoll::BinaryData { data }),
         Some(WsReceiveData::TextData(data)) => Ok(WsPoll::TextData { data }),
-        Some(WsReceiveData::Connected) => Ok(WsPoll::Connected),
+        Some(WsReceiveData::Connected { protocol }) => Ok(WsPoll::Connected { protocol }),
         Some(WsReceiveData::Error(err)) => Err(err),
         Some(WsReceiveData::Close(data)) => {
             let (code, reason) = match data {
@@ -295,6 +356,8 @@ fn op_ws_cleanup(state: &mut OpState, res_id: u32) -> Result<(), AnyError> {
         receiver.close();
     }
 
+    // Dropping the sender lets the native `ws_poll` task observe the closed
+    // channel and terminate, releasing the socket instead of leaking it.
     ws_state.ws_sender.remove(&res_id);
 
     Ok(())
@@ -303,19 +366,20 @@ fn op_ws_cleanup(state: &mut OpState, res_id: u32) -> Result<(), AnyError> {
 #[cfg(test)]
 mod tests {
     //! Integration tests for the native `ws_poll` transport task, exercised
-    //! against a local `tokio-tungstenite` server. These lock down the
-    //! transport behaviour scenes rely on — connect, text/binary round-trip,
-    //! message ordering, ping/pong, close-code propagation and connection
-    //! failure — and guard against regressions of the Colyseus WebSocket bug
-    //! (#2430), whose sibling defect was the close code/reason being dropped.
+    //! against a local `tokio-tungstenite` server (no new dependencies). These
+    //! lock down connect, text/binary round-trip, ordering, single-pong,
+    //! ping-does-not-block-reads, close-code propagation (both directions),
+    //! the close-handshake timeout, subprotocol negotiation and connection
+    //! failure — and guard against regressions of the Colyseus bug (#2430).
     //!
     //! Run with: `cargo test -p dclgodot websocket`
 
     use std::future::Future;
-    use std::time::Duration;
+    use std::time::{Duration, Instant};
 
     use futures_util::{SinkExt, StreamExt};
     use tokio::net::TcpListener;
+    use tokio_tungstenite::tungstenite::handshake::server::{Request, Response};
     use tokio_tungstenite::tungstenite::protocol::frame::coding::CloseCode;
     use tokio_tungstenite::tungstenite::protocol::CloseFrame;
     use tokio_tungstenite::tungstenite::Message;
@@ -325,8 +389,6 @@ mod tests {
 
     type ServerWs = WebSocketStream<tokio::net::TcpStream>;
 
-    /// Bind an ephemeral local server, accept ONE connection, run `handler`,
-    /// and return the `ws://` URL to dial.
     async fn serve<F, Fut>(handler: F) -> String
     where
         F: FnOnce(ServerWs) -> Fut + Send + 'static,
@@ -347,27 +409,34 @@ mod tests {
         from_native: tokio::sync::mpsc::Receiver<WsReceiveData>,
     }
 
-    /// Wire up the JS<->native channels the same way `op_ws_create` does and
-    /// spawn the real `ws_poll` task.
     fn connect(url: String) -> Client {
+        connect_with(url, vec![])
+    }
+
+    fn connect_with(url: String, protocols: Vec<String>) -> Client {
         let (to_native, rx_send) = tokio::sync::mpsc::channel(100);
         let (tx_recv, from_native) = tokio::sync::mpsc::channel(100);
-        tokio::spawn(ws_poll(url, vec![], rx_send, tx_recv));
+        tokio::spawn(ws_poll(url, protocols, rx_send, tx_recv));
         Client {
             to_native,
             from_native,
         }
     }
 
-    /// Await the next native->JS event, failing the test on timeout/close.
     async fn next(c: &mut Client) -> WsReceiveData {
-        tokio::time::timeout(Duration::from_secs(5), c.from_native.recv())
+        tokio::time::timeout(Duration::from_secs(8), c.from_native.recv())
             .await
             .expect("timed out waiting for a native event")
             .expect("native->JS channel closed unexpectedly")
     }
 
-    /// A server that echoes text/binary frames and stops on close.
+    fn close(code: Option<u16>, reason: Option<&str>) -> WsSendData {
+        WsSendData::Close {
+            code,
+            reason: reason.map(str::to_string),
+        }
+    }
+
     async fn echo_server(mut ws: ServerWs) {
         while let Some(Ok(m)) = ws.next().await {
             match m {
@@ -387,17 +456,20 @@ mod tests {
         let url = serve(echo_server).await;
         let mut c = connect(url);
         assert!(
-            matches!(next(&mut c).await, WsReceiveData::Connected),
+            matches!(next(&mut c).await, WsReceiveData::Connected { .. }),
             "the first native event must be Connected"
         );
-        c.to_native.send(WsSendData::Close).await.unwrap();
+        c.to_native.send(close(None, None)).await.unwrap();
     }
 
     #[tokio::test]
     async fn echoes_text() {
         let url = serve(echo_server).await;
         let mut c = connect(url);
-        assert!(matches!(next(&mut c).await, WsReceiveData::Connected));
+        assert!(matches!(
+            next(&mut c).await,
+            WsReceiveData::Connected { .. }
+        ));
 
         c.to_native
             .send(WsSendData::Text {
@@ -416,7 +488,10 @@ mod tests {
     async fn echoes_binary() {
         let url = serve(echo_server).await;
         let mut c = connect(url);
-        assert!(matches!(next(&mut c).await, WsReceiveData::Connected));
+        assert!(matches!(
+            next(&mut c).await,
+            WsReceiveData::Connected { .. }
+        ));
 
         let payload = vec![0u8, 1, 2, 3, 255, 254, 42];
         c.to_native
@@ -436,7 +511,10 @@ mod tests {
     async fn preserves_order_under_burst() {
         let url = serve(echo_server).await;
         let mut c = connect(url);
-        assert!(matches!(next(&mut c).await, WsReceiveData::Connected));
+        assert!(matches!(
+            next(&mut c).await,
+            WsReceiveData::Connected { .. }
+        ));
 
         for i in 0..50 {
             c.to_native
@@ -458,7 +536,10 @@ mod tests {
     async fn round_trips_large_binary() {
         let url = serve(echo_server).await;
         let mut c = connect(url);
-        assert!(matches!(next(&mut c).await, WsReceiveData::Connected));
+        assert!(matches!(
+            next(&mut c).await,
+            WsReceiveData::Connected { .. }
+        ));
 
         let payload: Vec<u8> = (0..1_000_000).map(|i| (i % 251) as u8).collect();
         c.to_native
@@ -475,16 +556,54 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn responds_to_server_ping_with_pong() {
-        let (tx, rx) = tokio::sync::oneshot::channel::<Vec<u8>>();
+    async fn responds_to_server_ping_with_a_single_pong() {
+        let (tx, rx) = tokio::sync::oneshot::channel::<usize>();
         let url = serve(|mut ws: ServerWs| async move {
             ws.send(Message::Ping(vec![9, 8, 7])).await.unwrap();
-            let mut tx = Some(tx);
-            while let Some(Ok(m)) = ws.next().await {
-                if let Message::Pong(p) = m {
-                    if let Some(tx) = tx.take() {
-                        let _ = tx.send(p);
+            let mut pongs = 0usize;
+            let deadline = tokio::time::sleep(Duration::from_millis(500));
+            tokio::pin!(deadline);
+            loop {
+                tokio::select! {
+                    _ = &mut deadline => break,
+                    m = ws.next() => match m {
+                        Some(Ok(Message::Pong(_))) => pongs += 1,
+                        Some(Ok(Message::Close(_))) | None => break,
+                        _ => {}
                     }
+                }
+            }
+            let _ = tx.send(pongs);
+        })
+        .await;
+
+        let mut c = connect(url);
+        assert!(matches!(
+            next(&mut c).await,
+            WsReceiveData::Connected { .. }
+        ));
+
+        let pongs = tokio::time::timeout(Duration::from_secs(5), rx)
+            .await
+            .expect("server never finished counting pongs")
+            .expect("pong channel dropped");
+        assert_eq!(
+            pongs, 1,
+            "exactly one pong must be sent (no manual duplicate)"
+        );
+    }
+
+    // Regression guard for the old join!/int-channel deadlock: pings must never
+    // stall the read path.
+    #[tokio::test]
+    async fn pings_do_not_block_inbound_data() {
+        let url = serve(|mut ws: ServerWs| async move {
+            for _ in 0..10 {
+                ws.send(Message::Ping(vec![0])).await.unwrap();
+            }
+            ws.send(Message::Text("after-pings".into())).await.unwrap();
+            while let Some(Ok(m)) = ws.next().await {
+                if m.is_close() {
                     break;
                 }
             }
@@ -492,22 +611,17 @@ mod tests {
         .await;
 
         let mut c = connect(url);
-        assert!(matches!(next(&mut c).await, WsReceiveData::Connected));
-
-        // The client must auto-pong; the ping must not surface to the JS side.
-        let pong = tokio::time::timeout(Duration::from_secs(5), rx)
-            .await
-            .expect("server never received a pong")
-            .expect("pong channel dropped");
-        assert_eq!(
-            pong,
-            vec![9, 8, 7],
-            "pong payload must echo the ping payload"
-        );
+        assert!(matches!(
+            next(&mut c).await,
+            WsReceiveData::Connected { .. }
+        ));
+        match next(&mut c).await {
+            WsReceiveData::TextData(s) => assert_eq!(s, "after-pings"),
+            _ => panic!("expected the Text that follows the pings"),
+        }
     }
 
-    /// Regression test for #2430's sibling defect: the server's close code and
-    /// reason must survive all the way to the native->JS boundary.
+    // Regression guard for the receive half of #2430.
     #[tokio::test]
     async fn server_close_propagates_code_and_reason() {
         let url = serve(|mut ws: ServerWs| async move {
@@ -517,7 +631,6 @@ mod tests {
             })))
             .await
             .unwrap();
-            // Drive the close handshake to completion.
             while let Some(Ok(_)) = ws.next().await {}
         })
         .await;
@@ -525,7 +638,7 @@ mod tests {
         let mut c = connect(url);
         loop {
             match next(&mut c).await {
-                WsReceiveData::Connected => continue,
+                WsReceiveData::Connected { .. } => continue,
                 WsReceiveData::Close(Some(frame)) => {
                     assert_eq!(u16::from(frame.code), 1001, "close code must be preserved");
                     assert_eq!(frame.reason, "going away", "close reason must be preserved");
@@ -537,34 +650,108 @@ mod tests {
         }
     }
 
+    // The client's close code + reason must reach the peer (send half of #2430).
     #[tokio::test]
-    async fn client_close_is_seen_by_server() {
-        let (tx, rx) = tokio::sync::oneshot::channel::<()>();
+    async fn client_close_sends_code_and_reason() {
+        let (tx, rx) = tokio::sync::oneshot::channel::<Option<(u16, String)>>();
         let url = serve(|mut ws: ServerWs| async move {
-            loop {
-                match ws.next().await {
-                    Some(Ok(Message::Close(_))) | Some(Err(_)) | None => break,
-                    Some(Ok(_)) => {}
+            let mut tx = Some(tx);
+            while let Some(msg) = ws.next().await {
+                if let Ok(Message::Close(frame)) = msg {
+                    let got = frame.map(|f| (u16::from(f.code), f.reason.into_owned()));
+                    if let Some(tx) = tx.take() {
+                        let _ = tx.send(got);
+                    }
+                    break;
                 }
             }
-            let _ = tx.send(());
         })
         .await;
 
         let mut c = connect(url);
-        assert!(matches!(next(&mut c).await, WsReceiveData::Connected));
-        c.to_native.send(WsSendData::Close).await.unwrap();
-
-        tokio::time::timeout(Duration::from_secs(5), rx)
+        assert!(matches!(
+            next(&mut c).await,
+            WsReceiveData::Connected { .. }
+        ));
+        c.to_native
+            .send(close(Some(4001), Some("kick")))
             .await
-            .expect("server never observed the client close")
-            .expect("close-signal channel dropped");
+            .unwrap();
+
+        let got = tokio::time::timeout(Duration::from_secs(5), rx)
+            .await
+            .expect("server never saw the close")
+            .expect("close channel dropped");
+        assert_eq!(got, Some((4001, "kick".to_string())));
+    }
+
+    // A peer that ignores our close must not wedge us: ws_poll terminates and
+    // the JS side receives a close within the handshake timeout.
+    #[tokio::test]
+    async fn close_handshake_times_out_when_peer_is_silent() {
+        let url = serve(|ws: ServerWs| async move {
+            // Never read our close frame (so tungstenite can't auto-echo it) and
+            // hold the TCP connection open -> forces our close-handshake timeout.
+            let _held_open = ws;
+            futures_util::future::pending::<()>().await;
+        })
+        .await;
+
+        let mut c = connect(url);
+        assert!(matches!(
+            next(&mut c).await,
+            WsReceiveData::Connected { .. }
+        ));
+        let started = Instant::now();
+        c.to_native.send(close(Some(1000), None)).await.unwrap();
+
+        loop {
+            match tokio::time::timeout(Duration::from_secs(15), c.from_native.recv()).await {
+                Ok(Some(WsReceiveData::Close(_))) | Ok(None) => break,
+                Ok(Some(_)) => continue,
+                Err(_) => panic!("ws_poll wedged: no close within timeout"),
+            }
+        }
+        let elapsed = started.elapsed();
+        assert!(
+            elapsed >= Duration::from_secs(4) && elapsed < Duration::from_secs(12),
+            "close should resolve via the ~5s handshake timeout, took {elapsed:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn reports_negotiated_subprotocol() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let mut ws = tokio_tungstenite::accept_hdr_async(
+                stream,
+                |_req: &Request, mut resp: Response| {
+                    resp.headers_mut()
+                        .insert("sec-websocket-protocol", "json".parse().unwrap());
+                    Ok(resp)
+                },
+            )
+            .await
+            .unwrap();
+            let _ = ws.next().await;
+        });
+
+        let mut c = connect_with(
+            format!("ws://{addr}/"),
+            vec!["json".into(), "msgpack".into()],
+        );
+        match next(&mut c).await {
+            WsReceiveData::Connected { protocol } => {
+                assert_eq!(protocol.as_deref(), Some("json"));
+            }
+            _ => panic!("expected Connected with the negotiated subprotocol"),
+        }
     }
 
     #[tokio::test]
     async fn connect_failure_returns_err_without_connected() {
-        // Accept the TCP connection then drop it before completing the
-        // WebSocket handshake -> deterministic handshake failure.
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
         tokio::spawn(async move {


### PR DESCRIPTION
## Summary

Fixes the Colyseus WebSocket failure reported in #2430 (Genesis Plaza fishing
game, `dclexperience2.dcl.eth`), then hardens the whole WebSocket implementation
based on a full audit and adds regression tests for both layers.

## The bug (#2430)

Our JS `WebSocket` shim (`ws.js`, exposed to scenes as `globalThis.WebSocket`)
used non-standard `readyState` constants and **never set `readyState` to `OPEN`**
on connect. `@colyseus/sdk@0.17.42` gates every send on
`isOpen = ws.readyState === WebSocket.OPEN`, so it was permanently `false` and
every gameplay message was enqueued/dropped instead of sent — the player could
cast but the cast never reached the server. The JOIN handshake still worked (its
ack is ungated), so the connection *looked* fine while gameplay went silent.

**Core fix:** WHATWG `readyState` values (`CONNECTING=0, OPEN=1, CLOSING=2,
CLOSED=3`), set `readyState=OPEN` on connect, deliver `close` exactly once with
`{code, reason, wasClean}`, and thread the real close code/reason from the
native `CloseFrame`.

## Hardening (WebSocket audit follow-ups)

Native transport (`websocket/mod.rs`):
- **Removed the manual-pong `int` channel** that could deadlock the read path
  when a peer stalled our writes — tokio-tungstenite auto-responds to pings, so
  the manual pong was redundant (and duplicated). Read and write now share one
  `select!` loop.
- **Close-handshake timeout** so a peer that ignores our close can’t wedge the
  socket in `CLOSING`; plus connect and per-write timeouts.
- **Client `close(code, reason)` reaches the peer** (send-side analog of the
  receive-side fix); **negotiated subprotocol** reported on connect.
- Inbound message/frame size bounded; **per-scene connection cap**; connection
  failures now surface as an error so `onerror` fires (then `onclose`).

JS shim (`ws.js`):
- Binary frames delivered as **`ArrayBuffer`** (matching `binaryType`).
- **`addEventListener`/`removeEventListener`/`dispatchEvent`** implemented.
- `send()` guarded on `readyState` (throws before OPEN, drops after close);
  **`bufferedAmount`** tracked; **`protocol`** getter; Event-shaped `onerror`;
  `close(code, reason)` validated and forwarded.

## Behavior changes worth a look

- **Deployed scenes can no longer open cleartext `ws://`** (only `wss://`). This
  matches the web client’s mixed-content behavior and the intent of the existing
  (previously disabled) guard. `previewMode` is read from `op_get_realm` and
  falls back to permissive if unavailable. The per-scene WebSocket *permission*
  gate stays permissive — there is no permission model in the client yet, and
  `fetch.js` has the identical TODO. Fixing that consistently is a follow-up.
- `onmessage` now dispatches a spec-shaped event (`type: "message"`, binary as
  `ArrayBuffer`). Colyseus reads `new Uint8Array(event.data)`, which is
  unaffected.

## Tests

- **Rust transport** — `websocket/mod.rs` `#[cfg(test)] mod tests` (12 tests vs a
  local `tokio-tungstenite` server, no new deps): connect, text/binary echo,
  ordering, 1 MB payloads, single-pong, pings-don’t-block-reads, close code both
  directions, close-handshake timeout, subprotocol, connect failure. Runs under
  the existing `cargo test` build jobs (`cargo test -p dclgodot websocket`).
- **JS shim** — `ws.test.cjs` (13 tests, Node built-in runner, no npm deps):
  the `Connected → readyState OPEN` #2430 guard, constants, ArrayBuffer/text
  delivery, `addEventListener`, exactly-once `onclose`, error-then-close,
  `send()` coercion + guard, `close()` validation, subprotocol. **Wired into
  `static_checks` CI** (`node --test`).

## Test plan

- [ ] Rebuild the client (`cargo run -- build`) and open the Genesis Plaza
      fishing game; confirm casting triggers server responses (fish bite).
- [ ] Confirm normal connect/send/close still works for a `wss` scene.
- [ ] Confirm a deployed scene using `ws://` now warns→throws (expected); verify
      no first-party scene relies on cleartext `ws://`.
- [ ] Smoke-test a mid-session drop: `onclose(1006)` fires and Colyseus
      reconnects.

## Out of scope (noted, not addressed)

- A real scene **permission model** for WebSocket/fetch (no infrastructure
  exists today; `fetch.js` shares the disabled-guard TODO).
- The issue’s **Network Inspector** note is a separate subsystem (HTTP fetch
  tracing), unrelated to this fix.

Closes #2430
