### PR TITLE
fix: restore rarity color indicator on wheel items

### DIFF
--- a/godot/src/ui/components/organisms/emotes/emote_item_ui.gd
+++ b/godot/src/ui/components/organisms/emotes/emote_item_ui.gd
@@ -36,15 +36,17 @@ var _is_equipped: bool = false
 var _is_dirty := false
 
 @onready var control_inner := %Control_Inner
-@onready var texture_rect_background := %TextureRect_Background
+@onready var texture_rect_background: TextureRect = get_node_or_null("%TextureRect_Background")
 @onready var texture_rect_selected := %Pressed
-@onready var texture_rect_selected_bold := %Pressed_bold
+@onready var texture_rect_selected_bold: TextureRect = get_node_or_null("%Pressed_bold")
 @onready var texture_rect_equiped := %Equiped
-@onready var texture_rect_equiped_mark := %TextureRect_Equiped
-@onready var texture_rect_skeleton: TextureRect = %TextureRect_Skeleton
+@onready var texture_rect_equiped_mark: Control = get_node_or_null("%TextureRect_Equiped")
+@onready var texture_rect_skeleton: TextureRect = get_node_or_null("%TextureRect_Skeleton")
 @onready var texture_rect_picture: TextureRect = %TextureRect_Picture
 @onready var button_equiped: Button = get_node_or_null("%Button_Equiped")
-@onready var panel_new_badge: PanelContainer = %PanelContainer_NewBadge
+@onready var panel_new_badge: PanelContainer = get_node_or_null("%PanelContainer_NewBadge")
+@onready var inner_rect: TextureRect = get_node_or_null("%Inner")
+@onready var glow_rect: TextureRect = get_node_or_null("%Glow")
 
 
 func async_load_from_urn(_emote_urn: String, _index: int = -1):
@@ -94,14 +96,16 @@ func _process(_delta: float) -> void:
 		return
 	set_rarity_background()
 	texture_rect_picture.texture = picture
-	texture_rect_skeleton.hide()
-	texture_rect_background.show()
+	if is_instance_valid(texture_rect_skeleton):
+		texture_rect_skeleton.hide()
+		texture_rect_background.show()
 	_is_dirty = false
 
 
 func _ready():
-	texture_rect_background.hide()
-	texture_rect_skeleton.show()
+	if is_instance_valid(texture_rect_background):
+		texture_rect_background.hide()
+		texture_rect_skeleton.show()
 	_update_equip_ui()
 	if not Engine.is_editor_hint():
 		set_meta("attenuated_sound", true)
@@ -118,28 +122,54 @@ func _ready():
 
 
 func set_rarity_background() -> void:
+	if is_instance_valid(texture_rect_background):
+		match rarity:
+			Wearables.ItemRarity.COMMON:
+				texture_rect_background.texture = common_thumbnail
+			Wearables.ItemRarity.UNCOMMON:
+				texture_rect_background.texture = uncommon_thumbnail
+			Wearables.ItemRarity.RARE:
+				texture_rect_background.texture = rare_thumbnail
+			Wearables.ItemRarity.EPIC:
+				texture_rect_background.texture = epic_thumbnail
+			Wearables.ItemRarity.LEGENDARY:
+				texture_rect_background.texture = legendary_thumbnail
+			Wearables.ItemRarity.EXOTIC:
+				texture_rect_background.texture = exotic_thumbnail
+			Wearables.ItemRarity.MYTHIC:
+				texture_rect_background.texture = mythic_thumbnail
+			Wearables.ItemRarity.UNIQUE:
+				texture_rect_background.texture = unique_thumbnail
+			_:
+				texture_rect_background.texture = base_thumbnail
+		if emote_urn == "":
+			texture_rect_background.texture = empty_thumbnail
+
+	if is_instance_valid(inner_rect):
+		inner_rect.self_modulate = _get_rarity_color()
+		glow_rect.visible = rarity != Wearables.ItemRarity.COMMON
+
+
+func _get_rarity_color() -> Color:
 	match rarity:
 		Wearables.ItemRarity.COMMON:
-			texture_rect_background.texture = common_thumbnail
+			return Wearables.RarityColor.COMMON
 		Wearables.ItemRarity.UNCOMMON:
-			texture_rect_background.texture = uncommon_thumbnail
+			return Wearables.RarityColor.UNCOMMON
 		Wearables.ItemRarity.RARE:
-			texture_rect_background.texture = rare_thumbnail
+			return Wearables.RarityColor.RARE
 		Wearables.ItemRarity.EPIC:
-			texture_rect_background.texture = epic_thumbnail
+			return Wearables.RarityColor.EPIC
 		Wearables.ItemRarity.LEGENDARY:
-			texture_rect_background.texture = legendary_thumbnail
-		Wearables.ItemRarity.EXOTIC:
-			texture_rect_background.texture = exotic_thumbnail
+			return Wearables.RarityColor.LEGENDARY
 		Wearables.ItemRarity.MYTHIC:
-			texture_rect_background.texture = mythic_thumbnail
+			return Wearables.RarityColor.MYTHIC
 		Wearables.ItemRarity.UNIQUE:
-			texture_rect_background.texture = unique_thumbnail
+			return Wearables.RarityColor.UNIQUE
+		Wearables.ItemRarity.EXOTIC:
+			return Wearables.RarityColor.EXOTIC
 		_:
-			texture_rect_background.texture = base_thumbnail
-
-	if emote_urn == "":
-		texture_rect_background.texture = empty_thumbnail
+			return Wearables.RarityColor.BASE
 
 
 # Executed with @tool
@@ -185,21 +215,21 @@ func set_equipped(equipped: bool) -> void:
 
 ## Shows the "NEW" tag (top-right corner) for a recently-acquired emote (#2300).
 func set_new_badge(is_new: bool) -> void:
-	panel_new_badge.visible = is_new
+	if is_instance_valid(panel_new_badge):
+		panel_new_badge.visible = is_new
 
 
 func set_slot_selected(toggled_on: bool) -> void:
-	texture_rect_selected_bold.set_visible(toggled_on)
+	if is_instance_valid(texture_rect_selected_bold):
+		texture_rect_selected_bold.set_visible(toggled_on)
 	texture_rect_selected.hide()
 
 
 func _update_equip_ui() -> void:
-	if button_equiped == null:
-		texture_rect_equiped.set_visible(_is_equipped)
-		texture_rect_equiped_mark.set_visible(_is_equipped)
+	texture_rect_equiped.set_visible(_is_equipped)
+	if not is_instance_valid(button_equiped):
 		return
 	if not button_pressed:
-		texture_rect_equiped.set_visible(_is_equipped)
 		texture_rect_equiped_mark.set_visible(_is_equipped)
 		button_equiped.hide()
 	else:

--- a/godot/src/ui/components/organisms/emotes/emote_wheel.gd
+++ b/godot/src/ui/components/organisms/emotes/emote_wheel.gd
@@ -114,6 +114,8 @@ func close() -> void:
 func open() -> void:
 	if control_wheel.visible:
 		return
+	if avatar_node != null:
+		_update_wheel(avatar_node.avatar_data.get_emotes())
 	control_wheel.show()
 	emote_wheel_opened.emit()
 	grab_focus()

--- a/godot/src/ui/components/organisms/emotes/emote_wheel.gd
+++ b/godot/src/ui/components/organisms/emotes/emote_wheel.gd
@@ -114,8 +114,6 @@ func close() -> void:
 func open() -> void:
 	if control_wheel.visible:
 		return
-	if avatar_node != null:
-		_update_wheel(avatar_node.avatar_data.get_emotes())
 	control_wheel.show()
 	emote_wheel_opened.emit()
 	grab_focus()

--- a/godot/src/ui/components/organisms/emotes/emote_wheel_item.tscn
+++ b/godot/src/ui/components/organisms/emotes/emote_wheel_item.tscn
@@ -2,7 +2,6 @@
 
 [ext_resource type="Texture2D" uid="uid://c3tpoj72yuxp4" path="res://src/ui/components/organisms/emotes/emote_item.svg" id="1_qctv4"]
 [ext_resource type="Script" uid="uid://cuall0fytf468" path="res://src/ui/components/organisms/emotes/emote_item_ui.gd" id="2_jdnf4"]
-[ext_resource type="Texture2D" uid="uid://drpjhk4w1jscd" path="res://assets/ui/CommonThumbnail.png" id="3_ap2cx"]
 
 [sub_resource type="Gradient" id="Gradient_mvm8j"]
 colors = PackedColorArray(1, 1, 1, 0.607843, 1, 1, 1, 0)
@@ -113,67 +112,6 @@ offset_bottom = 40.0
 grow_horizontal = 2
 grow_vertical = 2
 pivot_offset = Vector2(40, 40)
