### PR TITLE
fix: infinite loading hangs (delete accounting, HTTP timeouts, download notify leak, malformed /about)

### DIFF
--- a/godot/src/logic/realm.gd
+++ b/godot/src/logic/realm.gd
@@ -178,6 +178,18 @@ func async_set_realm(new_realm_string: String, search_new_pos: bool = false) -> 
 		_emit_realm_change_failed(new_realm_string, reason)
 		return false
 
+	# Guard malformed /about `content` BEFORE committing realm state. A null/missing
+	# `content` or a non-String `content.publicUrl` would otherwise throw at
+	# `content_base_url` below — after realm state was already partially committed and with
+	# NO `realm_change_failed` emitted — leaving a silently stuck loading screen (F-11 / RC-6).
+	# (`or` short-circuits, so `.get()` is never called on a non-Dictionary `content`.)
+	var about_content = json.get("content")
+	if not about_content is Dictionary or not about_content.get("publicUrl") is String:
+		var reason := "/about missing or malformed content.publicUrl"
+		printerr("[REALM] ", reason, " for ", new_realm_string)
+		_emit_realm_change_failed(new_realm_string, reason)
+		return false
+
 	# /about was validated — now it's safe to commit the new realm state.
 	realm_string = new_realm_string
 	realm_url = candidate_realm_url

--- a/lib/src/content/resource_provider.rs
+++ b/lib/src/content/resource_provider.rs
@@ -455,6 +455,17 @@ impl ResourceProvider {
         Ok(())
     }
 
