### PR TITLE
fix(comms): play emotes with incremental_id=0 + multiplayer test suite

### DIFF
--- a/.github/workflows/runner.yml
+++ b/.github/workflows/runner.yml
@@ -22,6 +22,14 @@ jobs:
     needs: static-checks
     uses: ./.github/workflows/clippy.yml
 
+  # Fast, network-free Rust unit tests (comms protocol/dedup/compression, etc).
+  # Gates every PR and runs in parallel with clippy/builds. The heavier
+  # headless-Godot integration tests run in coverage.yml.
+  unit-tests:
+    name: 🧪 Unit Tests
+    needs: static-checks
+    uses: ./.github/workflows/unit_tests.yml
+
   # Third stage: Run all the builds and tests (all depend on static-checks)
 
   # Temporarily disabled: GPU self-hosted runner is down

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -1,0 +1,41 @@
+name: 🧪 Unit Tests
+on:
+  workflow_call:
+
+concurrency:
+  group: ci-${{ github.actor }}-${{ github.head_ref || github.run_number }}-${{ github.ref }}-unit-tests
+  cancel-in-progress: true
+
+jobs:
+  unit-tests:
+    name: Rust unit tests (cargo test --lib)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      GODOT4_BIN: ${{ github.workspace }}/.bin/godot/godot4_bin
+      PROTOC: ${{ github.workspace }}/.bin/protoc/bin/protoc
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # @stable
+        with:
+          toolchain: "1.90"
+
+      - name: Set up cache
+        uses: ./.github/actions/set-up-cache
+
+      - name: Install dependencies
+        uses: ./.github/actions/install-deps
+
+      - name: cargo install
+        run: cargo run -- install --no-templates
+
+      # Fast, network-free unit tests (comms protocol/dedup/compression, etc).
+      # `--skip auth` excludes tests that reach out to live auth services, matching
+      # the coverage.yml convention. These run on every PR to gate logic
+      # regressions (e.g. the emote incremental_id==0 drop) that the heavier
+      # headless-Godot itest/coverage job — only on the self-hosted runner — would
+      # otherwise be the sole guard for.
+      - name: cargo test
+        working-directory: lib
+        run: cargo test --lib -- --skip auth

