### PR TITLE
ci(ios): fail iOS export on insufficient disk instead of shipping a truncated libgodot.a

### DIFF
--- a/.github/workflows/ios_r2_artifact.yml
+++ b/.github/workflows/ios_r2_artifact.yml
@@ -218,6 +218,21 @@ jobs:
           echo "exports/ contents:"; ls -la exports/
           echo "dylibs found:"; find exports -name "*.dylib" 2>/dev/null || true
 
+          # Integrity gate: a disk-exhausted export truncates libgodot.a to 0 bytes but still
+          # exits 0, so the broken tree only blows up downstream in godot-asc-deploy at link
+          # time (`ld: file is empty in 'libgodot.a'`). Healthy libgodot.a is ~2.3 GB; treat a
+          # missing or <100 MB library as corrupt and refuse to upload it.
+          if [ -z "$(find exports -name 'libgodot.a' -type f)" ]; then
+            echo "❌ No libgodot.a found in export — the iOS export is incomplete, refusing to upload"
+            exit 1
+          fi
+          if find exports -name 'libgodot.a' -type f -size -100M | grep -q .; then
+            echo "❌ Truncated libgodot.a in export (likely disk exhaustion) — refusing to upload:"
+            find exports -name 'libgodot.a' -type f -size -100M -exec ls -la {} +
+            exit 1
+          fi
+          echo "libgodot.a integrity OK:"; find exports -name 'libgodot.a' -type f -exec ls -la {} +
+
           # Tar the export TREE (Xcode project + embedded libdclgodot.dylib + assets). The
           # deploy repo untars this and runs xcodebuild archive + manual sign.
           tar -czf export.tar.gz -C exports .

--- a/.github/workflows/ios_self_hosted.yml
+++ b/.github/workflows/ios_self_hosted.yml
@@ -166,20 +166,34 @@ jobs:
       # The persistent build cache above grows with every branch built and the VM has a single
       # disk shared by all iOS builds — without a guard it eventually fills and cargo dies
       # mid-link with "No space left on device". Prune the Rust caches (NOT .bin/, whose
-      # re-download is the expensive part) only when free space drops below the threshold;
+      # re-download is the expensive part) only when free space drops below MIN_FREE_GB;
       # the next build is cold (~30 min) but self-heals instead of failing.
-      - name: Disk guard — auto-prune build caches when low on space
+      #
+      # Pruning alone is not always enough. A cold rebuild (~9 GB) plus the iOS export tree
+      # (two ~2.3 GB unstripped libgodot.a static libs) needs real headroom. If we push on with
+      # too little disk, the export runs out of space mid-write, truncates libgodot.a to 0 bytes
+      # WITHOUT failing the Godot export, and a broken tarball ships to R2 — which then explodes
+      # downstream in godot-asc-deploy with `ld: file is empty in 'libgodot.a'`. So after pruning,
+      # hard-fail HERE (loudly, on the right job) when free disk is still below REQUIRED_FREE_GB.
+      # The real fix is to grow/clean the dcl-ios VM disk, then re-run.
+      - name: Disk guard — prune caches, fail early if disk is insufficient
         env:
           MIN_FREE_GB: "40"
+          REQUIRED_FREE_GB: "25"
         run: |
           free_gb=$(df -g . | awk 'NR==2 {print $4}')
-          echo "Runner free disk: ${free_gb} GB (threshold: ${MIN_FREE_GB} GB)"
+          echo "Runner free disk: ${free_gb} GB (prune threshold: ${MIN_FREE_GB} GB, required: ${REQUIRED_FREE_GB} GB)"
           if [ "$free_gb" -lt "$MIN_FREE_GB" ]; then
             echo "::warning::Low disk on iOS runner (${free_gb} GB free < ${MIN_FREE_GB} GB) — pruning Rust build caches; this build runs cold"
             du -sh lib/target target 2>/dev/null || true
             rm -rf lib/target target
             rm -rf "${TMPDIR:-/tmp}/"rustc* 2>/dev/null || true
-            df -g . | awk 'NR==2 {print "After prune: " $4 " GB free"}'
+            free_gb=$(df -g . | awk 'NR==2 {print $4}')
+            echo "After prune: ${free_gb} GB free"
+          fi
+          if [ "$free_gb" -lt "$REQUIRED_FREE_GB" ]; then
+            echo "::error::Insufficient disk on dcl-ios runner: ${free_gb} GB free (< ${REQUIRED_FREE_GB} GB required). The iOS export writes ~2x2.3 GB unstripped libgodot.a on top of a cold Rust rebuild; continuing would truncate libgodot.a to 0 bytes and silently upload a broken export (downstream: 'ld: file is empty in libgodot.a'). Grow or clean the dcl-ios VM disk, then re-run."
+            exit 1
           fi
 
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # @stable
@@ -298,6 +312,21 @@ jobs:
 
           echo "exports/ contents:"; ls -la exports/
           echo "dylibs found:"; find exports -name "*.dylib" 2>/dev/null || true
