### PR TITLE
hotfix: port release-1.11.0 fixes to main

### DIFF
--- a/.github/workflows/ios_self_hosted.yml
+++ b/.github/workflows/ios_self_hosted.yml
@@ -163,6 +163,25 @@ jobs:
           # the source tree stays correct — only the build cache survives.
           clean: false
 
+      # The persistent build cache above grows with every branch built and the VM has a single
+      # disk shared by all iOS builds — without a guard it eventually fills and cargo dies
+      # mid-link with "No space left on device". Prune the Rust caches (NOT .bin/, whose
+      # re-download is the expensive part) only when free space drops below the threshold;
+      # the next build is cold (~30 min) but self-heals instead of failing.
+      - name: Disk guard — auto-prune build caches when low on space
+        env:
+          MIN_FREE_GB: "40"
+        run: |
+          free_gb=$(df -g . | awk 'NR==2 {print $4}')
+          echo "Runner free disk: ${free_gb} GB (threshold: ${MIN_FREE_GB} GB)"
+          if [ "$free_gb" -lt "$MIN_FREE_GB" ]; then
+            echo "::warning::Low disk on iOS runner (${free_gb} GB free < ${MIN_FREE_GB} GB) — pruning Rust build caches; this build runs cold"
+            du -sh lib/target target 2>/dev/null || true
+            rm -rf lib/target target
+            rm -rf "${TMPDIR:-/tmp}/"rustc* 2>/dev/null || true
+            df -g . | awk 'NR==2 {print "After prune: " $4 " GB free"}'
+          fi
+
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # @stable
         with:
           toolchain: "1.90"

--- a/godot/src/ui/components/molecules/guest_upgrade_card/guest_upgrade_card.gd
+++ b/godot/src/ui/components/molecules/guest_upgrade_card/guest_upgrade_card.gd
@@ -19,9 +19,14 @@ signal email_added(email: String)
 		side_margin = value
 		_apply_full_width()
 
-## True once the network check has been attempted (prevents re-checking every time
-## the parent becomes visible after a successful initial check).
+## True once the network check has completed with an authoritative result
+## (prevents re-checking every time the parent becomes visible afterwards).
 var _upgrade_checked: bool = false
+## True while the network check is in flight. Concurrent calls — e.g. the repeated
+## orientation_changed emissions Discover fires during a menu transition — must not
+## take the cached fast path against the not-yet-populated flag, which defaults to
+## "not upgraded" and would flash the card for an already-upgraded user (#2483).
+var _upgrade_check_in_flight: bool = false
 
 @onready var button_add_email: Button = %Button_AddEmail
 
@@ -78,10 +83,18 @@ func _async_update_visibility() -> void:
 		visible = not Global.player_identity.is_thirdweb_guest_upgraded()
 		return
 
-	_upgrade_checked = true
+	if _upgrade_check_in_flight:
+		# A check is already running; stay hidden (the default) until it resolves.
+		# Reading the cached flag now would return the default "not upgraded" and
+		# wrongly flash the card for an already-upgraded user (#2483).
+		return
+
+	_upgrade_check_in_flight = true
 	var anchor: String = Global.get_device_anchor_id()
 	var promise: Promise = Global.player_identity.async_refresh_thirdweb_upgrade_state(anchor)
 	var result = await PromiseUtils.async_awaiter(promise)
+	_upgrade_check_in_flight = false
+	_upgrade_checked = true
 	var is_upgraded: bool
 	if result is PromiseError:
 		# Couldn't confirm against thirdweb — fall back to the last-known cached

--- a/godot/src/ui/components/organisms/menu/menu.tscn
+++ b/godot/src/ui/components/organisms/menu/menu.tscn
@@ -2,6 +2,7 @@
 
 [ext_resource type="Theme" uid="uid://bm1rvmngc833v" path="res://assets/themes/theme.tres" id="1_ji0pe"]
 [ext_resource type="Script" uid="uid://cpa0oxye73bch" path="res://src/ui/components/organisms/menu/menu.gd" id="2_cgghr"]
