### PR TITLE
fix(profile): deploy token-instance urns so backpack changes survive scene loads

### DIFF
--- a/godot/src/iap/marketplace_tracker.gd
+++ b/godot/src/iap/marketplace_tracker.gd
@@ -75,6 +75,13 @@ var _restore_landscape_on_close: bool = false
 # a streak (the signal worth alerting on) and suppress repeats until a fetch succeeds. Reset per
 # tracking session in _arm() so each session reports its own outage onset.
 var _owned_fetch_failing: Dictionary = {}
+# item urn -> owned token-instance urn (…:<itemId>:<tokenId>) accumulated from every
+# owned-NFTs fetch. Profile deployments must reference on-chain items by the
+# token-instance urn (the catalyst rejects tokenless collections-v2 pointers with
+# HTTP 400 "The URN must include the tokenId"), while the grid/inject paths key by the
+# item urn — this map lets equip resolve the deployable form of a just-bought item the
+# catalyst lambda doesn't list yet (#2489). Session-lived, additive only.
+var _owned_token_urns: Dictionary = {}
 
 
 func _ready() -> void:
@@ -240,7 +247,7 @@ func _async_check(token: int) -> void:
 
 
 # Public: the most-recently-obtained owned urns of one category ("wearable"/"emote"),
-# as a Dictionary keyed by token-instance urn, or an empty dict on failure / no wallet.
+# as a Dictionary keyed by ITEM urn, or an empty dict on failure / no wallet.
 # The backpack and emote editor call this to surface a just-bought item on open — fast
 # (marketplace API, top _OWNED_FETCH_LIMIT), without waiting for the catalyst lambda.
 # Augments the lambda list; never the sole source.
@@ -255,8 +262,15 @@ func async_fetch_recent_owned(category: String) -> Dictionary:
 	return result if result != null else {}
 
 
+# The token-instance urn (…:<itemId>:<tokenId>) for an owned item urn, or "" when no
+# owned-NFTs fetch has reported a tokenId for it this session. Callers writing into the
+# avatar profile use this to keep deployments valid (see _owned_token_urns).
+func get_token_urn(item_urn: String) -> String:
+	return str(_owned_token_urns.get(item_urn, ""))
+
+
 # Returns a Dictionary of the player's most-recently-added owned wearables + emotes,
-# keyed by token-instance urn with the marketplace category ("wearable"/"emote") as
+# keyed by ITEM urn with the marketplace category ("wearable"/"emote") as
 # the value, or null on a fetch failure — callers must treat null as "unknown", never
 # as "empty". A failure in ANY category fails the whole snapshot, since a missing
 # category would otherwise look like "nothing owned there" and break the baseline
@@ -329,4 +343,9 @@ func _async_fetch_owned_urns_for(wallet: String, category: String):
 		# form (…:<itemId>:<tokenId>) does NOT resolve in get_wearable(), so appending the
 		# tokenId here was breaking the live inject of a just-bought item.
 		owned[item_urn] = category
+		# But DO remember the token-instance form: profile deploys need it (see
+		# _owned_token_urns / get_token_urn).
+		var token_id := str(nft.get("tokenId", ""))
+		if not token_id.is_empty():
+			_owned_token_urns[item_urn] = item_urn + ":" + token_id
 	return owned

--- a/godot/src/ui/components/organisms/emote_editor/emote_editor.gd
+++ b/godot/src/ui/components/organisms/emote_editor/emote_editor.gd
@@ -226,6 +226,17 @@ func _normalize_emote_urn(urn: String) -> String:
 	return urn
 
 
+# The urn to store in the avatar profile for an equipped emote. Lambda-listed owned emotes
+# already use the token-instance urn (…:<itemId>:<tokenId>) as their grid urn, but a
+# just-bought emote injected from the fast marketplace API (inject_owned_emote) only has
+# the ITEM urn — and the catalyst rejects deployments whose on-chain pointers lack the
+# tokenId, silently failing the save (#2489). Ask the tracker for the token form; base and
+# already-tokenized urns pass through unchanged.
+func _profile_emote_urn(urn: String) -> String:
+	var token_urn := MarketplaceTracker.get_token_urn(urn)
+	return token_urn if not token_urn.is_empty() else urn
+
+
 func _on_emote_editor_item_select_emote(_emote_urn: String, index: int):
 	if is_instance_valid(avatar) and not _emote_urn.is_empty():
 		avatar.async_play_emote(_emote_urn)
