### PR TITLE
fix(ui): update low memory modal copy to be less technical

### DIFF
--- a/godot/src/ui/components/organisms/modal/modal_manager.gd
+++ b/godot/src/ui/components/organisms/modal/modal_manager.gd
@@ -39,7 +39,7 @@ const SCENE_CRASH_PRIMARY = "RELOAD"
 const SCENE_CRASH_SECONDARY = "BACK"
 
 const LOW_MEMORY_TITLE = "Low memory"
-const LOW_MEMORY_BODY = "This place may not run smoothly on your device and could close unexpectedly. You can continue or go back to Discover."
+const LOW_MEMORY_BODY = "This place may not run smoothly on your device and could close unexpectedly."
 const LOW_MEMORY_PRIMARY = "CONTINUE"
 const LOW_MEMORY_SECONDARY = "BACK TO DISCOVER"
 

--- a/godot/src/ui/components/organisms/modal/modal_manager.gd
+++ b/godot/src/ui/components/organisms/modal/modal_manager.gd
@@ -38,9 +38,9 @@ const SCENE_CRASH_BODY = "This scene stopped working. Please reload or go back t
 const SCENE_CRASH_PRIMARY = "RELOAD"
 const SCENE_CRASH_SECONDARY = "BACK"
 
-const LOW_MEMORY_TITLE = "Running low on memory"
-const LOW_MEMORY_BODY = "This scene is using a lot of memory and might make the app close unexpectedly. You can continue anyway or go back to Discover."
-const LOW_MEMORY_PRIMARY = "CONTINUE ANYWAY"
+const LOW_MEMORY_TITLE = "Low memory"
+const LOW_MEMORY_BODY = "This place may not run smoothly on your device and could close unexpectedly. You can continue or go back to Discover."
+const LOW_MEMORY_PRIMARY = "CONTINUE"
 const LOW_MEMORY_SECONDARY = "BACK TO DISCOVER"
 
 const BAN_PRE_CHECK_TITLE = "You can't enter"


### PR DESCRIPTION
## What & why

The low-memory warning modal introduced in #2428 had copy that was a bit too technical for end users. This updates the wording per design feedback (Elizabeth) to be friendlier, more accessible, and less redundant with the buttons.

### Changes

| Element | Before | After |
|---------|--------|-------|
| Title | Running low on memory | Low memory |
| Body | This scene is using a lot of memory and might make the app close unexpectedly. You can continue anyway or go back to Discover. | This place may not run smoothly on your device and could close unexpectedly. |
| Primary button | CONTINUE ANYWAY | CONTINUE |
| Secondary button | BACK TO DISCOVER | BACK TO DISCOVER (unchanged) |

The trailing "You can continue or go back to Discover" sentence was dropped from the body — the buttons already communicate the choice, so it was redundant.

Closes #2527

Requested by Rodri via Slack