+[ext_resource type="Texture2D" uid="uid://djhqqgo0jyq4t" path="res://assets/backgrounds/gradient-background.png" id="3_57a8l"]
 [ext_resource type="Script" uid="uid://c8wv7cyh00l4o" path="res://src/ui/layouts/clean_orientation.gd" id="3_rdch8"]
 [ext_resource type="Script" uid="uid://bhwm0bl5qoiph" path="res://src/ui/layouts/safe_margin_container.gd" id="4_2fqoa"]
 [ext_resource type="PackedScene" uid="uid://cqnj0gb2vybsi" path="res://src/ui/components/atoms/buttons/static_button/static_button.tscn" id="4_lhdku"]
@@ -21,12 +22,6 @@
 [ext_resource type="PackedScene" uid="uid://bpx10vkib1ix" path="res://src/ui/components/molecules/button_profile/navbar_profile_button.tscn" id="22_n1jkd"]
 [ext_resource type="PackedScene" uid="uid://b3e5xybvamaqr" path="res://src/ui/components/organisms/menu/account_deletion_popup.tscn" id="31_kkhkt"]
 [ext_resource type="PackedScene" uid="uid://b7wwfp7f38typ" path="res://src/ui/components/organisms/menu/upgrade_otp_popup.tscn" id="32_otp01"]
-
-[sub_resource type="Gradient" id="Gradient_6v8vt"]
-colors = PackedColorArray(0.705882, 0.733333, 0.776471, 1, 0.945098, 0.945098, 0.945098, 1)
-
-[sub_resource type="GradientTexture2D" id="GradientTexture2D_8oh0n"]
-gradient = SubResource("Gradient_6v8vt")
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_2tihm"]
 bg_color = Color(0.08627451, 0.08235294, 0.09411765, 1)
@@ -82,7 +77,8 @@ theme_override_constants/separation = 0
 show_behind_parent = true
 layout_mode = 2
 size_flags_vertical = 3
-texture = SubResource("GradientTexture2D_8oh0n")
+texture = ExtResource("3_57a8l")
+expand_mode = 1
 
 [node name="Menus" type="Control" parent="VBoxContainer/ColorRect_Background" unique_id=1809653402]
 layout_mode = 1
@@ -206,6 +202,10 @@ anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
 color = Color(0, 0, 0, 0.501961)
+
+[node name="BackBufferCopy" type="BackBufferCopy" parent="Control_DeployingProfile" unique_id=1962847105]
+editor_description = "Forces a fresh screen capture for BackgrundBlur. Godot captures the screen once per frame for all hint_screen_texture materials: in the backpack, AvatarVFX (addition_shader) claims that capture early in draw order, so without this node the blur samples a stale snapshot taken before the bottom bar and this overlay's dim were drawn (#2487)."
+copy_mode = 2
 
 [node name="BackgrundBlur" type="ColorRect" parent="Control_DeployingProfile" unique_id=2073397854]
 material = ExtResource("16_7v87b")

--- a/godot/src/ui/pages/backpack/backpack.gd
+++ b/godot/src/ui/pages/backpack/backpack.gd
@@ -495,6 +495,13 @@ func _show_wearables():
 	margin_container_no_items.visible = not has_items
 	grid_container_wearables_list.visible = has_items
 
+	# The profile may store token-instance urns (…:<itemId>:<tokenId>) while the grid keys by the
+	# item urn; collapse the equipped list to item urns so on-chain equipped wearables highlight
+	# correctly (and are therefore unequippable).
+	var equipped_item_urns := {}
+	for equipped_urn in Global.player_identity.get_mutable_avatar().get_wearables():
+		equipped_item_urns[to_item_urn(equipped_urn)] = true
+
 	for wearable_id in filtered_data:
 		var wearable_item = WEARABLE_ITEM_INSTANTIABLE.instantiate()
 		var wearable = wearable_data[wearable_id]
@@ -507,9 +514,9 @@ func _show_wearables():
 		wearable_item.equip.connect(self._on_wearable_equip.bind(wearable_id))
 		wearable_item.unequip.connect(self._on_wearable_unequip.bind(wearable_id))
 