@@ -255,7 +266,7 @@ func _on_emote_item_equip_emote(equip: bool, _emote_urn: String, emote_item: Emo
 		emote_equipped.emit(false)
 		return
 	var emote_urns = avatar.avatar_data.get_emotes()
-	emote_urns[current_selected_index] = _emote_urn
+	emote_urns[current_selected_index] = _profile_emote_urn(_emote_urn)
 	avatar.avatar_data.set_emotes(emote_urns)
 	set_new_emotes.emit(emote_urns)
 	last_equipped_emote_urn = _emote_urn

--- a/godot/src/ui/pages/backpack/backpack.gd
+++ b/godot/src/ui/pages/backpack/backpack.gd
@@ -64,6 +64,14 @@ var _initial_focus_snapped: bool = false
 var _wearable_owned_counts: Dictionary = {}
 var _wearable_is_new: Dictionary = {}
 
+# item_urn -> owned token-instance urn (…:<itemId>:<tokenId>), from the catalyst lambda's
+# individualData. The grid keys by the ITEM urn (see _to_item_urn), but a deployed profile
+# must reference on-chain wearables by the token-instance urn — the catalyst rejects a
+# tokenless collections-v2 pointer with HTTP 400 ("The URN must include the tokenId"), the
+# deploy silently fails, and the next profile fetch reverts the equip (#2489). Equip
+# therefore writes _profile_urn_for(), never the grid key.
+var _wearable_token_urns: Dictionary = {}
+
 @onready var color_carrousel = %ColorCarrousel
 @onready var carrousel_separator = %CarrouselSeparator
 @onready var grid_container_wearables_list = %GridContainer_WearablesList
@@ -207,6 +215,7 @@ func _ready():
 	# NEW tag (#2300): owned counts are rebuilt below from the owned list, then evaluated
 	# against the persisted per-wallet snapshot.
 	_wearable_owned_counts.clear()
+	_wearable_token_urns.clear()
 
 	# Surface the most-recently-obtained owned wearables from the fast marketplace API
 	# first (added only if not already listed), so an item just bought on the web shows
@@ -228,6 +237,10 @@ func _ready():
 			# dedupes against the recent-owned API / live inject (see _to_item_urn).
 			var item_urn := _to_item_urn(wearable_item.urn, wearable_item.token_id)
 			wearable_data[item_urn] = null
+			# Keep the token-instance form for equips (first hit = newest transfer):
+			# deploys need it (see _wearable_token_urns).
+			if wearable_item.urn != item_urn and not _wearable_token_urns.has(item_urn):
+				_wearable_token_urns[item_urn] = wearable_item.urn
 			# Count owned token instances per item for the NEW tag (#2300).
 			_wearable_owned_counts[item_urn] = int(_wearable_owned_counts.get(item_urn, 0)) + 1
 	# Fast-API items the lambda hasn't listed yet (just bought) count as one.
@@ -662,10 +675,23 @@ func _on_wearable_equip(wearable_id: String):
 			var index = new_avatar_wearables.find(to_remove_id)
 			new_avatar_wearables.remove_at(index)
 
-		new_avatar_wearables.append(wearable_id)
+		new_avatar_wearables.append(_profile_urn_for(wearable_id))
 		Global.player_identity.get_mutable_avatar().set_wearables(new_avatar_wearables)
 
 	request_update_avatar = true
+
+
+# The urn to store in the avatar profile for a grid item: the owned token-instance urn
+# (…:<itemId>:<tokenId>) when one is known — from the catalyst lambda's individualData or,
+# for a just-bought item the lambda doesn't list yet, from the marketplace owned-NFTs API —
+# else the grid key itself (base/off-chain items pass through). The catalyst rejects
+# deployments whose collections-v2 pointers lack the tokenId, so equipping the bare item
+# urn makes every later profile save fail and revert (#2489).
+func _profile_urn_for(item_urn: String) -> String:
+	var token_urn := str(_wearable_token_urns.get(item_urn, ""))
+	if token_urn.is_empty():
+		token_urn = MarketplaceTracker.get_token_urn(item_urn)
+	return token_urn if not token_urn.is_empty() else item_urn
 
 
 func _on_wearable_unequip(wearable_id: String):
@@ -1082,6 +1108,9 @@ func _async_refresh_owned_wearables() -> void:
 		# dedupes against entries already added by the recent-owned API / live inject.
 		var item_urn := _to_item_urn(wearable_item.urn, wearable_item.token_id)
 		_wearable_owned_counts[item_urn] = int(_wearable_owned_counts.get(item_urn, 0)) + 1
+		# Keep the token-instance form for equips — deploys need it (see _wearable_token_urns).
+		if wearable_item.urn != item_urn and not _wearable_token_urns.has(item_urn):
+			_wearable_token_urns[item_urn] = wearable_item.urn
 		if not wearable_data.has(item_urn):
 			wearable_data[item_urn] = null
 			new_keys.append(item_urn)

--- a/lib/src/auth/dcl_player_identity.rs
+++ b/lib/src/auth/dcl_player_identity.rs
@@ -1060,6 +1060,25 @@ impl DclPlayerIdentity {
 
         match UserProfile::from_lambda_response(&request_response, base_url.as_str()) {
             Ok(profile) => {
+                // Never replace the local profile with an OLDER copy. Every realm change
+                // re-fetches the profile (PlayerIdentity._on_realm_changed) and the lambda
+                // can still serve the pre-deploy version right after the user saved an
+                // avatar change — applying it would revert the just-equipped wearables
+                // (#2489). Mirrors the peer-profile version guard in message_processor.
+                // Returns true: a stale response is handled, not a parse failure (false
+                // would make the GDScript caller reset to the default profile).
+                if let Some(current) = self.profile.as_ref() {
+                    let current_version = current.bind().inner.version;
+                    if profile.version < current_version {
+                        tracing::warn!(
+                            "profile > ignoring stale lambda profile v{} (local is v{})",
+                            profile.version,
+                            current_version
+                        );
+                        return true;
+                    }
+                }
+
                 let new_profile = DclUserProfile::from_gd(profile);
                 self.profile = Some(new_profile.clone());
                 tracing::info!("profile > set profile from lambda",);

--- a/lib/src/profile/profile_service.rs
+++ b/lib/src/profile/profile_service.rs
@@ -261,6 +261,14 @@ impl ProfileService {
         // ADR-290: Remove snapshots from avatar before deployment
         profile.content.avatar.snapshots = None;
 
+        // A cleared emote slot is stored locally as an empty urn, but the catalyst
+        // rejects any deployment whose emote pointers aren't urns ("Invalid pointer:
+        // ()"), failing the whole profile save. Drop empty slots from the deployed
+        // copy only — the local 10-slot wire format is untouched.
+        if let Some(emotes) = profile.content.avatar.emotes.as_mut() {
+            emotes.retain(|emote| !emote.urn.is_empty());
+        }
+
         // Prepare deployment data
         let unix_time = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)


### PR DESCRIPTION
Fixes #2489

## Root cause

Since the 1.10 marketplace work (#2276) the backpack grid keys owned wearables by the **item urn**, and equip wrote that key into the avatar profile. The catalyst rejects tokenless collections-v2 pointers per ADR-244:

```
HTTP 400 {"errors":["Wearable pointer urn:decentraland:matic:collections-v2:<contract>:<item> should be an item, not an asset. The URN must include the tokenId."]}
```

(~60 Sentry events/14d, heaviest on 1.10.1, still present on 1.11.0 builds 1162–1182 including the #2480 build.)

The failure is invisible: `await ProfileService.async_deploy_profile(...)` awaits a Promise *object* (a no-op), so the profile is committed locally with its version already incremented and nobody sees the rejection. On the next jump-in/teleport the realm change swaps the lambdas URL (LB → realm-provider catalyst), `_on_realm_changed` re-fetches the profile, and `_update_profile_from_lambda` overwrote the local profile with the server's old copy with **no version comparison** — reverting the avatar exactly when the loading screen shows. Same mechanism for clearing an emote slot, which deploys an empty urn (`400 "Invalid pointer: ()"`, the top deploy error in Sentry).

#2480 fixed the grid *reads* (equipped highlight / unequip / same-category replace) but not what gets *written* to the profile, so deploys kept failing and #2489 survived it.

## Fix

- **backpack.gd**: keep `item_urn → token-instance urn` from the lambda's `individualData[].id`; equip writes `_profile_urn_for()` (token form when known, pass-through for base wearables). Grid keys stay item urns, so the #2480 dedup/highlight behavior is unchanged.
- **marketplace_tracker.gd**: record `nft.tokenId` from the owned-NFTs API (`get_token_urn()`) so a just-bought item the catalyst lambda doesn't list yet still equips with its token form.
- **emote_editor.gd**: same normalization for emotes injected from the fast marketplace path.
- **profile_service.rs**: drop empty-urn emote slots from the deployed metadata only (local 10-slot wire format untouched).
- **dcl_player_identity.rs**: ignore lambda profile responses **older** than the local version (mirrors the peer-profile guard in message_processor) so a realm-change re-fetch racing a just-finished deploy — or catalyst replication lag — can't revert the avatar. Returns `true` on skip: `false` makes the GDScript caller reset to the default profile.

## Verified live (desktop client + debug-hub)

1. Injected a tokenless urn exactly like the pre-fix equip → save → reproduced the exact production 400, local v8 vs server v7, UI silent.
2. Jumped into Genesis Plaza at 0,0 → realm switched to `realm-provider-ea…/main`, lambdas moved to `peer-ec2`, the re-fetch fired mid-load → new guard logged `ignoring stale lambda profile v7 (local is v8)` instead of reverting (on 1.11.0 this exact re-fetch is the revert).
3. Restored wearables + cleared an emote slot → `deploy succeeded`, server profile updated with the cleared slot omitted.
4. Confirmed on real inventory data that `individualData[].id == item_urn + ":" + tokenId` for every owned instance (the mapping source).

Test-account caveat: the local account owns no NFTs, so the grid → token-urn equip path wasn't driven through the real UI — please QA-verify on a wallet with collectibles: equip an owned (on-chain) wearable, jump into Genesis Plaza, teleport around; the change must persist (and appear to other clients / after app restart).

Base `release-1.11.0`.