+    /// Release the `pending_downloads` slot for `file_hash`: remove the entry and wake any
+    /// waiters. Must run on EVERY exit path of a fetch (success or failure), otherwise a
+    /// failed download leaks the `Notify` — duplicate waiters hang forever and the hash is
+    /// poisoned permanently so retries can never succeed (RC-2 / F-2).
+    async fn finish_pending_download(&self, file_hash: &str) {
+        let mut pending_downloads = self.pending_downloads.write().await;
+        if let Some(notify) = pending_downloads.remove(file_hash) {
+            notify.notify_waiters();
+        }
+    }
+
     pub async fn file_exists(&self, file_hash: &str) -> bool {
         let existing_files = self.existing_files.read().await;
         let absolute_file_path = self.cache_folder.join(file_hash);
@@ -545,37 +556,40 @@ impl ResourceProvider {
 
         let permit = self.semaphore.acquire().await;
 
-        if tokio::fs::metadata(&absolute_file_path).await.is_err() {
-            self.download_file(
-                &url,
-                Path::new(&absolute_file_path),
-                #[cfg(feature = "use_resource_tracking")]
-                file_hash.clone(),
-            )
-            .await?;
+        // Run the fallible download/cache work, then ALWAYS release the pending-download
+        // slot below — success or failure — so a failed download can't poison the hash (F-2).
+        let result: Result<(), String> = async {
+            if tokio::fs::metadata(&absolute_file_path).await.is_err() {
+                self.download_file(
+                    &url,
+                    Path::new(&absolute_file_path),
+                    #[cfg(feature = "use_resource_tracking")]
+                    file_hash.clone(),
+                )
+                .await?;
 
-            let metadata = tokio::fs::metadata(&absolute_file_path)
-                .await
-                .map_err(|e| format!("Failed to get metadata: {:?}", e))?;
-            let file_size = metadata.len() as i64;
+                let metadata = tokio::fs::metadata(&absolute_file_path)
+                    .await
+                    .map_err(|e| format!("Failed to get metadata: {:?}", e))?;
+                let file_size = metadata.len() as i64;
 
-            let mut existing_files = self.existing_files.write().await;
-            self.ensure_space_for(&mut existing_files, file_size).await;
-            self.add_file(&mut existing_files, absolute_file_path.clone(), file_size)
-                .await;
-        } else {
-            tracing::debug!("Cache hit for {}: {}", file_hash, absolute_file_path);
-            self.handle_existing_file(&absolute_file_path).await?;
+                let mut existing_files = self.existing_files.write().await;
+                self.ensure_space_for(&mut existing_files, file_size).await;
+                self.add_file(&mut existing_files, absolute_file_path.clone(), file_size)
+                    .await;
+            } else {
+                tracing::debug!("Cache hit for {}: {}", file_hash, absolute_file_path);
+                self.handle_existing_file(&absolute_file_path).await?;
+            }
+            Ok(())
         }
+        .await;
 
-        let mut pending_downloads = self.pending_downloads.write().await;
-        if let Some(notify) = pending_downloads.remove(&file_hash) {
-            notify.notify_waiters();
-        }
+        self.finish_pending_download(&file_hash).await;
 
         drop(permit);
 
-        Ok(())
+        result
     }
 
     /// Fetch a resource with low priority. Low-priority downloads must acquire both
@@ -595,37 +609,39 @@ impl ResourceProvider {
         let _low_priority_permit = self.low_priority_semaphore.acquire().await;
         let permit = self.semaphore.acquire().await;
 
-        if tokio::fs::metadata(&absolute_file_path).await.is_err() {
-            self.download_file(
-                &url,
-                Path::new(&absolute_file_path),
-                #[cfg(feature = "use_resource_tracking")]
-                file_hash.clone(),
-            )
-            .await?;
+        // Always release the pending-download slot below, success or failure (F-2).
+        let result: Result<(), String> = async {
+            if tokio::fs::metadata(&absolute_file_path).await.is_err() {
+                self.download_file(
+                    &url,
+                    Path::new(&absolute_file_path),
+                    #[cfg(feature = "use_resource_tracking")]
+                    file_hash.clone(),
+                )
+                .await?;
 
-            let metadata = tokio::fs::metadata(&absolute_file_path)
-                .await
-                .map_err(|e| format!("Failed to get metadata: {:?}", e))?;
-            let file_size = metadata.len() as i64;
+                let metadata = tokio::fs::metadata(&absolute_file_path)
+                    .await
+                    .map_err(|e| format!("Failed to get metadata: {:?}", e))?;
+                let file_size = metadata.len() as i64;
 
-            let mut existing_files = self.existing_files.write().await;
-            self.ensure_space_for(&mut existing_files, file_size).await;
-            self.add_file(&mut existing_files, absolute_file_path.clone(), file_size)
-                .await;
-        } else {
-            tracing::debug!("Cache hit for {}: {}", file_hash, absolute_file_path);
-            self.handle_existing_file(&absolute_file_path).await?;
+                let mut existing_files = self.existing_files.write().await;
+                self.ensure_space_for(&mut existing_files, file_size).await;
+                self.add_file(&mut existing_files, absolute_file_path.clone(), file_size)
+                    .await;
+            } else {
+                tracing::debug!("Cache hit for {}: {}", file_hash, absolute_file_path);
+                self.handle_existing_file(&absolute_file_path).await?;
+            }
+            Ok(())
         }
+        .await;
 
-        let mut pending_downloads = self.pending_downloads.write().await;
-        if let Some(notify) = pending_downloads.remove(&file_hash) {
-            notify.notify_waiters();
-        }
+        self.finish_pending_download(&file_hash).await;
 
         drop(permit);
 
-        Ok(())
+        result
     }
 
     // Method to fetch resource and wait for the data
@@ -641,36 +657,37 @@ impl ResourceProvider {
             .await?;
 
         let permit = self.semaphore.acquire().await;
-        let data = if tokio::fs::metadata(&absolute_file_path).await.is_err() {
-            let data = self
-                .download_file_with_buffer(
-                    url,
-                    Path::new(absolute_file_path),
-                    #[cfg(feature = "use_resource_tracking")]
-                    file_hash.clone(),
-                )
-                .await?;
-            let metadata = tokio::fs::metadata(absolute_file_path)
-                .await
-                .map_err(|e| format!("Failed to get metadata: {:?}", e))?;
-            let file_size = metadata.len() as i64;
-            let mut existing_files = self.existing_files.write().await;
-            self.ensure_space_for(&mut existing_files, file_size).await;
-            self.add_file(&mut existing_files, absolute_file_path.clone(), file_size)
-                .await;
-            data
-        } else {
-            self.handle_existing_file(absolute_file_path).await?
-        };
-
-        let mut pending_downloads = self.pending_downloads.write().await;
-        if let Some(notify) = pending_downloads.remove(file_hash) {
-            notify.notify_waiters();
+        // Always release the pending-download slot below, success or failure (F-2).
+        let result: Result<Vec<u8>, String> = async {
+            if tokio::fs::metadata(&absolute_file_path).await.is_err() {
+                let data = self
+                    .download_file_with_buffer(
+                        url,
+                        Path::new(absolute_file_path),
+                        #[cfg(feature = "use_resource_tracking")]
+                        file_hash.clone(),
+                    )
+                    .await?;
+                let metadata = tokio::fs::metadata(absolute_file_path)
+                    .await
+                    .map_err(|e| format!("Failed to get metadata: {:?}", e))?;
+                let file_size = metadata.len() as i64;
+                let mut existing_files = self.existing_files.write().await;
+                self.ensure_space_for(&mut existing_files, file_size).await;
+                self.add_file(&mut existing_files, absolute_file_path.clone(), file_size)
+                    .await;
+                Ok(data)
+            } else {
+                self.handle_existing_file(absolute_file_path).await
+            }
         }
+        .await;
+
+        self.finish_pending_download(file_hash).await;
 
         drop(permit);
 
-        Ok(data)
+        result
     }
 
     // Method to clear the cache and delete all files from the file system
@@ -815,6 +832,89 @@ mod tests {
         });
 
         format!("http://{}/image.png", addr)
+    }
+
+    /// Spawn a localhost server that answers every GET with `500 Internal Server Error`, so
+    /// `download_file` fails deterministically (used by the F-2 pending-slot-leak test).
+    async fn spawn_failing_server() -> String {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind ephemeral failing server");
+        let addr = listener.local_addr().expect("read local addr");
+
+        tokio::spawn(async move {
+            while let Ok((mut socket, _)) = listener.accept().await {
+                tokio::spawn(async move {
+                    let mut buf = [0u8; 1024];
+                    let _ = socket.read(&mut buf).await;
+                    let head = "HTTP/1.1 500 Internal Server Error\r\nContent-Length: 0\r\nConnection: close\r\n\r\n";
+                    let _ = socket.write_all(head.as_bytes()).await;
+                    let _ = socket.flush().await;
+                });
+            }
+        });
+
+        format!("http://{}/fail.bin", addr)
+    }
+
+    /// F-2 regression: a failed download must release its `pending_downloads` slot, otherwise
+    /// the hash is poisoned forever — duplicate waiters hang and even retries can never
+    /// succeed (RC-2). Before the fix, the retry below would block indefinitely.
+    #[tokio::test]
+    async fn test_failed_download_releases_pending_slot() {
+        let fail_url = spawn_failing_server().await;
+
+        let dir = std::env::temp_dir().join(format!("dcl-rp-f2-test-{}", std::process::id()));
+        let path = dir.to_str().expect("temp dir path is valid utf-8");
+        setup_cache_folder(path)
+            .await
+            .expect("Failed to create cache folder");
+
+        #[cfg(feature = "use_resource_tracking")]
+        let resource_download_tracking = Arc::new(ResourceDownloadTracking::new());
+        let provider = Arc::new(ResourceProvider::new(
+            path,
+            1024 * 1024,
+            2,
+            #[cfg(feature = "use_resource_tracking")]
+            resource_download_tracking.clone(),
+        ));
+        provider.clear().await;
+
+        let file_hash = "bafkreibmrvrdgqthfrvehyell552sk7ivuas2ozzjdmlojbzttqlcrxiya".to_string();
+        let absolute_file_path = format!("{}/{}", path, file_hash);
+
+        // First attempt fails (server 500).
+        let first = provider
+            .fetch_resource(
+                fail_url.clone(),
+                file_hash.clone(),
+                absolute_file_path.clone(),
+            )
+            .await;
+        assert!(first.is_err(), "expected the 500 download to fail");
+
+        // The pending-download slot must have been released, not leaked.
+        {
+            let pending = provider.pending_downloads.read().await;
+            assert!(
+                !pending.contains_key(&file_hash),
+                "failed download leaked its pending_downloads entry (hash poisoned)"
+            );
+        }
+
+        // A retry against a working server must now succeed (proves the hash isn't poisoned
+        // and no waiter is stranded). This would hang forever before the fix.
+        let good_url = spawn_fake_image_server().await;
+        provider
+            .fetch_resource(good_url, file_hash.clone(), absolute_file_path.clone())
+            .await
+            .expect("retry after a failed download should succeed, not hang");
+
+        provider.clear().await;
+        let _ = tokio::fs::remove_dir_all(path).await;
     }
 
     #[tokio::test]

--- a/lib/src/content/resource_provider.rs
+++ b/lib/src/content/resource_provider.rs
@@ -4,10 +4,11 @@ use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicI64, AtomicU64, Ordering};
 use std::sync::Arc;
+use std::time::Duration;
 use tokio::fs;
 use tokio::io::{self, AsyncReadExt, AsyncWriteExt};
 use tokio::sync::{Notify, OnceCell, RwLock};
-use tokio::time::Instant;
+use tokio::time::{timeout, Instant};
 
 #[cfg(feature = "use_resource_tracking")]
 use super::resource_download_tracking::ResourceDownloadTracking;
@@ -33,6 +34,16 @@ pub struct ResourceProvider {
 }
 
 const UPDATE_THRESHOLD: u64 = 1_024 * 1_024; // 1 MB threshold
+
+// Asset-download timeouts (F-1 / RC-1). These bound *dead* connections without killing
+// *slow-but-alive* downloads: on a constrained link a single legitimate asset was observed
+// taking ~198s of wire time, so we deliberately set NO total-request timeout. Instead we
+// bound (a) connection establishment, (b) time-to-first-response (headers), and (c) the
+// idle gap between body chunks. A stalled/half-open connection now surfaces as `Err`
+// (→ the GLTF container reaches FinishedWithError) instead of hanging forever.
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(20);
+const RESPONSE_TIMEOUT: Duration = Duration::from_secs(30);
+const IDLE_CHUNK_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// Base identity of a cache-folder file name — the key that ties every on-disk
 /// form of an asset back to its content hash (or url-hash). CID hashes contain
@@ -87,7 +98,10 @@ impl ResourceProvider {
             existing_files: RwLock::new(HashMap::new()),
             max_cache_size: AtomicI64::new(max_cache_size),
             pending_downloads: RwLock::new(HashMap::new()),
-            client: Client::new(),
+            client: Client::builder()
+                .connect_timeout(CONNECT_TIMEOUT)
+                .build()
+                .expect("Failed to build ResourceProvider HTTP client"),
             initialized: OnceCell::new(),
             semaphore: Arc::new(CappedSemaphore::new(max_concurrent_downloads)),
             low_priority_semaphore: Arc::new(CappedSemaphore::new(max_concurrent_downloads)),
@@ -240,11 +254,9 @@ impl ResourceProvider {
     ) -> Result<(), String> {
         tracing::debug!("[HTTP] GET {}", url);
         let tmp_dest = dest.with_extension("tmp");
-        let response = self
-            .client
-            .get(url)
-            .send()
+        let response = timeout(RESPONSE_TIMEOUT, self.client.get(url).send())
             .await
+            .map_err(|_| format!("Response timeout ({RESPONSE_TIMEOUT:?}): {url}"))?
             .map_err(|e| format!("Request error: {:?}", e))?;
 
         #[cfg(feature = "use_resource_tracking")]
@@ -264,7 +276,10 @@ impl ResourceProvider {
 
         let mut accumulated_size = 0;
 
-        while let Some(chunk) = stream.next().await {
+        while let Some(chunk) = timeout(IDLE_CHUNK_TIMEOUT, stream.next())
+            .await
+            .map_err(|_| format!("Idle timeout ({IDLE_CHUNK_TIMEOUT:?}) while downloading {url}"))?
+        {
             let chunk = chunk.map_err(|e| format!("Stream error: {:?}", e))?;
             file.write_all(&chunk)
                 .await
@@ -318,11 +333,9 @@ impl ResourceProvider {
     ) -> Result<Vec<u8>, String> {
         tracing::debug!("[HTTP] GET {}", url);
         let tmp_dest = dest.with_extension("tmp");
-        let response = self
-            .client
-            .get(url)
-            .send()
+        let response = timeout(RESPONSE_TIMEOUT, self.client.get(url).send())
             .await
+            .map_err(|_| format!("Response timeout ({RESPONSE_TIMEOUT:?}): {url}"))?
             .map_err(|e| format!("Request error: {:?}", e))?;
 
         if !response.status().is_success() {
@@ -342,7 +355,10 @@ impl ResourceProvider {
 
         let mut accumulated_size = 0;
 
-        while let Some(chunk) = stream.next().await {
+        while let Some(chunk) = timeout(IDLE_CHUNK_TIMEOUT, stream.next())
+            .await
+            .map_err(|_| format!("Idle timeout ({IDLE_CHUNK_TIMEOUT:?}) while downloading {url}"))?
+        {
             let chunk = chunk.map_err(|e| format!("Stream error: {:?}", e))?;
             file.write_all(&chunk)
                 .await

--- a/lib/src/scene_runner/deleted_entities.rs
+++ b/lib/src/scene_runner/deleted_entities.rs
@@ -45,7 +45,13 @@ pub fn update_deleted_entities(scene: &mut Scene, pools: &mut PoolManager) {
         scene.audio_streams.remove(deleted_entity);
         scene.video_players.remove(deleted_entity);
         scene.dup_animator.remove(deleted_entity);
-        scene.gltf_loading.remove(deleted_entity);
+        // If a GLTF was still loading when its entity was deleted, count it as finished so
+        // the loading session's asset accounting stays balanced. Mirrors the
+        // component-removal and normal-completion paths in `gltf_container.rs`; without
+        // this the Assets phase never reaches 100% and the loading screen hangs (RC-10).
+        if scene.gltf_loading.remove(deleted_entity) {
+            scene.gltf_loading_finished_count += 1;
+        }
         scene.continuos_raycast.remove(deleted_entity);
         scene.tweens.remove(deleted_entity);
         scene.texture_animations.remove(deleted_entity);


### PR DESCRIPTION
Fixes a group of infinite loading and "stuck at 25 to 30%" root causes found during the #1602 and #1640 scene loading investigation. Each fix is small, isolated and independently verified. The user facing symptom is tracked in #2450.

## What this fixes

**Deleted while loading GLTFs never counted as finished (RC-10, confirmed)**
Deleting an entity while its GLTF was still loading removed it from `gltf_loading` but never bumped `gltf_loading_finished_count` (`deleted_entities.rs:48`). The component removal and normal completion paths both bump it (`gltf_container.rs:68`), so this path left `started > finished` forever. The Assets phase then never reached 100% and the loading screen hung with nothing actually stuck. One line, mirrors the existing pattern.

**No HTTP timeout on the asset download path (RC-1)**
`ResourceProvider` used `Client::new()` with no timeout, so a stalled or half open connection hung the download future forever and left the entity stuck in `gltf_loading`. This adds bounds that kill dead connections without killing slow but alive ones. A legitimate asset was measured taking 198s of wire time on a 1 Mbps link, so there is deliberately no total request timeout. Instead it sets a connect timeout, a response (headers) timeout and a per chunk idle timeout. A stall now surfaces as an error and the container reaches `FinishedWithError`.

**pending_downloads notify leak (RC-2)**
On download failure the `Arc<Notify>` was never removed or fired, because cleanup only ran on the success path. Duplicate waiters hung forever and the content hash stayed poisoned, so even retries could never succeed. Cleanup now runs on every exit path via `finish_pending_download`, across all three fetch variants. Includes a regression test where a failed download must release its slot and a following retry must succeed. Before the fix that retry hangs forever.

**Malformed /about content left the screen stuck silently (RC-6)**
A realm whose `/about` returns `content: null` or a missing `publicUrl` threw at `content_base_url` after realm state was already partially committed and without emitting `realm_change_failed`. The loading screen just sat there. It is now validated before the state commit, so the failure is surfaced and recoverable.

## Verification
- `cargo clippy --features use_livekit,use_deno -- -D warnings` clean
- `cargo test --features use_livekit,use_deno resource_provider` 4 of 4, including the new leak regression test
- `gdformat --check` and `gdlint` clean on `realm.gd`

Closes #2475. Closes #2462. Closes #2463. Closes #2472.
Refs #1640, #1602, #2450.
