### PR TITLE
hotfix: update emote wheel loading tip for mobile

### DIFF
--- a/godot/src/ui/components/molecules/tip_card/tip_card.gd
+++ b/godot/src/ui/components/molecules/tip_card/tip_card.gd
@@ -3,7 +3,7 @@ extends PanelContainer
 
 const TIPS: Array[String] = [
 	"Wearables shape how you appear over time. Made by the community.",
-	"Use Emotes to wave, react, or celebrate. Press B to open the Emote Wheel.",
+	"Use Emotes to wave, react, or celebrate. Tap the Emote icon to open the Emote Wheel.",
 	"Use the Creator Hub to build your own places and experiences.",
 	"Decentraland is better with friends. Meet new people and see where they’re hanging out."
 ]


### PR DESCRIPTION
## Summary
Hotfix on `release`: updates the loading screen tip text that referenced the desktop-only "Press B" keyboard shortcut, which doesn't apply on mobile (no physical keyboard).

**Before:** "Use Emotes to wave, react, or celebrate. Press B to open the Emote Wheel."
**After:** "Use Emotes to wave, react, or celebrate. Tap the Emote icon to open the Emote Wheel."

Text approved by Elizabeth in Slack.

Fixes #2509

(Supersedes #2519, retargeted to `release` per hotfix request)

---
Requested by Mateo via Slack