### PR TITLE
ci(android): don't fail fork-PR builds on APK signing / build-report comment

### DIFF
--- a/.github/workflows/android_builds.yml
+++ b/.github/workflows/android_builds.yml
@@ -151,15 +151,31 @@ jobs:
           mkdir -p android-debug-symbols
           cp godot/android/build/build/outputs/native-debug-symbols/standardRelease/native-debug-symbols.zip android-debug-symbols/ || true
 
-      # Decode and setup keystore for APK signing
-      - name: Setup APK Signing Keystore
+      # Re-sign the exported APK with the production distribution key so every published
+      # build shares one stable signing identity (Android requires the same key across
+      # upgrades). The export step above already signs the APK with an auto-generated
+      # keystore, so this is a re-sign — not the APK's only signature.
+      #
+      # Fork PRs don't receive repo secrets, so the keystore is unavailable there. In that
+      # case skip the re-sign and keep the export-signed APK — a valid, installable build
+      # for testing. Mirrors the graceful degradation of the R2-upload / build-number steps
+      # (an empty secret used to decode to a 0-byte keystore and hard-fail apksigner).
+      - name: Sign Android APK
+        env:
+          APK_ANDROID_KEYSTORE_BASE64: ${{ secrets.APK_ANDROID_KEYSTORE_BASE64 }}
+          APK_ANDROID_KEYSTORE_PASSWORD: ${{ secrets.APK_ANDROID_KEYSTORE_PASSWORD }}
         run: |
-          echo "${{ secrets.APK_ANDROID_KEYSTORE_BASE64 }}" | base64 -d > apk-release.keystore
+          if [ -z "$APK_ANDROID_KEYSTORE_BASE64" ]; then
+            echo "⚠️  APK signing keystore unavailable (fork PR — repo secrets are not exposed to forks)."
+            echo "    Keeping the APK as signed by the Godot export step; production re-signing runs"
+            echo "    only on same-repo branches (main/release and internal PRs)."
+            exit 0
+          fi
+
+          # Decode the production release keystore from the secret.
+          echo "$APK_ANDROID_KEYSTORE_BASE64" | base64 -d > apk-release.keystore
           ls -la apk-release.keystore
 
-      # Sign the APK file
-      - name: Sign Android APK
-        run: |
           # Find Android build-tools
           BUILD_TOOLS_DIR=$(ls -d $ANDROID_HOME/build-tools/*/ | sort -V | tail -1)
           echo "Using build-tools: $BUILD_TOOLS_DIR"
@@ -169,7 +185,7 @@ jobs:
 
           # Sign the APK
           ${BUILD_TOOLS_DIR}apksigner sign --ks apk-release.keystore \
-            --ks-pass pass:"${{ secrets.APK_ANDROID_KEYSTORE_PASSWORD }}" \
+            --ks-pass pass:"$APK_ANDROID_KEYSTORE_PASSWORD" \
             --out exports/decentraland.godot.client-signed.apk \
             exports/decentraland.godot.client-aligned.apk
 
@@ -490,8 +506,13 @@ jobs:
             echo "🔄 **Updated**: $(date -u +'%Y-%m-%d %H:%M:%S UTC')"
           } > build-report.md
 
+      # On fork PRs the GITHUB_TOKEN is read-only regardless of the declared
+      # `pull-requests: write` permission, so posting the comment fails with "Resource not
+      # accessible by integration". Let it fail soft: the comment just won't appear on fork
+      # PRs, but the Android build itself must not be marked failed because of it.
       - name: Comment PR with Build Report
         if: github.event_name == 'pull_request' && always()
+        continue-on-error: true
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           header: build-report


### PR DESCRIPTION
## Problem

The **Android** CI job hard-fails on **every fork PR**, unrelated to the PR's own contents (surfaced by #2517, a fork PR from `eordano`).

Fork PRs don't receive repository secrets, so `APK_ANDROID_KEYSTORE_BASE64` is empty. The signing step ran `echo "" | base64 -d > apk-release.keystore`, producing a **0-byte keystore**, and `apksigner` then died with:

```
Failed to load signer "signer #1"
java.io.IOException: Tag number over 30 is not supported
##[error]Process completed with exit code 2.
```

Separately, the build-report comment step also errors on fork PRs because the fork's `GITHUB_TOKEN` is read-only regardless of the declared `pull-requests: write` (`Resource not accessible by integration`).

## Fix

- **Sign Android APK** — skip the production re-sign when the keystore secret is empty (fork PR), keeping the APK **already signed by the Godot export step** (`export_presets.cfg` has `package/signed=true`; `export.rs` feeds it an auto-generated keystore). The result is still a valid, installable build for testing. The password is now read from `env` instead of being inlined into the script. Same-repo branches (`main`/`release` and internal PRs) re-sign with the production key **exactly as before**.
- **Comment PR with Build Report** — `continue-on-error: true` so a read-only fork token can't fail the build; the comment just won't appear on fork PRs.

This mirrors the graceful fork-PR degradation already used by the **R2-upload** and **build-number** steps in the same workflow.

## Impact / safety

- Same-repo builds (`main`, `release`, internal PRs): **no behavior change** — the real secret is present, so the APK is re-signed with the production distribution key as today.
- Fork PRs: the Android job now goes green with an export-signed APK (uploaded as a GitHub Actions artifact; R2 upload remains skipped since those secrets are also absent on forks).

## Test plan

- [ ] Fork PR: Android job completes; "Sign Android APK" logs the skip message; APK artifact is present.
- [ ] Same-repo PR / `main`: APK is re-signed with the production key and verified (unchanged path).