### PR TITLE
feat: add TextEncoder/TextDecoder scene globals

### DIFF
--- a/lib/src/dcl/js/js_modules/main.js
+++ b/lib/src/dcl/js/js_modules/main.js
@@ -310,6 +310,14 @@ globalThis.Headers = fetchModule.Headers;
 globalThis.Response = fetchModule.Response;
 globalThis.WebSocket = require('ws').WebSocket;
 
+const textEncodingModule = require('text_encoding');
+if (globalThis.TextEncoder === undefined) {
+    globalThis.TextEncoder = textEncodingModule.TextEncoder;
+}
+if (globalThis.TextDecoder === undefined) {
+    globalThis.TextDecoder = textEncodingModule.TextDecoder;
+}
+
 
 globalThis.UnityOpsApi = undefined
 globalThis.global = globalThis

--- a/lib/src/dcl/js/js_modules/text_encoding.js
+++ b/lib/src/dcl/js/js_modules/text_encoding.js
@@ -1,0 +1,77 @@
+const UTF8_LABELS = new Set([
+    'unicode-1-1-utf-8',
+    'unicode11utf8',
+    'unicode20utf8',
+    'utf-8',
+    'utf8',
+    'x-unicode20utf8'
+]);
+
+class TextDecoder {
+    constructor(label = 'utf-8', options = {}) {
+        const normalized = String(label).replace(/^[\t\n\f\r ]+|[\t\n\f\r ]+$/g, '').toLowerCase();
+        if (!UTF8_LABELS.has(normalized)) {
+            throw new RangeError(`The encoding label provided ('${label}') is invalid (only utf-8 is supported)`);
+        }
+        this.encoding = 'utf-8';
+        this.fatal = !!(options && options.fatal);
+        this.ignoreBOM = !!(options && options.ignoreBOM);
+    }
+
+    decode(input, options) {
+        if (options && options.stream) {
+            throw new TypeError('TextDecoder.decode: the stream option is not supported');
+        }
+        if (input === undefined) {
+            return '';
+        }
+        let bytes;
+        if (input instanceof ArrayBuffer) {
+            bytes = new Uint8Array(input);
+        } else if (ArrayBuffer.isView(input)) {
+            bytes = new Uint8Array(input.buffer, input.byteOffset, input.byteLength);
+        } else {
+            throw new TypeError('TextDecoder.decode: input must be an ArrayBuffer or ArrayBufferView');
+        }
+        try {
+            return Deno.core.ops.op_utf8_decode(bytes, this.fatal, this.ignoreBOM);
+        } catch (_) {
+            throw new TypeError('TextDecoder.decode: the encoded data is not valid utf-8');
+        }
+    }
+}
+
+class TextEncoder {
+    constructor() {
+        this.encoding = 'utf-8';
+    }
+
+    encode(input = '') {
+        return Deno.core.ops.op_utf8_encode(String(input));
+    }
+
+    encodeInto(source, destination) {
+        if (!(destination instanceof Uint8Array)) {
+            throw new TypeError('TextEncoder.encodeInto: destination must be a Uint8Array');
+        }
+        const text = String(source);
+        const bytes = Deno.core.ops.op_utf8_encode(text);
+        if (bytes.length <= destination.length) {
+            destination.set(bytes);
+            return { read: text.length, written: bytes.length };
+        }
+        let written = destination.length;
+        while (written > 0 && (bytes[written] & 0xc0) === 0x80) {
+            written -= 1;
+        }
+        const prefix = bytes.subarray(0, written);
+        destination.set(prefix);
+        // read = UTF-16 length of the written prefix: the op encodes lone
+        // surrogates as U+FFFD (1 unit), so encode/decode round-trip unit-for-unit
+        const read = Deno.core.ops.op_utf8_decode(prefix, false, true).length;
+        return { read, written };
+    }
+}
+
+module.exports.TextDecoder = TextDecoder;
+module.exports.TextEncoder = TextEncoder;

