### PR TITLE
fix(realm): make SpawnPoint.default optional so worlds without it still load

### DIFF
--- a/lib/src/dcl/common/scene.rs
+++ b/lib/src/dcl/common/scene.rs
@@ -44,6 +44,10 @@ impl SpawnPosition {
 #[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct SpawnPoint {
     pub name: Option<String>,
+    // `default` is optional in the SDK scene schema; a spawn point without it is not the default.
+    // Without `#[serde(default)]`, a missing field aborts the whole scene-metadata parse, which
+    // silently drops the scene (e.g. pixelarcade.dcl.eth has a spawn point with no `default`).
+    #[serde(default)]
     pub default: bool,
     pub position: SpawnPosition,
 }


### PR DESCRIPTION
## Problem

Worlds/scenes fail to load silently when a scene's `spawnPoints` array contains an entry without a `default` field.

Reproduced with:
```
cargo run -- run -- --fake-deeplink "decentraland://open?realm=pixelarcade.dcl.eth" --emulate-android --only-no-optimized
```

The client logged:
```
ERROR: Error parsing scene data from entity ... : missing field `default`
```
…followed by a loading-screen timeout and no scene.

## Root cause

`SpawnPoint.default` was a required `bool` (no `#[serde(default)]`):

```rust
pub struct SpawnPoint {
    pub name: Option<String>,
    pub default: bool,          // required
    pub position: SpawnPosition,
}
```

In the SDK scene schema `spawnPoints[].default` is **optional**. `pixelarcade.dcl.eth` has two spawn points, and the second one (`SpawnArea2`) omits `default`. serde therefore fails to deserialize the whole `SceneEntityMetadata`, `SceneEntityDefinition::from_json_ex` returns `Err`, and `handle_scene_data` logs the error and returns **without caching the scene** — so the scene runner never receives a scene to spawn and the world never loads.

## Fix

Add `#[serde(default)]` to `SpawnPoint.default` — a missing field now deserializes to `false` (not the default spawn point), which is the correct semantics (`from_json_ex` picks the spawn point with `default == true`, falling back to the first).

This matches the reference client **bevy-explorer**, whose `SpawnPoint` struct already uses `#[serde(default)]` on exactly this field.

## Verification

Reran the same command after the fix:
- `Cached scene data for: bafkrei…nabzm (is_global=false)` — scene definition now parses & caches
- Scene runner opens an active session and enters the `Spawning` phase
- **24/24 assets loaded → `Scene SceneId(0) reported READY`**
- Scene runs its update loop, no crash, healthy for 60s+

Before the fix: parse error → no active session → loading timeout → empty world.