+
+          # Integrity gate: a disk-exhausted export truncates libgodot.a to 0 bytes but still
+          # exits 0, so the broken tree only blows up downstream in godot-asc-deploy at link
+          # time (`ld: file is empty in 'libgodot.a'`). Healthy libgodot.a is ~2.3 GB; treat a
+          # missing or <100 MB library as corrupt and refuse to upload it.
+          if [ -z "$(find exports -name 'libgodot.a' -type f)" ]; then
+            echo "❌ No libgodot.a found in export — the iOS export is incomplete, refusing to upload"
+            exit 1
+          fi
+          if find exports -name 'libgodot.a' -type f -size -100M | grep -q .; then
+            echo "❌ Truncated libgodot.a in export (likely disk exhaustion) — refusing to upload:"
+            find exports -name 'libgodot.a' -type f -size -100M -exec ls -la {} +
+            exit 1
+          fi
+          echo "libgodot.a integrity OK:"; find exports -name 'libgodot.a' -type f -exec ls -la {} +
 
           tar -czf export.tar.gz -C exports .
           echo "Export tarball size: $(du -h export.tar.gz | cut -f1)"


### PR DESCRIPTION
## Problem

The signed-iOS TestFlight deploy failed in `godot-asc-deploy` ([run 29260408730](https://github.com/decentraland/godot-asc-deploy/actions/runs/29260408730)) at the archive/link step:

```
ld: file is empty in '.../Release-iphoneos/libgodot.a'
** ARCHIVE FAILED **
```

That's a red herring against Xcode/signing. The real cause is upstream, in **this** repo's iOS export.

### Root cause

The export was produced by `ios_self_hosted.yml` on the disk-starved `dcl-ios` VM ([run 29256451266](https://github.com/decentraland/godot-explorer/actions/runs/29256451266), release `5f02ea88`), which **reported success** but shipped a broken artifact:

```
Runner free disk: 3 GB (threshold: 40 GB)
Low disk on iOS runner — pruning Rust build caches; this build runs cold
After prune: 12 GB free
ℹ️ Keeping iOS debug symbols   # libgodot.a stays ~2.3 GB
```

A healthy export writes **two ~2.3 GB unstripped `libgodot.a`** (device + simulator):

```
ADDING: .../ios-arm64/libgodot.a  size: 2307987016   # ~2.3 GB
ADDING: .../ios-arm64_x86_64-simulator/libgodot.a  size: 2160757752
```

With only ~12 GB free after the prune — consumed by a cold Rust rebuild (~9 GB) — the disk filled mid-export and `libgodot.a` was truncated to **0 bytes**. Godot did not treat the short write as fatal (exit 0), so the broken tree was tarred (only **600 MB** total — proof the library was empty) and uploaded to R2, then exploded downstream at link time.

Two gaps let this through silently:
1. The disk guard **pruned but always continued**, even when the recovered space was still insufficient.
2. The packaging step **never verified** `libgodot.a` before tar + upload.

## Fix

**`ios_self_hosted.yml` — disk guard now fails fast.** After pruning, hard-fail the job if free disk is still below `REQUIRED_FREE_GB` (25), with an actionable message. Better a loud, correctly-attributed failure on the iOS build than a silently-corrupted TestFlight upload 25 min later in another repo.

**`ios_self_hosted.yml` + `ios_r2_artifact.yml` — integrity gate before upload.** Refuse to upload if any `libgodot.a` in `exports/` is missing or `<100 MB` (healthy is ~2.3 GB). Deterministic backstop that catches a truncated export from **any** cause. (`ios_r2_artifact.yml` runs on a fresh cloud runner so it needs no disk guard, but it uploads to the same R2 keys, so it gets the same integrity gate.)

## Notes / follow-up

- The `REQUIRED_FREE_GB=25` floor sits between the known-bad (12 GB → failed) and known-good (≥40 GB) states; it's an env var, easy to retune once the VM disk is grown.
- **The durable fix is still to grow/clean the `dcl-ios` VM disk** — this PR converts the silent corruption into a clear, early failure and prevents a broken export from ever reaching R2.

## Testing

- Both workflows validate as YAML.
- Smoke-tested the integrity gate: a 0-byte `libgodot.a` → exit 1 (blocked); a healthy library → exit 0 (passes). `find -size -100M` + `set -eu` interaction confirmed safe on macOS.