### PR TITLE
Release Candidate 1.11.1

### DIFF
--- a/godot/export_presets.cfg
+++ b/godot/export_presets.cfg
@@ -42,7 +42,7 @@ architectures/x86=false
 architectures/x86_64=true
 ; placeholder — the real store versionCode is stamped at export time from DCL_BUILD_NUMBER (Cloudflare Worker allocator); this committed value never ships
 version/code=1
-version/name="1.11.0"
+version/name="1.11.1"
 package/unique_name="org.decentraland.godotexplorer"
 package/name="Decentraland"
 package/signed=true
@@ -295,7 +295,7 @@ application/provisioning_profile_specifier_release=""
 application/export_method_release=1
 application/bundle_identifier="org.decentraland.godotexplorer"
 application/signature=""
-application/short_version="1.11.0"
+application/short_version="1.11.1"
 ; placeholder — the real CFBundleVersion is stamped at export time from DCL_BUILD_NUMBER (Cloudflare Worker allocator); this committed value never ships
 application/version="1"
 application/additional_plist_content="	<key>CFBundleURLTypes</key>

--- a/godot/src/ui/components/molecules/guest_upgrade_card/guest_upgrade_card.tscn
+++ b/godot/src/ui/components/molecules/guest_upgrade_card/guest_upgrade_card.tscn
@@ -74,7 +74,7 @@ theme_override_styles/separator = SubResource("StyleBoxEmpty_qvy7f")
 custom_minimum_size = Vector2(0, 10)
 layout_mode = 2
 size_flags_vertical = 1
-text = "Add email to play across mobile and desktop, and claim an exclusive wearable."
+text = "Add email to play across mobile and desktop."
 label_settings = SubResource("LabelSettings_vwd20")
 autowrap_mode = 2
 

--- a/lib/Cargo.lock
+++ b/lib/Cargo.lock
@@ -861,7 +861,7 @@ dependencies = [
 
 [[package]]
 name = "dclgodot"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dclgodot"
-version = "1.11.0"
+version = "1.11.1"
 edition = "2021"
 publish = false
 


### PR DESCRIPTION
## Release Candidate 1.11.1

Hotfix release candidate off `release`.

### Version
- Bump app version `1.11.0` → `1.11.1` (`lib/Cargo.toml`, `lib/Cargo.lock`, `godot/export_presets.cfg` — `version/name` + `application/short_version`). Build/version codes left as placeholders (stamped at export time from `DCL_BUILD_NUMBER`).

### Hotfix — #2549
- Simplify the guest account-upgrade card copy: drop the "and claim an exclusive wearable" clause.
  - Before: `Add email to play across mobile and desktop, and claim an exclusive wearable.`
  - After: `Add email to play across mobile and desktop.`

Closes #2549