--- a/lib/src/dcl/js/js_modules/text_encoding.test.cjs
+++ b/lib/src/dcl/js/js_modules/text_encoding.test.cjs
@@ -1,0 +1,144 @@
+// Unit tests for the JS-side TextEncoder/TextDecoder shim (text_encoding.js).
+//
+// The shim only talks to the native layer through `Deno.core.ops`, so we stub
+// op_utf8_encode / op_utf8_decode with Node's WHATWG-conformant codecs, which
+// match the semantics the Rust ops implement (BOM strip unless ignoreBOM,
+// fatal vs U+FFFD replacement). No npm dependencies — Node's built-in test
+// runner only.
+//
+// Run with:  node --test lib/src/dcl/js/js_modules/text_encoding.test.cjs
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const native = {
+    TextEncoder: globalThis.TextEncoder,
+    TextDecoder: globalThis.TextDecoder,
+};
+
+globalThis.Deno = {
+    core: {
+        ops: {
+            op_utf8_encode: (text) => new native.TextEncoder().encode(text),
+            op_utf8_decode: (bytes, fatal, ignoreBOM) =>
+                new native.TextDecoder("utf-8", { fatal, ignoreBOM }).decode(bytes),
+        },
+    },
+};
+
+const { TextEncoder, TextDecoder } = require("./text_encoding.js");
+
+test("decoder accepts the utf-8 label set, case- and whitespace-insensitive", () => {
+    for (const label of [
+        "unicode-1-1-utf-8",
+        "unicode11utf8",
+        "unicode20utf8",
+        "utf-8",
+        "utf8",
+        "x-unicode20utf8",
+        "UTF-8",
+        " \tutf-8\n",
+        undefined,
+    ]) {
+        const decoder = label === undefined ? new TextDecoder() : new TextDecoder(label);
+        assert.equal(decoder.encoding, "utf-8");
+    }
+});
+
+test("decoder rejects any other label with RangeError", () => {
+    for (const label of ["utf-16", "latin1", "", "utf 8", "unicode"]) {
+        assert.throws(() => new TextDecoder(label), RangeError);
+    }
+});
+
+test("decoder exposes fatal and ignoreBOM", () => {
+    assert.deepEqual(
+        (({ fatal, ignoreBOM }) => ({ fatal, ignoreBOM }))(new TextDecoder()),
+        { fatal: false, ignoreBOM: false }
+    );
+    const decoder = new TextDecoder("utf-8", { fatal: true, ignoreBOM: true });
+    assert.equal(decoder.fatal, true);
+    assert.equal(decoder.ignoreBOM, true);
+});
+
+test("decode with no argument returns the empty string", () => {
+    assert.equal(new TextDecoder().decode(), "");
+});
+
+test("decode accepts ArrayBuffer and views honoring byteOffset/byteLength", () => {
+    const bytes = new native.TextEncoder().encode("__héllo…__");
+    assert.equal(new TextDecoder().decode(bytes.buffer), "__héllo…__");
+    const view = new Uint8Array(bytes.buffer, 2, bytes.length - 4);
+    assert.equal(new TextDecoder().decode(view), "héllo…");
+    const dataView = new DataView(bytes.buffer, 2, bytes.length - 4);
+    assert.equal(new TextDecoder().decode(dataView), "héllo…");
+});
+
+test("decode rejects non-buffer input with TypeError", () => {
+    assert.throws(() => new TextDecoder().decode("text"), TypeError);
+    assert.throws(() => new TextDecoder().decode(null), TypeError);
+});
+
+test("decode strips the BOM unless ignoreBOM", () => {
+    const bytes = new Uint8Array([0xef, 0xbb, 0xbf, 0x68, 0x69]);
+    assert.equal(new TextDecoder().decode(bytes), "hi");
+    assert.equal(
+        new TextDecoder("utf-8", { ignoreBOM: true }).decode(bytes),
+        "﻿hi"
+    );
+});
+
+test("decode rejects the stream option loudly", () => {
+    const bytes = new Uint8Array([0x68]);
+    assert.throws(() => new TextDecoder().decode(bytes, { stream: true }), TypeError);
+    assert.equal(new TextDecoder().decode(bytes, { stream: false }), "h");
+});
+
+test("invalid utf-8: U+FFFD by default, TypeError when fatal", () => {
+    const invalid = new Uint8Array([0x61, 0xff, 0x62]);
+    assert.equal(new TextDecoder().decode(invalid), "a�b");
+    assert.throws(
+        () => new TextDecoder("utf-8", { fatal: true }).decode(invalid),
+        TypeError
+    );
+});
+
+test("encoder encodes to utf-8 bytes", () => {
+    const encoder = new TextEncoder();
+    assert.equal(encoder.encoding, "utf-8");
+    assert.deepEqual(encoder.encode(), new Uint8Array(0));
+    assert.deepEqual(
+        encoder.encode("aé€\u{1d4b3}"),
+        new Uint8Array([0x61, 0xc3, 0xa9, 0xe2, 0x82, 0xac, 0xf0, 0x9d, 0x92, 0xb3])
+    );
+});
+
+test("encodeInto reports read/written when everything fits", () => {
+    const dest = new Uint8Array(8);
+    const result = new TextEncoder().encodeInto("a\u{1d4b3}b", dest);
+    assert.deepEqual(result, { read: 4, written: 6 });
+    assert.deepEqual(dest.subarray(6), new Uint8Array(2));
+});
+
+test("encodeInto truncates on a utf-8 character boundary", () => {
+    const encoder = new TextEncoder();
+
+    let dest = new Uint8Array(2);
+    assert.deepEqual(encoder.encodeInto("aé", dest), { read: 1, written: 1 });
+    assert.equal(dest[0], 0x61);
+
+    dest = new Uint8Array(3);
+    assert.deepEqual(encoder.encodeInto("\u{1d4b3}", dest), { read: 0, written: 0 });
+
+    dest = new Uint8Array(5);
+    assert.deepEqual(encoder.encodeInto("a\u{1d4b3}b", dest), { read: 3, written: 5 });
+    assert.deepEqual(
+        dest,
+        new Uint8Array([0x61, 0xf0, 0x9d, 0x92, 0xb3])
+    );
+});
+
+test("encodeInto requires a Uint8Array destination", () => {
+    assert.throws(() => new TextEncoder().encodeInto("a", new Uint16Array(4)), TypeError);
+    assert.throws(() => new TextEncoder().encodeInto("a", []), TypeError);
+});

