### PR TITLE
fix: truncate scene name in event detail to prevent overflow

### DIFF
--- a/godot/src/ui/components/molecules/place_item/place_item.gd
+++ b/godot/src/ui/components/molecules/place_item/place_item.gd
@@ -383,7 +383,7 @@ func set_location(_location: Vector2i):
 func set_scene_event_name(scene_name: String) -> void:
 	var event_location_name = _get_label_event_location_name()
 	if event_location_name:
-		event_location_name.text = scene_name
+		event_location_name.text = format_name(scene_name, 30)
 
 
 func set_world(world: String, unlimited: bool = false):

--- a/godot/src/ui/pages/events/event_details_portrait.tscn
+++ b/godot/src/ui/pages/events/event_details_portrait.tscn
@@ -118,6 +118,8 @@ font = ExtResource("6_ds20p")
 font_size = 22
 font_color = Color(0.9098039, 0.7254902, 1, 1)
 
+[sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_ikdkm"]
+
 [sub_resource type="LabelSettings" id="LabelSettings_hxdex"]
 font = ExtResource("19_gpni3")
 font_size = 30
@@ -547,6 +549,11 @@ layout_mode = 2
 size_flags_horizontal = 3
 text = "(37,-4)"
 label_settings = SubResource("LabelSettings_ygmng")
+
+[node name="VSeparator" type="VSeparator" parent="Control_Card/PanelContainer_Card/PanelContainer_Content/SafeMarginContainer/MarginContainer/ScrollDescription/VBoxContainer/VBoxContainer_Description/MarginContainer/HBoxContainer" unique_id=1594307813]
+layout_mode = 2
+theme_override_constants/separation = 12
+theme_override_styles/separator = SubResource("StyleBoxEmpty_ikdkm")
 
 [node name="Button_JumpToEventSmall" type="Button" parent="Control_Card/PanelContainer_Card/PanelContainer_Content/SafeMarginContainer/MarginContainer/ScrollDescription/VBoxContainer/VBoxContainer_Description/MarginContainer/HBoxContainer" unique_id=1207726274]
 unique_name_in_owner = true

--- a/godot/src/ui/pages/events/event_details_portrait.tscn
+++ b/godot/src/ui/pages/events/event_details_portrait.tscn
@@ -118,8 +118,6 @@ font = ExtResource("6_ds20p")
 font_size = 22
 font_color = Color(0.9098039, 0.7254902, 1, 1)
 
-[sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_ikdkm"]
-
 [sub_resource type="LabelSettings" id="LabelSettings_hxdex"]
 font = ExtResource("19_gpni3")
 font_size = 30
@@ -549,11 +547,6 @@ layout_mode = 2
 size_flags_horizontal = 3
 text = "(37,-4)"
 label_settings = SubResource("LabelSettings_ygmng")
-
-[node name="VSeparator" type="VSeparator" parent="Control_Card/PanelContainer_Card/PanelContainer_Content/SafeMarginContainer/MarginContainer/ScrollDescription/VBoxContainer/VBoxContainer_Description/MarginContainer/HBoxContainer" unique_id=1594307813]
-layout_mode = 2
-theme_override_constants/separation = 12
-theme_override_styles/separator = SubResource("StyleBoxEmpty_ikdkm")
 
 [node name="Button_JumpToEventSmall" type="Button" parent="Control_Card/PanelContainer_Card/PanelContainer_Content/SafeMarginContainer/MarginContainer/ScrollDescription/VBoxContainer/VBoxContainer_Description/MarginContainer/HBoxContainer" unique_id=1207726274]
 unique_name_in_owner = true


### PR DESCRIPTION
Fix #2485

## Summary
- Truncates the scene/place name in event detail cards using the existing `format_name(..., 30)` helper to prevent long titles from overflowing the visible area

## Test plan
- Open the event detail for "HODL National Park Climb and 'Vertical Voyager' Badge Unlock!"
- Verify the scene name in the detail card is truncated and no longer overflows the container
- Verify the rest of the card layout (image, title, buttons, pills) renders correctly