-expand_mode = 1
-
-[node name="ControlsWithoutFunction" type="Control" parent="." unique_id=1533658465]
-editor_description = "This nodes are only to satisfy the script. And don't have any function here."
-visible = false
-anchors_preset = 0
-offset_right = 40.0
-offset_bottom = 40.0
-
-[node name="TextureRect_Background" type="TextureRect" parent="ControlsWithoutFunction" unique_id=990508003]
-unique_name_in_owner = true
-visible = false
-texture_filter = 2
-layout_mode = 1
-anchors_preset = 15
-anchor_right = 1.0
-anchor_bottom = 1.0
-grow_horizontal = 2
-grow_vertical = 2
-pivot_offset = Vector2(32, 32)
-texture = ExtResource("3_ap2cx")
-expand_mode = 1
-
-[node name="TextureRect_Equiped" type="TextureRect" parent="ControlsWithoutFunction" unique_id=288758585]
-unique_name_in_owner = true
-visible = false
-texture_filter = 2
-layout_mode = 1
-anchors_preset = 15
-anchor_right = 1.0
-anchor_bottom = 1.0
-grow_horizontal = 2
-grow_vertical = 2
-pivot_offset = Vector2(32, 32)
-texture = ExtResource("3_ap2cx")
-expand_mode = 1
-
-[node name="TextureRect_Skeleton" type="TextureRect" parent="ControlsWithoutFunction" unique_id=1021987130]
-unique_name_in_owner = true
-texture_filter = 2
-layout_mode = 1
-anchors_preset = 15
-anchor_right = 1.0
-anchor_bottom = 1.0
-grow_horizontal = 2
-grow_vertical = 2
-pivot_offset = Vector2(32, 32)
-texture = ExtResource("3_ap2cx")
-expand_mode = 1
-
-[node name="Pressed_bold" type="TextureRect" parent="ControlsWithoutFunction" unique_id=1833801176]
-unique_name_in_owner = true
-texture_filter = 2
-layout_mode = 1
-anchors_preset = 15
-anchor_right = 1.0
-anchor_bottom = 1.0
-grow_horizontal = 2
-grow_vertical = 2
-pivot_offset = Vector2(32, 32)
-texture = ExtResource("3_ap2cx")
 expand_mode = 1
 
 [connection signal="item_rect_changed" from="." to="." method="_on_item_rect_changed"]


### PR DESCRIPTION
Fixes #1743

## Root cause

The rarity color was lost in `f7b30a99` (new backpack v1). That PR introduced the square-item design for the backpack and refactored `emote_item_ui.gd` to use `TextureRect_Background` (PNG thumbnails) for rarity. In `emote_wheel_item.tscn`, those nodes were placed inside a hidden `ControlsWithoutFunction` container — intentionally inert — so the rarity update was silently a no-op.

Before that PR, the wheel showed rarity by setting `%Inner.self_modulate` to the rarity color. This PR restores that behavior.

## Changes

- `emote_item_ui.gd`: `set_rarity_background()` now has two blocks:
  - **Square item** (guarded by `is_instance_valid(texture_rect_background)`): existing PNG thumbnail logic, unchanged.
  - **Wheel item** (guarded by `is_instance_valid(inner_rect)`): sets `%Inner.self_modulate` to `Wearables.RarityColor.*` and shows/hides `%Glow` for non-common rarities.
- All nodes that lived inside `ControlsWithoutFunction` in the wheel scene are now declared with `get_node_or_null` and guarded with `is_instance_valid` — one guard per logical block, not per line.
- `emote_wheel_item.tscn`: removed the `ControlsWithoutFunction` node and all its children — they were placeholder dummies added to satisfy mandatory script references that are now properly optional.
- This also fixes a pre-existing silent error: `%PanelContainer_NewBadge` was referenced as mandatory but doesn't exist in `emote_wheel_item.tscn`.

## Test plan

- [x] Open the emote wheel and verify each slot displays the correct rarity color on its background (`%Inner` modulate) matching the emote's rarity
- [x] Verify non-common emotes show the glow effect and common emotes do not
- [x] Open the backpack emotes section and verify rarity backgrounds (PNG thumbnails) still display correctly for all rarities
- [ ] Equip/unequip emotes from the backpack and verify the equipped indicator still works correctly in both the wheel and the backpack
- [ ] Verify the "NEW" badge still appears correctly on newly acquired emotes in the backpack