--- a/lib/src/dcl/js/mod.rs
+++ b/lib/src/dcl/js/mod.rs
@@ -12,6 +12,7 @@ mod restricted_actions;
 mod runtime;
 mod scene_inspector_ops;
 mod testing;
+mod text_encoding;
 mod websocket;
 
 use crate::comms::truncate_utf8_safe;
@@ -106,6 +107,7 @@ pub fn create_runtime(inspect: bool) -> (deno_core::JsRuntime, Option<InspectorS
         runtime::ops(),
         fetch::ops(),
         websocket::ops(),
+        text_encoding::ops(),
         restricted_actions::ops(),
         portables::ops(),
         players::ops(),
@@ -711,6 +713,7 @@ fn op_require(
         }
         "fetch" => Ok(include_str!("js_modules/fetch.js").to_owned()),
         "ws" => Ok(include_str!("js_modules/ws.js").to_owned()),
+        "text_encoding" => Ok(include_str!("js_modules/text_encoding.js").to_owned()),
         "~system/Runtime" => Ok(include_str!("js_modules/Runtime.js").to_owned()),
         "~system/Scene" => Ok(include_str!("js_modules/Scene.js").to_owned()),
         "~system/SignedFetch" => Ok(include_str!("js_modules/SignedFetch.js").to_owned()),

--- a/lib/src/dcl/js/text_encoding.rs
+++ b/lib/src/dcl/js/text_encoding.rs
@@ -1,0 +1,67 @@
+use deno_core::{anyhow::anyhow, error::AnyError, op2, OpDecl};
+
+pub fn ops() -> Vec<OpDecl> {
+    vec![op_utf8_encode(), op_utf8_decode()]
+}
+
+#[op2]
+#[buffer]
+fn op_utf8_encode(#[string] text: String) -> Vec<u8> {
+    text.into_bytes()
+}
+
+#[op2]
+#[string]
+fn op_utf8_decode(
+    #[buffer] bytes: &[u8],
+    fatal: bool,
+    ignore_bom: bool,
+) -> Result<String, AnyError> {
+    decode_utf8(bytes, fatal, ignore_bom)
+}
+
+fn decode_utf8(bytes: &[u8], fatal: bool, ignore_bom: bool) -> Result<String, AnyError> {
+    let bytes = if ignore_bom {
+        bytes
+    } else {
+        bytes.strip_prefix(b"\xEF\xBB\xBF").unwrap_or(bytes)
+    };
+    if fatal {
+        std::str::from_utf8(bytes)
+            .map(str::to_owned)
+            .map_err(|err| anyhow!("invalid utf-8 sequence: {err}"))
+    } else {
+        Ok(String::from_utf8_lossy(bytes).into_owned())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::decode_utf8;
+
+    #[test]
+    fn strips_bom_unless_ignored() {
+        assert_eq!(decode_utf8(b"\xEF\xBB\xBFhi", false, false).unwrap(), "hi");
+        assert_eq!(
+            decode_utf8(b"\xEF\xBB\xBFhi", false, true).unwrap(),
+            "\u{FEFF}hi"
+        );
+        assert_eq!(decode_utf8(b"\xEF\xBB", false, false).unwrap(), "\u{FFFD}");
+    }
+
+    #[test]
+    fn lossy_replaces_invalid_sequences_with_maximal_subparts() {
+        assert_eq!(
+            decode_utf8(b"a\xF0\x90\x28\xBCb", false, false).unwrap(),
+            "a\u{FFFD}(\u{FFFD}b"
+        );
+        assert_eq!(decode_utf8(b"\xC3\xA9", false, false).unwrap(), "é");
+    }
+
+    #[test]
+    fn fatal_rejects_invalid_utf8() {
+        assert!(decode_utf8(b"\xFF", true, false).is_err());
+        assert!(decode_utf8(b"\xEF\xBB\xBF\xFF", true, false).is_err());
+        assert_eq!(decode_utf8(b"ok", true, false).unwrap(), "ok");
+    }
+}


### PR DESCRIPTION
Scene runtimes have no `TextEncoder`/`TextDecoder` because the embedded deno_core runs without deno_web, so SDK scenes and libraries relying on the WHATWG text codecs crash at load (or fall back to slow bundled polyfills).

This adds two std-only ops (`op_utf8_encode`/`op_utf8_decode`) and a small JS shim module registered like the existing fetch/ws shims, installing WHATWG-shaped `TextEncoder` and `TextDecoder` on `globalThis` when absent.

- `TextDecoder` accepts the WHATWG utf-8 label set with `fatal` and `ignoreBOM` support, throws `RangeError` for any other encoding and a loud `TypeError` for the unsupported `{ stream: true }` option.
- `TextEncoder` implements `encode` and `encodeInto`, including correct UTF-8 boundary truncation for `encodeInto` on short destinations.
- Decoding uses Rust's `from_utf8_lossy`, whose maximal-subparts U+FFFD substitution matches the WHATWG spec exactly; encoding inherits USVString lone-surrogate replacement from deno_core's string conversion. No new dependencies.

Unit tests cover the Rust decode paths (`cargo test text_encoding`) and the JS shim (13 `node:test` cases mirroring `ws.test.cjs`). Full crate suite passes (170 tests), `cargo fmt` clean. The ops are pure `std` string/slice operations with no OS APIs, so this ships identically on desktop and the Android/iOS builds (default features include `use_deno` on all targets).

Scenes built with the current SDK keep working unchanged: the SDK installs its polyfill only when the global is absent, so the native-backed implementation wins automatically, including for already-published content.

Related: decentraland/js-sdk-toolchain#1452 (slims the SDK polyfill to a validating utf-8 codec), decentraland/bevy-explorer#958 (same exposure via deno_web).

Note for maintainers: the shim tests are runnable with `node --test lib/src/dcl/js/js_modules/text_encoding.test.cjs` and are meant to join `ws.test.cjs` in the static-checks `node --test` step; that one-line workflow edit is left out of this PR (pushed from a token without workflow scope).