-		# Check if the item is equipped
+		# Check if the item is equipped (compare on the collapsed item urn — see to_item_urn)
 		var is_wearable_pressed = (
-			Global.player_identity.get_mutable_avatar().get_wearables().has(wearable_id)
+			equipped_item_urns.has(wearable_id)
 			or Global.player_identity.get_mutable_avatar().get_body_shape() == wearable_id
 		)
 		wearable_item.set_pressed_no_signal(is_wearable_pressed)
@@ -644,8 +651,10 @@ func _on_wearable_equip(wearable_id: String):
 		var to_remove = []
 		# Unequip current wearable with category
 		for current_wearable_id in new_avatar_wearables:
-			# TODO: put the fetch wearable function
-			var wearable = wearable_data.get(current_wearable_id)
+			# Normalize to the item urn: the profile may hold a token-instance urn
+			# (…:<itemId>:<tokenId>) while wearable_data is keyed by the item urn, so a raw lookup
+			# misses and the old same-category wearable is never replaced (leaves duplicates).
+			var wearable = wearable_data.get(to_item_urn(current_wearable_id))
 			if wearable != null and wearable.get_category() == category:
 				to_remove.push_back(current_wearable_id)
 
@@ -672,9 +681,12 @@ func _on_wearable_unequip(wearable_id: String):
 	var new_avatar_wearables: PackedStringArray = (
 		Global.player_identity.get_mutable_avatar().get_wearables()
 	)
-	var index = new_avatar_wearables.find(wearable_id)
-	if index != -1:
-		new_avatar_wearables.remove_at(index)
+	# Remove every entry that collapses to this item urn — covers the token-instance urn the
+	# profile stores (…:<itemId>:<tokenId>) plus any item-level duplicate. A plain
+	# find(wearable_id) misses the token form and leaves the wearable stuck on the avatar.
+	for i in range(new_avatar_wearables.size() - 1, -1, -1):
+		if to_item_urn(new_avatar_wearables[i]) == wearable_id:
+			new_avatar_wearables.remove_at(i)
 
 	Global.player_identity.get_mutable_avatar().set_wearables(new_avatar_wearables)
 	request_update_avatar = true