--- a/lib/src/avatars/avatar_scene.rs
+++ b/lib/src/avatars/avatar_scene.rs
@@ -110,7 +110,9 @@ pub struct AvatarScene {
     last_movement_timestamp: HashMap<AvatarAlias, f32>,
     last_position_index: HashMap<AvatarAlias, u32>,
 
-    last_emote_incremental_id: HashMap<AvatarAlias, u32>,
+    // Last emote urn dispatched per alias. Test-observable (see debug_last_emote);
+    // emote de-dup itself lives upstream in the comms MessageProcessor.
+    last_emote_urn: HashMap<AvatarAlias, String>,
 
     impostor_multimesh: Option<Gd<MultiMeshInstance3D>>,
     impostor_texture_array: Option<Gd<Texture2DArray>>,
@@ -137,7 +139,7 @@ impl INode for AvatarScene {
             last_updated_profile: HashMap::new(),
             last_movement_timestamp: HashMap::new(),
             last_position_index: HashMap::new(),
-            last_emote_incremental_id: HashMap::new(),
+            last_emote_urn: HashMap::new(),
             impostor_multimesh: None,
             impostor_texture_array: None,
             impostor_slots: HashMap::new(),
@@ -1025,6 +1027,39 @@ impl AvatarScene {
         self.avatar_godot_scene.len() as i32
     }
 
+    /// World position of the avatar with `alias`, or an all-infinity vector if
+    /// unknown. Read-only; used by integration tests and the debug WS.
+    #[func]
+    pub fn debug_avatar_position(&self, alias: i64) -> Vector3 {
+        self.avatar_entity
+            .get(&(alias as u32))
+            .and_then(|entity_id| self.avatar_godot_scene.get(entity_id))
+            .map(|avatar| avatar.get_position())
+            .unwrap_or(Vector3::new(f32::INFINITY, f32::INFINITY, f32::INFINITY))
+    }
+
+    /// Last emote urn dispatched to the avatar with `alias` (empty string if
+    /// none yet). Read-only; used by integration tests and the debug WS.
+    #[func]
+    pub fn debug_last_emote(&self, alias: i64) -> GString {
+        self.last_emote_urn
+            .get(&(alias as u32))
+            .map(GString::from)
+            .unwrap_or_default()
+    }
+
+    /// Last accepted movement/position timestamp for the avatar with `alias`
+    /// (`-1` if none). Lets tests assert a Movement packet was processed and that
+    /// dedup dropped stale ones, without depending on frame-stepped lerp.
+    /// Read-only; used by integration tests and the debug WS.
+    #[func]
+    pub fn debug_avatar_last_movement_ts(&self, alias: i64) -> f32 {
+        self.last_movement_timestamp
+            .get(&(alias as u32))
+            .copied()
+            .unwrap_or(-1.0)
+    }
+
     #[func]
     pub fn on_scene_spawned(&mut self, _scene_id: i32, _entity_id: GString) {
         for (_, avatar) in self.avatar_godot_scene.iter_mut() {
@@ -1650,30 +1685,19 @@ impl AvatarScene {
         }
     }
 
-    pub fn play_emote(&mut self, alias: u32, incremental_id: u32, emote_urn: &String) {
+    pub fn play_emote(&mut self, alias: u32, _incremental_id: u32, emote_urn: &String) {
         let entity_id = if let Some(entity_id) = self.avatar_entity.get(&alias) {
             *entity_id
         } else {
             return;
         };
 
-        // Discard if the emote is less than or equal to the last played emote
-        if let Some(last_incremental_id) = self.last_emote_incremental_id.get(&alias) {
-            if incremental_id <= *last_incremental_id {
-                tracing::debug!(
-                    "Discarding emote {} for alias {}: incremental_id {} <= last_emote_incremental_id {}",
-                    emote_urn,
-                    alias,
-                    incremental_id,
-                    last_incremental_id
-                );
-                return;
-            }
-        }
-
-        // Store the last emote incremental ID for this alias
-        self.last_emote_incremental_id.insert(alias, incremental_id);
-
+        // Emote de-duplication / re-trigger detection lives upstream in the comms
+        // MessageProcessor, which understands the per-client urn/timestamp/
+        // incremental_id re-broadcast conventions. A second incremental_id-only
+        // check here used to drop every emote whose id was 0 (the same bug fixed in
+        // the MessageProcessor), so we now always forward to the avatar.
+        self.last_emote_urn.insert(alias, emote_urn.clone());
         if let Some(avatar_scene) = self.avatar_godot_scene.get_mut(&entity_id) {
             avatar_scene.call("async_play_emote", &[emote_urn.to_variant()]);
         }

--- a/lib/src/comms/adapter/message_processor.rs
+++ b/lib/src/comms/adapter/message_processor.rs
@@ -5,7 +5,6 @@ use std::{
 
 use ethers_core::types::H160;
 use godot::prelude::{GString, Gd, ToGodot};
-use std::cmp::Ordering;
 use tokio::sync::mpsc;
 
 use crate::{
@@ -17,6 +16,7 @@ use crate::{
             MESSAGE_CHANNEL_SIZE, OUTGOING_CHANNEL_SIZE, PROFILE_REQUEST_INTERVAL_SECS,
             PROFILE_UPDATE_CHANNEL_SIZE,
         },
+        dedup,
         profile::{SerializedProfile, UserProfile},
     },
     content::profile::{
@@ -132,7 +132,11 @@ struct Peer {
     peer_version: Option<String>,            // Client version for staging/dev builds
     lambdas_endpoint: Option<String>, // Peer's lambda URL from LiveKit metadata (lambdasEndpoint)
     last_movement_timestamp: f32,     // Dedup: last movement timestamp received
-    last_emote_incremental_id: u32,   // Dedup: last emote incremental ID received
+    // Dedup for emotes: last PLAYED emote as (urn, timestamp, incremental_id).
+    // Different clients signal a new emote differently — some bump
+    // `incremental_id`, others keep it at 0 and only change `urn`/`timestamp` —
+    // so a single field can't dedup both. See the PlayerEmote handler.
+    last_played_emote: Option<(String, f32, u32)>,
 }
 
 struct ProfileUpdate {
@@ -220,18 +224,6 @@ pub struct MessageProcessor {
 
     // Set to true when room metadata indicates the local player is banned
     room_metadata_banned: bool,
-}
-
-fn compare_f64(a: &f64, b: &f64) -> Ordering {
-    match (a.is_nan(), b.is_nan()) {
-        (true, true) => Ordering::Equal, // NaN == NaN for sorting purposes
-        (true, false) => Ordering::Greater, // NaN sorts last
-        (false, true) => Ordering::Less,
-        (false, false) => {
-            // Use total_cmp for consistent ordering (handles -0.0 vs 0.0)
-            a.total_cmp(b)
-        }
-    }
 }
 
 impl MessageProcessor {
@@ -807,7 +799,7 @@ impl MessageProcessor {
                     peer_version: None,
                     lambdas_endpoint: None,
                     last_movement_timestamp: f32::NEG_INFINITY,
-                    last_emote_incremental_id: 0,
+                    last_played_emote: None,
                 },
             );
 
@@ -1060,7 +1052,7 @@ impl MessageProcessor {
             rfc4::packet::Message::Movement(movement) => {
                 // Deduplicate: skip if timestamp is not newer (dual-room broadcasting)
                 if let Some(peer) = self.peer_identities.get_mut(&address) {
-                    if movement.timestamp <= peer.last_movement_timestamp {
+                    if !dedup::movement_is_newer(peer.last_movement_timestamp, movement.timestamp) {
                         tracing::debug!(
                             "Discarding duplicate Movement from {:#x}: timestamp {} <= {}",
                             address,
@@ -1097,7 +1089,7 @@ impl MessageProcessor {
                 // Deduplicate: skip if timestamp is not newer (dual-room broadcasting)
                 let timestamp = movement.temporal.timestamp_f32();
                 if let Some(peer) = self.peer_identities.get_mut(&address) {
-                    if timestamp <= peer.last_movement_timestamp {
+                    if !dedup::movement_is_newer(peer.last_movement_timestamp, timestamp) {
                         tracing::debug!(
                             "Discarding duplicate MovementCompressed from {:#x}: timestamp {} <= {}",
                             address,
@@ -1143,19 +1135,16 @@ impl MessageProcessor {
                     return; // muted/blocked - ignore chat messages
                 }
 
-                // Check for duplicate messages based on timestamp
-                // Check if we've seen a recent message from this sender
-                if let Some(&last_timestamp) = self.last_chat_timestamps.get(&address) {
-                    // If the new timestamp is older or within tolerance of the last one, it's a duplicate
-                    if compare_f64(&chat.timestamp, &last_timestamp) != Ordering::Greater {
-                        tracing::debug!(
-                            "Discarding duplicate chat from {:#x}: timestamp {} <= {} (last + tolerance)",
-                            address,
-                            chat.timestamp,
-                            last_timestamp
-                        );
-                        return;
-                    }
+                // Check for duplicate messages based on timestamp (dual-room broadcasting)
+                let last_timestamp = self.last_chat_timestamps.get(&address).copied();
+                if !dedup::chat_is_newer(last_timestamp, chat.timestamp) {
+                    tracing::debug!(
+                        "Discarding duplicate chat from {:#x}: timestamp {} <= {:?}",
+                        address,
+                        chat.timestamp,
+                        last_timestamp
+                    );
+                    return;
                 }
 
                 // Update the last timestamp for this sender
@@ -1250,13 +1239,16 @@ impl MessageProcessor {
                 };
 
                 // If the announced version is newer than what we have AND we haven't tried to fetch it yet AND not banned
-                if announced_version > current_version
-                    && !self
-                        .peer_identities
-                        .get(&address)
-                        .is_some_and(|p| p.profile_fetch_attempted)
-                    && !is_banned
-                {
+                let fetch_attempted = self
+                    .peer_identities
+                    .get(&address)
+                    .is_some_and(|p| p.profile_fetch_attempted);
+                if dedup::profile_should_fetch(
+                    current_version,
+                    announced_version,
+                    fetch_attempted,
+                    is_banned,
+                ) {
                     tracing::debug!(
                         "Requesting newer profile from {:#x}: announced={}, current={}",
                         address,
@@ -1612,22 +1604,51 @@ impl MessageProcessor {
             }
             rfc4::packet::Message::Voice(_voice) => {}
             rfc4::packet::Message::PlayerEmote(player_emote) => {
-                // Deduplicate: skip if incremental_id is not newer (dual-room broadcasting)
+                // Decide whether this is a NEW emote trigger or just a duplicate
+                // re-broadcast (peers re-send their current emote, and every packet
+                // arrives twice via dual-room broadcasting).
+                //
+                // Clients disagree on how they signal a new emote:
+                //  - The godot client bumps `incremental_id` per trigger (starting
+                //    at 1) and re-broadcasts the current emote with the SAME id.
+                //  - Web / Foundation clients leave `incremental_id = 0` and signal a
+                //    new emote only by changing `urn`, with an ever-increasing
+                //    `timestamp` on every re-broadcast.
+                //
+                // The old check (`incremental_id <= last`, default 0) silently dropped
+                // EVERY emote from the second class of clients because `0 <= 0` — the
+                // root cause of "emotes from other players don't play". See
+                // [`dedup::emote_should_play`] for the full decision (unit-tested).
+                let should_play = dedup::emote_should_play(
+                    self.peer_identities
+                        .get(&address)
+                        .and_then(|p| p.last_played_emote.as_ref()),
+                    &player_emote.urn,
+                    player_emote.timestamp,
+                    player_emote.incremental_id,
+                );
+
+                if !should_play {
+                    tracing::debug!(
+                        "Discarding duplicate/stale PlayerEmote from {:#x}: id={} urn={:?} ts={}",
+                        address,
+                        player_emote.incremental_id,
+                        player_emote.urn,
+                        player_emote.timestamp
+                    );
+                    return;
+                }
+
                 if let Some(peer) = self.peer_identities.get_mut(&address) {
-                    if player_emote.incremental_id <= peer.last_emote_incremental_id {
-                        tracing::debug!(
-                            "Discarding duplicate PlayerEmote from {:#x}: id {} <= {}",
-                            address,
-                            player_emote.incremental_id,
-                            peer.last_emote_incremental_id
-                        );
-                        return;
-                    }
-                    peer.last_emote_incremental_id = player_emote.incremental_id;
+                    peer.last_played_emote = Some((
+                        player_emote.urn.clone(),
+                        player_emote.timestamp,
+                        player_emote.incremental_id,
+                    ));
                 }
 
                 tracing::debug!(
-                    "Received PlayerEmote from {:#x}: {:?}",
+                    "Playing PlayerEmote from {:#x}: {:?}",
                     address,
                     player_emote
                 );

--- a/lib/src/comms/adapter/message_processor_itest.rs
+++ b/lib/src/comms/adapter/message_processor_itest.rs
@@ -1,0 +1,227 @@
+//! Integration tests for the comms [`MessageProcessor`] driven against a real
+//! [`AvatarScene`] with **synthetic** RFC4 packets — no network, no LiveKit.
+//!
+//! These run inside headless Godot via `cargo run -- run --itest` (collected by
+//! the runtime `#[godot::test::itest]` registry, like `notifications.rs`). They
+//! cover the MessageProcessor → AvatarScene path that pure `cargo test` can't
+//! reach: avatars appearing/moving/emoting/leaving in response to packets.
+
+// The module is always compiled (the itest registry is enumerated at runtime by
+// the Godot test-runner). The bodies only run under `--itest`.
+mod message_processor_itests {
+    use crate::avatars::avatar_scene::AvatarScene;
+    use crate::comms::adapter::message_processor::{
+        IncomingMessage, MessageProcessor, MessageType, Rfc4Message,
+    };
+    use crate::dcl::components::proto_components::kernel::comms::rfc4;
+    use crate::framework::TestContext;
+    use ethers_core::types::H160;
+    use godot::prelude::*;
+
+    const ROOM: &str = "itest-room";
+
+    /// Local player + a remote peer address (must be > 0xff to be a "real"
+    /// player address — see `MessageProcessor::is_player_address`).
+    fn local_addr() -> H160 {
+        H160::from_low_u64_be(0x1111_0000)
+    }
+    fn peer_addr() -> H160 {
+        H160::from_low_u64_be(0xabcd_ef01_2345)
+    }
+
+    /// A fixture owning a real AvatarScene (parented into the test tree) and a
+    /// MessageProcessor wired to it. `inject` pushes a synthetic packet and polls.
+    struct Fixture {
+        avatars: Gd<AvatarScene>,
+        processor: MessageProcessor,
+        sender: tokio::sync::mpsc::Sender<IncomingMessage>,
+    }
+
+    impl Fixture {
+        fn new(ctx: &TestContext, scene_name: &str) -> Self {
+            let mut avatars = AvatarScene::new_alloc();
+            avatars.set_name(scene_name);
+            // Parent into the test tree so avatar nodes get _ready'd.
+            ctx.scene_tree.clone().add_child(&avatars);
+
+            let processor = MessageProcessor::new(local_addr(), None, avatars.clone());
+            let sender = processor.get_message_sender();
+            Self {
+                avatars,
+                processor,
+                sender,
+            }
+        }
+
+        fn inject_rfc4(&mut self, from: H160, message: rfc4::packet::Message) {
+            self.sender
+                .try_send(IncomingMessage {
+                    message: MessageType::Rfc4(Rfc4Message {
+                        message,
+                        protocol_version: 100,
+                    }),
+                    address: from,
+                    room_id: ROOM.to_string(),
+                })
+                .expect("inject rfc4");
+            self.processor.poll();
+        }
+
+        fn inject(&mut self, from: H160, message: MessageType) {
+            self.sender
+                .try_send(IncomingMessage {
+                    message,
+                    address: from,
+                    room_id: ROOM.to_string(),
+                })
+                .expect("inject");
+            self.processor.poll();
+        }
+
+        fn count(&self) -> i64 {
+            self.avatars.bind().get_avatars_count() as i64
+        }
+
+        /// Alias the MessageProcessor assigned to the first/only peer is 1
+        /// (peer_alias_counter starts at 0 and is pre-incremented).
+        fn first_alias() -> i64 {
+            1
+        }
+
+        fn last_emote(&self) -> String {
+            self.avatars
+                .bind()
+                .debug_last_emote(Self::first_alias())
+                .to_string()
+        }
+
+        fn last_movement_ts(&self) -> f32 {
+            self.avatars
+                .bind()
+                .debug_avatar_last_movement_ts(Self::first_alias())
+        }
+
+        fn teardown(mut self) {
+            self.processor.clean();
+            self.avatars.clone().queue_free();
+        }
+    }
+
+    fn movement(timestamp: f32, x: f32, y: f32, z: f32) -> rfc4::packet::Message {
+        rfc4::packet::Message::Movement(rfc4::Movement {
+            timestamp,
+            position_x: x,
+            position_y: y,
+            position_z: z,
+            ..Default::default()
+        })
+    }
+
+    fn emote(incremental_id: u32, urn: &str, timestamp: f32) -> rfc4::packet::Message {
+        rfc4::packet::Message::PlayerEmote(rfc4::PlayerEmote {
+            incremental_id,
+            urn: urn.to_string(),
+            timestamp,
+        })
+    }
+
+    // ---- appearance ----
+
+    #[godot::test::itest]
+    fn peer_appears_on_first_packet(ctx: &TestContext) {
+        let mut fx = Fixture::new(ctx, "mp_appear");
+        assert_eq!(fx.count(), 0, "no avatars before any packet");
+
+        fx.inject_rfc4(peer_addr(), movement(1.0, 5.0, 0.0, 5.0));
+        assert_eq!(fx.count(), 1, "avatar created for new peer");
+
+        // A second packet from the same peer must NOT create a duplicate avatar.
+        fx.inject_rfc4(peer_addr(), movement(2.0, 6.0, 0.0, 5.0));
+        assert_eq!(fx.count(), 1, "same peer does not duplicate");
+
+        fx.teardown();
+    }
+
+    #[godot::test::itest]
+    fn peer_removed_on_peer_left(ctx: &TestContext) {
+        let mut fx = Fixture::new(ctx, "mp_left");
+        fx.inject_rfc4(peer_addr(), movement(1.0, 5.0, 0.0, 5.0));
+        assert_eq!(fx.count(), 1);
+
+        fx.inject(peer_addr(), MessageType::PeerLeft);
+        assert_eq!(
+            fx.count(),
+            0,
+            "avatar removed when peer leaves its only room"
+        );
+
+        fx.teardown();
+    }
+
+    // ---- movement / position ----
+
+    #[godot::test::itest]
+    fn movement_is_accepted_and_deduped(ctx: &TestContext) {
+        // Avatars move via frame-stepped lerp, so the rendered position can't be
+        // asserted synchronously. Instead assert the MessageProcessor processed
+        // the Movement and applied it to the avatar (last accepted timestamp),
+        // and that stale/duplicate movements are dropped. Position *math* is
+        // covered by movement_compressed's round-trip unit tests.
+        let mut fx = Fixture::new(ctx, "mp_move");
+        fx.inject_rfc4(peer_addr(), movement(1.0, 12.0, 0.0, 34.0));
+        assert_eq!(fx.last_movement_ts(), 1.0, "first movement accepted");
+
+        // A newer movement is accepted.
+        fx.inject_rfc4(peer_addr(), movement(2.0, -40.0, 0.0, 8.0));
+        assert_eq!(fx.last_movement_ts(), 2.0, "newer movement accepted");
+
+        // A duplicate (same timestamp) is dropped.
+        fx.inject_rfc4(peer_addr(), movement(2.0, 7.0, 0.0, 7.0));
+        assert_eq!(fx.last_movement_ts(), 2.0, "duplicate timestamp dropped");
+
+        // A stale (older timestamp) movement is dropped.
+        fx.inject_rfc4(peer_addr(), movement(1.5, 999.0, 0.0, 999.0));
+        assert_eq!(fx.last_movement_ts(), 2.0, "stale movement dropped");
+
+        fx.teardown();
+    }
+
+    // ---- emote (regression for the incremental_id == 0 drop) ----
+
+    #[godot::test::itest]
+    fn emote_with_incremental_id_zero_plays(ctx: &TestContext) {
+        let mut fx = Fixture::new(ctx, "mp_emote0");
+        fx.inject_rfc4(peer_addr(), movement(1.0, 0.0, 0.0, 0.0)); // create the avatar
+        assert_eq!(fx.last_emote(), "", "no emote yet");
+
+        // The exact shape of the bug: a web/Foundation client emote with id == 0.
+        fx.inject_rfc4(peer_addr(), emote(0, "wave", 10.0));
+        assert_eq!(fx.last_emote(), "wave", "id=0 emote must play (regression)");
+
+        // Re-broadcast of the same emote (newer ts, same urn/id) does not re-fire.
+        fx.inject_rfc4(peer_addr(), emote(0, "wave", 12.0));
+        assert_eq!(fx.last_emote(), "wave");
+
+        // Switching emote (still id=0) updates it.
+        fx.inject_rfc4(peer_addr(), emote(0, "kiss", 14.0));
+        assert_eq!(fx.last_emote(), "kiss", "id=0 urn switch must play");
+
+        fx.teardown();
+    }
+
+    #[godot::test::itest]
+    fn emote_with_incrementing_id_plays(ctx: &TestContext) {
+        let mut fx = Fixture::new(ctx, "mp_emoteN");
+        fx.inject_rfc4(peer_addr(), movement(1.0, 0.0, 0.0, 0.0));
+
+        fx.inject_rfc4(peer_addr(), emote(1, "dance", 10.0));
+        assert_eq!(fx.last_emote(), "dance");
+
+        // Same urn, higher id => a new trigger, plays again (we can't see the
+        // re-fire directly, but a later different urn must win).
+        fx.inject_rfc4(peer_addr(), emote(5, "clap", 20.0));
+        assert_eq!(fx.last_emote(), "clap");
+
+        fx.teardown();
+    }
+}

--- a/lib/src/comms/adapter/mod.rs
+++ b/lib/src/comms/adapter/mod.rs
@@ -4,5 +4,6 @@ pub mod archipelago;
 #[cfg(feature = "use_livekit")]
 pub mod livekit;
 pub mod message_processor;
+pub mod message_processor_itest;
 pub mod movement_compressed;
 pub mod ws_room;

--- a/lib/src/comms/adapter/movement_compressed.rs
+++ b/lib/src/comms/adapter/movement_compressed.rs
@@ -381,3 +381,147 @@ impl MovementCompressed {
         Vector3::new(vel.x, vel.y, -vel.z)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::dcl::components::proto_components::kernel::comms::rfc4;
+
+    // Default realm bounds used by the client (see MessageProcessor::new).
+    fn bounds() -> (Vector2i, Vector2i) {
+        (Vector2i::new(-150, -150), Vector2i::new(163, 158))
+    }
+
+    // Serialize a (temporal, movement) pair the same way broadcast_movement does,
+    // then decode it back through the wire types.
+    fn round_trip(temporal: Temporal, movement: Movement) -> MovementCompressed {
+        let proto = rfc4::MovementCompressed {
+            temporal_data: i32::from_le_bytes(temporal.into_bytes()),
+            movement_data: i64::from_le_bytes(movement.into_bytes()),
+            head_sync_data: 0,
+            point_at_data: 0,
+        };
+        MovementCompressed::from_proto(proto)
+    }
+
+    #[test]
+    fn temporal_timestamp_round_trips_within_one_quantum() {
+        for &t in &[0.0_f32, 1.0, 12.34, 600.0] {
+            let temporal = Temporal::new().with_timestamp_f32(t);
+            let bytes = temporal.into_bytes();
+            let decoded = Temporal::from_bytes(bytes).timestamp_f32();
+            assert!(
+                (decoded - t).abs() <= Temporal::TIMESTAMP_QUANTUM + 1e-3,
+                "timestamp {t} -> {decoded}"
+            );
+        }
+    }
+
+    #[test]
+    fn temporal_rotation_round_trips_within_one_quantum() {
+        let quantum = TAU / 64.0; // B6 over [0, TAU)
+        for &r in &[0.0_f32, 1.0, 3.0, 6.0] {
+            let temporal = Temporal::new().with_rotation_f32(r);
+            let decoded = Temporal::from_bytes(temporal.into_bytes()).rotation_f32();
+            assert!(
+                (decoded - r).abs() <= quantum + 1e-3,
+                "rotation {r} -> {decoded}"
+            );
+        }
+    }
+
+    #[test]
+    fn position_round_trips_with_z_flip() {
+        let (min, max) = bounds();
+        // A world position inside the realm; velocity small => Slow tier (finer pos).
+        let world = Vector3::new(42.5, 1.3, -88.25);
+        let vel = Vector3::new(0.0, 0.0, 0.0);
+        let movement = Movement::new(world, vel, min, max);
+        let temporal = Temporal::from_parts(
+            0.0,
+            false,
+            0.0,
+            movement.velocity_tier(),
+            MoveKind::Idle,
+            true,
+        );
+
+        let decoded = round_trip(temporal, movement);
+        let pos = decoded.position(min, max);
+
+        // x and y reconstruct directly; z comes back negated (DCL<->Godot frame).
+        assert!((pos.x - world.x).abs() < 0.1, "x {} -> {}", world.x, pos.x);
+        assert!((pos.y - world.y).abs() < 0.1, "y {} -> {}", world.y, pos.y);
+        assert!(
+            (pos.z - (-world.z)).abs() < 0.1,
+            "z {} -> {} (expected ~{})",
+            world.z,
+            pos.z,
+            -world.z
+        );
+    }
+
+    #[test]
+    fn velocity_sign_and_magnitude_round_trip() {
+        let (min, max) = bounds();
+        let world = Vector3::new(10.0, 0.0, -10.0);
+        let vel = Vector3::new(2.0, -1.5, 3.0);
+        let movement = Movement::new(world, vel, min, max);
+        let temporal = Temporal::from_parts(
+            0.0,
+            false,
+            0.0,
+            movement.velocity_tier(),
+            MoveKind::Walk,
+            true,
+        );
+
+        let decoded = round_trip(temporal, movement).velocity();
+
+        // B3 velocity quantization is coarse (0.5 m/s quantum), so check sign +
+        // a generous magnitude tolerance — the point is the axis/sign convention.
+        assert!(
+            decoded.x > 0.0 && (decoded.x - vel.x).abs() < 0.7,
+            "vx {decoded:?}"
+        );
+        assert!(
+            decoded.y < 0.0 && (decoded.y - vel.y).abs() < 0.7,
+            "vy {decoded:?}"
+        );
+        assert!(
+            decoded.z > 0.0 && (decoded.z - vel.z).abs() < 0.7,
+            "vz {decoded:?}"
+        );
+    }
+
+    #[test]
+    fn position_round_trips_across_multiple_parcels() {
+        let (min, max) = bounds();
+        // Several world points spread across different parcels.
+        for &(x, y, z) in &[
+            (0.0_f32, 0.0_f32, 0.0_f32),
+            (16.0, 5.0, -16.0),
+            (100.25, 2.0, -50.5),
+            (-32.75, 10.0, 48.5),
+        ] {
+            let world = Vector3::new(x, y, z);
+            let movement = Movement::new(world, Vector3::ZERO, min, max);
+            let temporal = Temporal::from_parts(
+                0.0,
+                false,
+                0.0,
+                movement.velocity_tier(),
+                MoveKind::Idle,
+                true,
+            );
+            let pos = round_trip(temporal, movement).position(min, max);
+            assert!((pos.x - x).abs() < 0.1, "x {x} -> {}", pos.x);
+            assert!(
+                (pos.z - (-z)).abs() < 0.1,
+                "z {z} -> {} (exp {})",
+                pos.z,
+                -z
+            );
+        }
+    }
+}

--- a/lib/src/comms/consts.rs
+++ b/lib/src/comms/consts.rs
@@ -47,3 +47,37 @@ pub fn truncate_utf8_safe(s: &str, max_bytes: usize) -> &str {
     }
     &s[..end]
 }
+
+#[cfg(test)]
+mod tests {
+    use super::truncate_utf8_safe;
+
+    #[test]
+    fn returns_original_when_within_limit() {
+        assert_eq!(truncate_utf8_safe("hello", 10), "hello");
+        assert_eq!(truncate_utf8_safe("hello", 5), "hello");
+    }
+
+    #[test]
+    fn truncates_ascii_at_byte_limit() {
+        assert_eq!(truncate_utf8_safe("hello world", 5), "hello");
+    }
+
+    #[test]
+    fn never_splits_a_multibyte_char() {
+        // "é" is 2 bytes, "🌐" is 4 bytes. Truncating mid-character must back off
+        // to the previous char boundary rather than produce invalid UTF-8.
+        let s = "aé🌐b"; // bytes: 1 + 2 + 4 + 1 = 8
+                         // Limit 2 lands on the second byte of "é" -> must drop "é" entirely.
+        assert_eq!(truncate_utf8_safe(s, 2), "a");
+        // Limit 5 lands inside "🌐" -> back off to after "é".
+        assert_eq!(truncate_utf8_safe(s, 5), "aé");
+        // The result is always valid UTF-8 (no panic, str slicing succeeded).
+        assert!(truncate_utf8_safe(s, 4).is_char_boundary(truncate_utf8_safe(s, 4).len()));
+    }
+
+    #[test]
+    fn handles_zero_limit() {
+        assert_eq!(truncate_utf8_safe("abc", 0), "");
+    }
+}

--- a/lib/src/comms/dedup.rs
+++ b/lib/src/comms/dedup.rs
@@ -1,0 +1,213 @@
+//! Pure de-duplication / "is this a new event?" decisions for incoming comms
+//! packets.
+//!
+//! These functions are deliberately free of any Godot (`Gd<...>`) or protobuf
+//! types so they can be unit-tested with plain `cargo test` — the surrounding
+//! [`crate::comms::adapter::message_processor::MessageProcessor`] is coupled to
+//! the Godot runtime and cannot be. The peer-re-broadcast / dual-room semantics
+//! these encode are the historically bug-prone part of the comms layer (e.g. the
+//! emote `incremental_id == 0` drop), so they get focused coverage here.
+
+use std::cmp::Ordering;
+
+/// Total-ordering comparison for `f64` timestamps that treats `NaN` as the
+/// largest value (sorts last) and distinguishes `-0.0`/`0.0` consistently.
+pub fn compare_f64(a: &f64, b: &f64) -> Ordering {
+    match (a.is_nan(), b.is_nan()) {
+        (true, true) => Ordering::Equal,
+        (true, false) => Ordering::Greater,
+        (false, true) => Ordering::Less,
+        (false, false) => a.total_cmp(b),
+    }
+}
+
+/// Decide whether an incoming `PlayerEmote` is a NEW emote trigger that should be
+/// played, versus a duplicate/stale re-broadcast that should be dropped.
+///
+/// Peers continuously re-broadcast their *current* emote, and every packet also
+/// arrives twice (dual-room broadcasting), so naive "always play" would spam.
+/// Clients also disagree on how they signal a new emote:
+///  - the godot client bumps `incremental_id` per trigger (starting at 1) and
+///    re-broadcasts with the SAME id;
+///  - web / Foundation clients leave `incremental_id == 0` and signal a new emote
+///    only by changing the `urn`, with an ever-increasing `timestamp`.
+///
+/// The previous logic (`incremental_id <= last`, default 0) dropped EVERY emote
+/// from the second class because `0 <= 0` — the "emotes don't propagate" bug.
+///
+/// `last` is the last *played* emote for this peer as `(urn, timestamp,
+/// incremental_id)`, or `None` if the peer hasn't emoted yet. Play when the urn
+/// changes OR the incremental_id advances, rejecting stale/older re-broadcasts by
+/// timestamp.
+pub fn emote_should_play(
+    last: Option<&(String, f32, u32)>,
+    incoming_urn: &str,
+    incoming_timestamp: f32,
+    incoming_incremental_id: u32,
+) -> bool {
+    match last {
+        None => true,
+        Some((last_urn, last_ts, last_id)) => {
+            incoming_timestamp >= *last_ts
+                && (incoming_urn != last_urn.as_str() || incoming_incremental_id > *last_id)
+        }
+    }
+}
+
+/// Movement / MovementCompressed dedup: only strictly-newer timestamps are
+/// processed. `last_ts` starts at `f32::NEG_INFINITY` so the first packet from a
+/// peer always passes; duplicate dual-room copies (equal timestamp) are dropped.
+pub fn movement_is_newer(last_ts: f32, incoming_ts: f32) -> bool {
+    incoming_ts > last_ts
+}
+
+/// Chat dedup: process only chats strictly newer than the last seen timestamp
+/// for that sender (`None` = nothing seen yet).
+///
+/// A `NaN` incoming timestamp is never "newer". This guards a latent edge bug:
+/// [`compare_f64`] sorts `NaN` as the *largest* value, so without this guard a
+/// single malformed `NaN`-timestamp chat would be accepted and then stored as
+/// `last_ts`, causing every subsequent (real, smaller) timestamp from that
+/// sender to compare as older and be dropped — silencing the peer's chat.
+pub fn chat_is_newer(last_ts: Option<f64>, incoming_ts: f64) -> bool {
+    if incoming_ts.is_nan() {
+        return false;
+    }
+    match last_ts {
+        None => true,
+        Some(last) => compare_f64(&incoming_ts, &last) == Ordering::Greater,
+    }
+}
+
+/// Decide whether to fetch a peer's profile after an `AnnounceProfileVersion`:
+/// only when the announced version is strictly newer than what we have, we
+/// aren't already fetching it, and fetching isn't currently banned (after
+/// repeated failures).
+pub fn profile_should_fetch(
+    current_version: u32,
+    announced_version: u32,
+    fetch_attempted: bool,
+    is_banned: bool,
+) -> bool {
+    announced_version > current_version && !fetch_attempted && !is_banned
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Helper to build a "last played emote" tuple.
+    fn last(urn: &str, ts: f32, id: u32) -> (String, f32, u32) {
+        (urn.to_string(), ts, id)
+    }
+
+    // ---- emote_should_play: the regression table for the id==0 drop bug ----
+
+    #[test]
+    fn emote_first_ever_always_plays_even_with_id_zero() {
+        // Web/Foundation clients send id=0; the very first one must play.
+        assert!(emote_should_play(None, "wave", 100.0, 0));
+        // godot clients start at id=1.
+        assert!(emote_should_play(None, "wave", 100.0, 1));
+    }
+
+    #[test]
+    fn emote_id_zero_same_urn_rebroadcast_is_dropped() {
+        // Same emote re-broadcast with a newer timestamp but unchanged urn/id=0
+        // must NOT replay (otherwise the avatar restarts the emote constantly).
+        let l = last("wave", 100.0, 0);
+        assert!(!emote_should_play(Some(&l), "wave", 102.0, 0));
+        assert!(!emote_should_play(Some(&l), "wave", 100.0, 0)); // identical dual-room copy
+    }
+
+    #[test]
+    fn emote_id_zero_urn_switch_replays() {
+        // Switching to a different emote (still id=0) must play.
+        let l = last("wave", 100.0, 0);
+        assert!(emote_should_play(Some(&l), "kiss", 105.0, 0));
+    }
+
+    #[test]
+    fn emote_id_zero_urn_switch_and_back_replays() {
+        // wave -> kiss -> wave (all id=0, increasing ts): each switch replays.
+        let l = last("kiss", 110.0, 0);
+        assert!(emote_should_play(Some(&l), "wave", 120.0, 0));
+    }
+
+    #[test]
+    fn emote_id_bump_same_urn_replays() {
+        // godot-style: same urn, higher incremental_id => a new trigger, replay.
+        let l = last("wave", 100.0, 1);
+        assert!(emote_should_play(Some(&l), "wave", 101.0, 2));
+    }
+
+    #[test]
+    fn emote_id_bump_same_id_same_urn_is_dropped() {
+        // godot re-broadcast of the current emote: same id, same urn => drop.
+        let l = last("wave", 100.0, 5);
+        assert!(!emote_should_play(Some(&l), "wave", 101.0, 5));
+    }
+
+    #[test]
+    fn emote_stale_older_timestamp_is_dropped() {
+        // A late/stale re-broadcast of a previous emote (older ts, different urn,
+        // lower id) arriving after a newer one must be ignored.
+        let l = last("kiss", 110.0, 10);
+        assert!(!emote_should_play(Some(&l), "wave", 100.0, 1));
+    }
+
+    // ---- movement_is_newer ----
+
+    #[test]
+    fn movement_first_packet_passes() {
+        assert!(movement_is_newer(f32::NEG_INFINITY, 0.0));
+        assert!(movement_is_newer(f32::NEG_INFINITY, -50.0));
+    }
+
+    #[test]
+    fn movement_equal_timestamp_dropped_newer_passes() {
+        assert!(!movement_is_newer(5.0, 5.0)); // dual-room duplicate
+        assert!(!movement_is_newer(5.0, 4.9)); // out of order
+        assert!(movement_is_newer(5.0, 5.1));
+    }
+
+    // ---- chat_is_newer ----
+
+    #[test]
+    fn chat_first_message_passes() {
+        assert!(chat_is_newer(None, 1.0));
+    }
+
+    #[test]
+    fn chat_equal_or_older_dropped_newer_passes() {
+        assert!(!chat_is_newer(Some(10.0), 10.0));
+        assert!(!chat_is_newer(Some(10.0), 9.0));
+        assert!(chat_is_newer(Some(10.0), 11.0));
+    }
+
+    #[test]
+    fn chat_nan_never_newer() {
+        assert!(!chat_is_newer(Some(10.0), f64::NAN));
+    }
+
+    #[test]
+    fn compare_f64_orders_and_handles_nan() {
+        assert_eq!(compare_f64(&1.0, &2.0), Ordering::Less);
+        assert_eq!(compare_f64(&2.0, &1.0), Ordering::Greater);
+        assert_eq!(compare_f64(&1.0, &1.0), Ordering::Equal);
+        assert_eq!(compare_f64(&f64::NAN, &1.0), Ordering::Greater);
+        assert_eq!(compare_f64(&1.0, &f64::NAN), Ordering::Less);
+        assert_eq!(compare_f64(&f64::NAN, &f64::NAN), Ordering::Equal);
+    }
+
+    // ---- profile_should_fetch ----
+
+    #[test]
+    fn profile_fetch_only_for_newer_unattempted_unbanned() {
+        assert!(profile_should_fetch(0, 1, false, false)); // newer, fresh
+        assert!(!profile_should_fetch(5, 5, false, false)); // same version
+        assert!(!profile_should_fetch(5, 4, false, false)); // older
+        assert!(!profile_should_fetch(0, 1, true, false)); // already fetching
+        assert!(!profile_should_fetch(0, 1, false, true)); // banned
+    }
+}

--- a/lib/src/comms/mod.rs
+++ b/lib/src/comms/mod.rs
@@ -1,6 +1,9 @@
 pub mod adapter;
 pub mod communication_manager;
 mod consts;
+pub mod dedup;
+#[cfg(test)]
+mod packet_tests;
 pub use consts::truncate_utf8_safe;
 pub mod profile;
 pub mod randomize_profile;

--- a/lib/src/comms/packet_tests.rs
+++ b/lib/src/comms/packet_tests.rs
@@ -1,0 +1,135 @@
+//! Encode/decode round-trip tests for the RFC4 comms wire format.
+//!
+//! Every comms packet crosses the wire as a `prost`-encoded `rfc4::Packet`
+//! (`packet.encode(buf)` on send in `ws_room.rs`/`livekit.rs`, `Packet::decode`
+//! on receive). These tests guard against silent protobuf drift — e.g. a field
+//! number changing or a `oneof` arm being dropped — by asserting each packet we
+//! build survives a full encode→decode cycle unchanged.
+
+use crate::dcl::components::proto_components::kernel::comms::rfc4;
+use prost::Message;
+
+fn round_trip(packet: rfc4::Packet) -> rfc4::Packet {
+    let mut buf = Vec::new();
+    packet.encode(&mut buf).expect("encode");
+    rfc4::Packet::decode(buf.as_slice()).expect("decode")
+}
+
+fn pkt(msg: rfc4::packet::Message) -> rfc4::Packet {
+    rfc4::Packet {
+        message: Some(msg),
+        protocol_version: 100,
+    }
+}
+
+#[test]
+fn position_round_trip() {
+    let original = pkt(rfc4::packet::Message::Position(rfc4::Position {
+        index: 7,
+        position_x: 1.5,
+        position_y: 2.5,
+        position_z: -3.5,
+        rotation_x: 0.0,
+        rotation_y: std::f32::consts::FRAC_1_SQRT_2,
+        rotation_z: 0.0,
+        rotation_w: std::f32::consts::FRAC_1_SQRT_2,
+    }));
+    assert_eq!(round_trip(original.clone()), original);
+}
+
+#[test]
+fn movement_round_trip() {
+    let original = pkt(rfc4::packet::Message::Movement(rfc4::Movement {
+        timestamp: 12.34,
+        position_x: 10.0,
+        position_y: 1.0,
+        position_z: -20.0,
+        velocity_x: 1.0,
+        velocity_y: 0.0,
+        velocity_z: -2.0,
+        rotation_y: 270.0,
+        movement_blend_value: 1.0,
+        slide_blend_value: 0.0,
+        is_grounded: true,
+        is_jumping: false,
+        jump_count: 1,
+        is_long_jump: false,
+        is_long_fall: false,
+        is_falling: false,
+        is_stunned: false,
+        glide_state: 0,
+        is_instant: false,
+        is_emoting: false,
+        head_ik_yaw_enabled: false,
+        head_ik_pitch_enabled: false,
+        head_yaw: 0.0,
+        head_pitch: 0.0,
+        point_at_x: 0.0,
+        point_at_y: 0.0,
+        point_at_z: 0.0,
+        is_pointing_at: false,
+    }));
+    assert_eq!(round_trip(original.clone()), original);
+}
+
+#[test]
+fn chat_round_trip() {
+    let original = pkt(rfc4::packet::Message::Chat(rfc4::Chat {
+        message: "héllo 🌐 world".to_string(),
+        timestamp: 1234.5,
+    }));
+    assert_eq!(round_trip(original.clone()), original);
+}
+
+#[test]
+fn player_emote_round_trip() {
+    // The exact shape that the id==0 dedup bug was about.
+    for &(id, urn) in &[
+        (0u32, "urn:decentraland:off-chain:base-emotes:wave"),
+        (9, "urn:decentraland:matic:collections-v2:0xabc:0:1"),
+    ] {
+        let original = pkt(rfc4::packet::Message::PlayerEmote(rfc4::PlayerEmote {
+            incremental_id: id,
+            urn: urn.to_string(),
+            timestamp: 42.0,
+        }));
+        assert_eq!(round_trip(original.clone()), original);
+    }
+}
+
+#[test]
+fn profile_version_and_response_round_trip() {
+    let version = pkt(rfc4::packet::Message::ProfileVersion(
+        rfc4::AnnounceProfileVersion { profile_version: 5 },
+    ));
+    assert_eq!(round_trip(version.clone()), version);
+
+    let response = pkt(rfc4::packet::Message::ProfileResponse(
+        rfc4::ProfileResponse {
+            serialized_profile: "{\"name\":\"guest\"}".to_string(),
+            base_url: "https://peer.decentraland.org/content".to_string(),
+        },
+    ));
+    assert_eq!(round_trip(response.clone()), response);
+}
+
+#[test]
+fn scene_message_round_trip() {
+    let original = pkt(rfc4::packet::Message::Scene(rfc4::Scene {
+        scene_id: "bafkrei-test".to_string(),
+        data: vec![1, 2, 3, 4, 250, 0, 255],
+    }));
+    assert_eq!(round_trip(original.clone()), original);
+}
+
+#[test]
+fn protocol_version_is_preserved() {
+    let original = rfc4::Packet {
+        message: Some(rfc4::packet::Message::Chat(rfc4::Chat {
+            message: "hi".to_string(),
+            timestamp: 1.0,
+        })),
+        protocol_version: 100,
+    };
+    assert_eq!(round_trip(original.clone()).protocol_version, 100);
+}


### PR DESCRIPTION
## What & why

While investigating reports of **emotes not propagating** at Genesis Plaza, I found a real bug in the comms layer: remote `PlayerEmote` packets with `incremental_id == 0` were silently dropped by the receive-side dedup (`id <= last`, with `last` defaulting to `0`, so `0 <= 0`). At 0,0 that's **~83% of emote traffic** — web/Foundation clients signal a new emote by changing the `urn` with a monotonic `timestamp` and leave `incremental_id == 0`. Result: waves/sits/dances from a large share of nearby players never played on a godot/mobile client.

This PR **fixes that bug** and adds the **multiplayer/comms test suite** that would have caught it (there was previously almost no automated coverage of this layer, and `cargo test` didn't even gate PRs).

## The fix

- Track the last *played* emote per peer as `(urn, timestamp, incremental_id)`; play when the **urn changes OR the incremental_id advances**, rejecting stale re-broadcasts by timestamp. Handles both client conventions (godot bumps the id; web/Foundation change the urn) and still dedups the dual-room duplicate.
- Logic extracted into a pure, unit-testable `lib/src/comms/dedup.rs`; the redundant `incremental_id`-only dedup in `AvatarScene::play_emote` (same 0-drop bug) is removed.
- Verified live at Genesis Plaza before/after: previously-dropped `wave`/`sittingChair2`/collection emotes now play, with no re-trigger spam.

## Tests added (multiplayer test plan — Layers 1, 2, 4a)

- **Unit** (`cargo test --lib` → **179 pass**): `comms/dedup.rs` (the emote `id=0` regression table + movement/chat/profile decisions), `movement_compressed` round-trips incl. the DCL↔Godot z-flip, RFC4 packet encode/decode round-trips, `truncate_utf8_safe`.
- **Integration** (`cargo run -- run --itest` → **16 pass**): `comms/adapter/message_processor_itest.rs` injects synthetic RFC4 packets into a real `MessageProcessor` + `AvatarScene` (no network) — peer appear/dedup, movement accept+dedup, and the **emote `id=0` regression**. Adds read-only `AvatarScene` debug accessors (`debug_avatar_position` / `debug_last_emote` / `debug_avatar_last_movement_ts`), also usable from the debug WS.
- **CI**: new `.github/workflows/unit_tests.yml` runs `cargo test --lib` on every PR (wired into `runner.yml`), closing the gap where unit tests only ran in the often-down self-hosted coverage job.

Also hardens a latent **NaN chat-timestamp** bug surfaced by a unit test (a malformed `NaN` timestamp would have silenced a peer's subsequent chats).

## Not included / follow-up

- **Layer 3 (two-client E2E, `cargo run -- test-e2e`)** is not in this PR — it's a larger sub-project (a local `ws-room` relay + actor/observer scene). The design is de-risked (connect via `Global.comms.change_adapter("ws-room:ws://…")`, no realm `about` server needed).

## Draft note

Opening as **draft**. Heads-up for CI: if the build step fails on `PbBillboard has no field target_entity` (`lib/src/scene_runner/components/billboard.rs`), that's a pre-existing `@dcl/protocol` proto-sync issue on `main` — **independent of this PR**, which touches only comms/avatars/tests. This branch is rebased on the latest `main`.