@@ -728,7 +740,8 @@ func _async_marketplace_preview_equip(urn: String, wearable: DclItemEntityDefini
 	var preview_wearables = _marketplace_saved_wearables.duplicate()
 	var to_remove = []
 	for current_id in preview_wearables:
-		var current_wearable = wearable_data.get(current_id)
+		# Same item/token urn normalization as the equip path (see to_item_urn).
+		var current_wearable = wearable_data.get(to_item_urn(current_id))
 		if current_wearable != null and current_wearable.get_category() == category:
 			to_remove.push_back(current_id)
 	for remove_id in to_remove:
@@ -917,6 +930,21 @@ static func newtag_item_urn(urn: String, token_id: String) -> String:
 	if not token_id.is_empty() and urn.ends_with(":" + token_id):
 		return urn.trim_suffix(":" + token_id)
 	return urn
+
+
+# Collapse ANY wearable urn to its ITEM form, stripping a trailing :<tokenId> when present.
+# Mirrors the Rust ContentProvider.get_wearable normalization (truncate at the 6th ':'), the
+# canonical item urn that wearable_data / can_equip / the avatar profile use. A profile may
+# store either the item urn or the token-instance urn (…:<itemId>:<tokenId>), so equipped-state
+# / unequip / same-category-replace must compare on this collapsed form — otherwise on-chain
+# wearables already equipped in the profile read as un-equipped and can never be removed.
+# Off-chain/base urns (< 6 ':') pass through unchanged. Unlike newtag_item_urn this needs no
+# pre-parsed tokenId, so it works on arbitrary urns coming from the avatar wearable list.
+static func to_item_urn(urn: String) -> String:
+	var parts := urn.split(":")
+	if parts.size() <= 6:
+		return urn
+	return ":".join(parts.slice(0, 6))
 
 
 # Evaluates the NEW tags for a category from the current owned counts and persists the

--- a/godot/src/ui/pages/discover/discover.gd
+++ b/godot/src/ui/pages/discover/discover.gd
@@ -196,7 +196,9 @@ func set_search_filter_text(new_text: String) -> void:
 		places_my_places.visible = places_my_places.has_items()
 		places_most_active.title = "Most Actives"
 		if guest_upgrade_card:
-			guest_upgrade_card.show()
+			# Don't force it visible — let the card re-evaluate its own upgrade state
+			# so already-upgraded users never see it flash (#2483).
+			guest_upgrade_card.refresh_visibility()
 	else:
 		friends_online.hide()
 		last_visited.hide()

--- a/godot/src/ui/pages/loading_screen/loading_screen.gd
+++ b/godot/src/ui/pages/loading_screen/loading_screen.gd
@@ -164,6 +164,14 @@ func _on_timer_check_progress_timeout_timeout():
 
 
 func _on_loading_screen_progress_logic_loading_show_requested():
+	# Dismiss any on-screen keyboard and exit chat mode so neither overlaps the
+	# loading UI when navigation starts while a search/chat input is active (#2491).
+	# close_chat also hides the chat's own keyboard; the explicit hide covers
+	# keyboards opened from other inputs (e.g. Discover search).
+	if Global.is_mobile():
+		DisplayServer.virtual_keyboard_hide()
+	Global.close_chat.emit()
+
 	var now = Time.get_ticks_msec()
 	last_activity_time = now
 	loading_start_time = now

--- a/lib/src/scene_runner/components/billboard.rs
+++ b/lib/src/scene_runner/components/billboard.rs
@@ -117,7 +117,7 @@ mod test {
             entity,
             Some(PbBillboard {
                 billboard_mode: Some(3),
-                target_entity: None,
+                ..Default::default()
             }),
         );
 

--- a/lib/src/scene_runner/scene.rs
+++ b/lib/src/scene_runner/scene.rs
@@ -75,7 +75,10 @@ pub struct Dirty {
 #[derive(PartialEq)]
 pub enum SceneState {
     Alive,
-    ToKill,
+    /// Marked for removal. Carries the time (in the SceneManager's `begin_time`
+    /// clock, microseconds) at which the kill was requested, so `reap_dying_scenes`
+    /// can force-terminate a scene that never manages to receive the kill signal.
+    ToKill(i64),
     KillSignal(i64),
     Dead,
 }

--- a/lib/src/scene_runner/scene_manager.rs
+++ b/lib/src/scene_runner/scene_manager.rs
@@ -358,9 +358,10 @@ impl SceneManager {
     #[func]
     fn kill_scene(&mut self, scene_id: i32) -> bool {
         let scene_id = SceneId(scene_id);
+        let now_us = (std::time::Instant::now() - self.begin_time).as_micros() as i64;
         if let Some(scene) = self.scenes.get_mut(&scene_id) {
             if let SceneState::Alive = scene.state {
-                scene.state = SceneState::ToKill;
+                scene.state = SceneState::ToKill(now_us);
                 self.dying_scene_ids.push(scene_id);
                 return true;
             }
@@ -370,9 +371,10 @@ impl SceneManager {
 
     #[func]
     fn kill_all_scenes(&mut self) {
+        let now_us = (std::time::Instant::now() - self.begin_time).as_micros() as i64;
         for (scene_id, scene) in self.scenes.iter_mut() {
             if let SceneState::Alive = scene.state {
-                scene.state = SceneState::ToKill;
+                scene.state = SceneState::ToKill(now_us);
                 self.dying_scene_ids.push(*scene_id);
             }
         }
@@ -1503,10 +1505,36 @@ impl SceneManager {
     /// scenes killed on sign-out or realm change are guaranteed to be torn down
     /// (V8/Deno threads joined, Godot nodes freed) even after the lobby pauses the
     /// runner. Without this, killed scenes would linger forever as ToKill.
+    /// Force-terminate a scene's V8 isolate via its handle. Last resort when the
+    /// graceful kill can't be delivered or the thread won't exit on its own. Takes
+    /// no `&self` so it can be called from inside `reap_dying_scenes`'s loop while a
+    /// scene is mutably borrowed. No-op when built without `use_deno`.
+    fn force_terminate_scene_v8(scene_id: &SceneId) {
+        #[cfg(feature = "use_deno")]
+        {
+            if let Ok(handles) = crate::dcl::js::VM_HANDLES.lock() {
+                if let Some(handle) = handles.get(scene_id) {
+                    handle.terminate_execution();
+                    tracing::info!("V8 execution terminated for scene {:?}", scene_id);
+                }
+            }
+        }
+        #[cfg(not(feature = "use_deno"))]
+        {
+            let _ = scene_id;
+        }
+    }
+
     fn reap_dying_scenes(&mut self) {
         if self.dying_scene_ids.is_empty() {
             return;
         }
+
+        // Force-terminate a scene this long after the kill was *requested* if it
+        // still hasn't finished — whether or not we ever managed to deliver the
+        // graceful kill signal. Measured against the kill-request time for
+        // `ToKill` and the kill-signal time for `KillSignal`.
+        const KILL_SCENE_TIMEOUT_US: i64 = 10 * 1_000_000;
 
         let current_time_us = (std::time::Instant::now() - self.begin_time).as_micros() as i64;
         let mut scene_to_remove: HashSet<SceneId> = HashSet::new();
@@ -1521,7 +1549,7 @@ impl SceneManager {
                 continue;
             };
             match scene.state {
-                SceneState::ToKill => {
+                SceneState::ToKill(request_time_us) => {
                     match scene
                         .dcl_scene
                         .main_sender_to_thread
@@ -1542,8 +1570,27 @@ impl SceneManager {
                             );
                             scene.state = SceneState::KillSignal(current_time_us);
                         }
-                        // Capacity-1 channel with the receiver still alive; retry next tick.
-                        Err(TrySendError::Full(_)) => {}
+                        // Capacity-1 channel and the scene thread hasn't drained the
+                        // previous RendererResponse (its JS is wedged and never calls
+                        // op_crdt_recv_wait). We can't deliver the graceful kill, so
+                        // without a timeout here the scene would stay ToKill forever and
+                        // its Godot nodes would never be freed — leaving the old scene
+                        // rendered on top of the new one after a teleport (issue #2229).
+                        // The V8 force-terminate below doesn't need the channel, so apply
+                        // it once we're past the timeout measured from the kill *request*.
+                        Err(TrySendError::Full(_)) => {
+                            let elapsed_from_request_us = current_time_us - request_time_us;
+                            if elapsed_from_request_us > KILL_SCENE_TIMEOUT_US {
+                                tracing::error!(
+                                    "timeout delivering kill to scene {:?} (channel full for {}s), forcing V8 termination",
+                                    scene_id,
+                                    elapsed_from_request_us / 1_000_000
+                                );
+                                Self::force_terminate_scene_v8(scene_id);
+                                // Mark as dead - thread should exit soon after V8 termination
+                                scene.state = SceneState::Dead;
+                            }
+                        }
                     }
                 }
                 SceneState::KillSignal(kill_time_us) => {
@@ -1551,27 +1598,13 @@ impl SceneManager {
                         scene.state = SceneState::Dead;
                     } else {
                         let elapsed_from_kill_us = current_time_us - kill_time_us;
-                        if elapsed_from_kill_us > 10 * 1e6 as i64 {
-                            // 10 seconds from the kill signal - force terminate V8
+                        if elapsed_from_kill_us > KILL_SCENE_TIMEOUT_US {
+                            // Timeout from the kill signal - force terminate V8
                             tracing::error!(
                                 "timeout killing scene {:?}, forcing V8 termination",
                                 scene_id
                             );
-
-                            // Use the V8 isolate handle to force-terminate execution
-                            #[cfg(feature = "use_deno")]
-                            {
-                                if let Ok(handles) = crate::dcl::js::VM_HANDLES.lock() {
-                                    if let Some(handle) = handles.get(scene_id) {
-                                        handle.terminate_execution();
-                                        tracing::info!(
-                                            "V8 execution terminated for scene {:?}",
-                                            scene_id
-                                        );
-                                    }
-                                }
-                            }
-
+                            Self::force_terminate_scene_v8(scene_id);
                             // Mark as dead - thread should exit soon after V8 termination
                             scene.state = SceneState::Dead;
                         }

--- a/src/install_dependency.rs
+++ b/src/install_dependency.rs
@@ -31,10 +31,19 @@ fn create_directory_all(path: &Path) -> io::Result<()> {
     Ok(())
 }
 
-// Resolve @dcl/protocol from the npm `next` dist-tag (see PROTOCOL_NPM_DIST_TAG).
-// Set this to `Some("<tarball-url>")` only to temporarily pin a specific build
-// (e.g. a per-PR protocol tarball); leave it `None` to track @next.
-const PROTOCOL_FIXED_VERSION_URL: Option<&str> = None;
+// Resolve @dcl/protocol from the npm `next` dist-tag (see PROTOCOL_NPM_DIST_TAG),
+// unless PROTOCOL_FIXED_VERSION_URL pins a specific tarball.
+//
+// Pinned for the 1.11.0 RC: tracking `next` re-resolves on every CI run, so an
+// upstream protocol publish can break or change builds with no repo change
+// (e.g. PBBillboard.target_entity landed mid-RC and broke the billboard itest).
+// Bump the pin deliberately — grab the new tarball URL from
+// `https://registry.npmjs.org/@dcl/protocol/next` (dist.tarball), update any
+// affected generated-struct usages, and set it here. Reset to `None` to track
+// @next again after the release is cut.
+const PROTOCOL_FIXED_VERSION_URL: Option<&str> = Some(
+    "https://registry.npmjs.org/@dcl/protocol/-/protocol-1.0.0-28974105118.commit-a598406.tgz",
+);
 const PROTOCOL_NPM_DIST_TAG: &str = "next";
 
 fn get_protocol_url() -> Result<String, anyhow::Error> {


### PR DESCRIPTION
## Port release-1.11.0 hotfixes to main

Cherry-picks the fixes that landed directly on the `release-1.11.0` RC branch (PR #2459) so `main` doesn't lose them. All commits are already validated on the RC (local + CI).

### Fixes
- **Backpack: equip/unequip wearables stored as token-instance urns** (#2480)
- **Guest upgrade notice no longer flashes for already-upgraded users** (Fixes #2483)
- **Loading screen dismisses the on-screen keyboard and exits chat mode** (Fixes #2491)
- **Scenes wedged in `ToKill` are force-terminated so they unload on teleport**
- **"Updating profile…" overlay gray footer band** — the deploy overlay's blur re-used the once-per-frame screen capture already claimed by the backpack's `AvatarVFX` screen-texture shader; a `BackBufferCopy` now forces a fresh capture (Fixes #2487)

### CI
- **Billboard itest hardened against protocol field additions** — uses `..Default::default()` instead of an exhaustive `PbBillboard` literal. `main` already hot-patched the same break with an explicit `target_entity: None`; this supersedes it so the *next* `@next` field addition doesn't break CI again.
- **iOS runner disk guard** — the `dcl-ios` VM persists build caches between runs and filled up (this PR's iOS export failed twice with "No space left on device"); the workflow now auto-prunes the Rust caches before building whenever free space drops below 40 GB.
- **`@dcl/protocol` pinned to `1.0.0-28974105118.commit-a598406`** — the same tarball current code compiles against. This is the version that broke CI mid-RC when resolved fresh from the `next` dist-tag. **If `main` should keep floating on `@next`, drop this commit (`94d964d3fa`) — the itest hardening above already unbreaks the float.** Unpin by resetting `PROTOCOL_FIXED_VERSION_URL` to `None` in `src/install_dependency.rs`.

### Test plan
- CI green (clippy + platform builds) — the billboard/protocol situation is exercised by every build.
- UI fixes were manually verified on the RC branch (see PR #2459 test plan items 7–9); no `main`-specific behavior differences expected.

Merging this closes #2483, #2487, #2491 (base is the default branch, so `Fixes` references auto-close).
