### PR TITLE
feat(analytics): track guest wallet creation to Segment

### DIFF
--- a/godot/src/logic/metrics/analytics_controller.gd
+++ b/godot/src/logic/metrics/analytics_controller.gd
@@ -46,6 +46,7 @@ func setup() -> void:
 	# (lobby's handler is what calls `metrics.update_identity`, so `common.dcl_eth_address` is
 	# stale at this point). We connect here in Global._ready, before the lobby scene loads.
 	Global.player_identity.wallet_connected.connect(_on_wallet_connected_track_login)
+	Global.player_identity.guest_login_outcome.connect(_on_guest_login_outcome)
 	Global.loading_started.connect(_on_loading_started)
 	Global.loading_finished.connect(_on_loading_finished)
 
@@ -81,6 +82,20 @@ func _on_wallet_connected_track_login(
 	if Global.metrics == null:
 		return
 	Global.metrics.track_login(address, is_guest_value)
+
+
+## Forwards each silent thirdweb guest-login attempt to Segment as a "Guest Wallet Creation"
+## event (see SegmentEventGuestWalletCreation). Emitted by DclPlayerIdentity from the login
+## task; not gated on session recovery — a recovered session doesn't re-run guest_login, so
+## this only fires on genuine attempts. The EULA consent gate in Metrics still applies.
+func _on_guest_login_outcome(
+	outcome: String, is_new_user: bool, failure_reason: String, http_status: int, duration_ms: int
+) -> void:
+	if Global.metrics == null:
+		return
+	Global.metrics.track_guest_wallet_creation(
+		outcome, is_new_user, failure_reason, http_status, duration_ms
+	)
 
 
 func _on_loading_started() -> void:

--- a/lib/src/analytics/data_definition.rs
+++ b/lib/src/analytics/data_definition.rs
@@ -78,6 +78,7 @@ pub enum SegmentEvent {
     // discriminated by `type` and correlated across one full load by `loading_id`
     // (see SegmentEventLoading). Boxed: it is the largest variant by far.
     Loading(Box<SegmentEventLoading>),
+    GuestWalletCreation(SegmentEventGuestWalletCreation),
 }
 
 /// Cross-system correlation anchor. The ONLY Segment event that carries the Firebase Analytics
@@ -627,6 +628,36 @@ pub struct SegmentEventAttestationSessionCacheLoaded {
     pub remaining_s: Option<i64>,
 }
 
+// Emitted once per silent thirdweb guest-login attempt (see
+// auth/thirdweb_guest.rs). One event per attempt — the dashboard computes:
+//   - success rate    = count(outcome="success") / count(*)
+//   - wallets created  = count(outcome="success" AND is_new_user=true)
+//   - top failure     = group_by(failure_reason) where outcome="failure"
+//   - service down     = a spike in failure_reason in ("http_5xx","timeout","network")
+//
+// This is the guest-flow analog of SegmentEventAttestationAttempt and, unlike
+// AUTH_SUCCESS (a "Screen Viewed" whose login_type is a nested JSON string),
+// exposes every dimension as a first-class property.
+#[derive(Serialize, Clone)]
+pub struct SegmentEventGuestWalletCreation {
+    // "success" | "failure".
+    pub outcome: String,
+    // Whether thirdweb minted a NEW wallet for this session (true) or returned
+    // the existing wallet for a returning device anchor (false). Only
+    // meaningful on success; always false on failure.
+    pub is_new_user: bool,
+    // Failure bucket: "http_4xx" | "http_5xx" | "timeout" | "network" |
+    // "bad_response" | "invalid_address" | "sign_message" | "ephemeral".
+    // None on success.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub failure_reason: Option<String>,
+    // Upstream HTTP status when the failure was an HTTP error. None otherwise.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub http_status: Option<u32>,
+    // Wall-clock duration of the whole attempt, in milliseconds.
+    pub duration_ms: u32,
+}
+
 pub fn build_segment_event_batch_item(
     user_id: String,
     common: &SegmentEventCommonExplorerFields,
@@ -728,6 +759,11 @@ pub fn build_segment_event_batch_item(
         SegmentEvent::Loading(event) => (
             "Loading Event".to_string(),
             serde_json::to_value(*event).unwrap(),
+            None,
+        ),
+        SegmentEvent::GuestWalletCreation(event) => (
+            "Guest Wallet Creation".to_string(),
+            serde_json::to_value(event).unwrap(),
             None,
         ),
     };

--- a/lib/src/analytics/metrics.rs
+++ b/lib/src/analytics/metrics.rs
@@ -26,8 +26,9 @@ use super::{
         SegmentEventAttestationAttempt, SegmentEventAttestationSessionCacheLoaded,
         SegmentEventBlockUser, SegmentEventChatMessageSent, SegmentEventClickButton,
         SegmentEventCommonExplorerFields, SegmentEventExplorerMoveToParcel,
-        SegmentEventFirebaseInit, SegmentEventIosStoreKitEnvironment, SegmentEventLoading,
-        SegmentEventRequestFriend, SegmentEventScreenViewed, SegmentEventUnfriend,
+        SegmentEventFirebaseInit, SegmentEventGuestWalletCreation,
+        SegmentEventIosStoreKitEnvironment, SegmentEventLoading, SegmentEventRequestFriend,
+        SegmentEventScreenViewed, SegmentEventUnfriend,
     },
     frame::Frame,
     install_referrer::InstallReferrer,
@@ -528,6 +529,40 @@ impl Metrics {
             session_ttl_s: opt_i64(5),
         });
         self.queue_event("Attestation Attempt", event);
+    }
+
+    /// One per silent thirdweb guest-login attempt. See
+    /// data_definition::SegmentEventGuestWalletCreation for field meanings.
+    ///
+    /// GDScript-friendly sentinels (gdext doesn't surface Option<T> across FFI):
+    ///   - `failure_reason`: empty string ("") == None (success path).
+    ///   - `http_status`: -1 == None.
+    ///   - `duration_ms`: clamped to >= 0.
+    #[func]
+    pub fn track_guest_wallet_creation(
+        &mut self,
+        outcome: String,
+        is_new_user: bool,
+        failure_reason: String,
+        http_status: i64,
+        duration_ms: i64,
+    ) {
+        let event = SegmentEvent::GuestWalletCreation(SegmentEventGuestWalletCreation {
+            outcome,
+            is_new_user,
+            failure_reason: if failure_reason.is_empty() {
+                None
+            } else {
+                Some(failure_reason)
+            },
+            http_status: if http_status < 0 {
+                None
+            } else {
+                Some(http_status as u32)
+            },
+            duration_ms: duration_ms.max(0) as u32,
+        });
+        self.queue_event("Guest Wallet Creation", event);
     }
 
     /// Boot-time cache probe event. `remaining_s` is -1 (becomes None) for any

--- a/lib/src/auth/dcl_player_identity.rs
+++ b/lib/src/auth/dcl_player_identity.rs
@@ -2,7 +2,7 @@ use ethers_core::types::H160;
 use ethers_signers::LocalWallet;
 use godot::prelude::*;
 use rand::thread_rng;
-use std::time::UNIX_EPOCH;
+use std::time::{Instant, UNIX_EPOCH};
 use tokio::task::JoinHandle;
 
 use crate::avatars::dcl_user_profile::DclUserProfile;
@@ -97,6 +97,22 @@ impl DclPlayerIdentity {
 
     #[signal]
     fn auth_error(error_message: GString);
+
+    /// One per silent thirdweb guest-login attempt, for analytics. `outcome` is
+    /// "success" | "failure". On success `failure_reason` is "" and `http_status`
+    /// is -1; `is_new_user` says whether a NEW wallet was minted. On failure
+    /// `failure_reason` is a stable code (see thirdweb_guest::GuestLoginError)
+    /// and `http_status` is the upstream status or -1. `duration_ms` is the
+    /// whole attempt's wall-clock time. Emitted deferred from the login task so
+    /// GDScript (analytics_controller.gd) can forward it to Segment.
+    #[signal]
+    fn guest_login_outcome(
+        outcome: GString,
+        is_new_user: bool,
+        failure_reason: GString,
+        http_status: i64,
+        duration_ms: i64,
+    );
 
     #[func]
     fn try_set_remote_wallet(
@@ -265,21 +281,25 @@ impl DclPlayerIdentity {
         let anchor_input = device_anchor_id.to_string();
 
         handle.spawn(async move {
+            let started = Instant::now();
             let result = perform_thirdweb_guest_login(anchor_input).await;
+            let duration_ms = started.elapsed().as_millis() as i64;
             let Some(mut promise) = get_promise() else {
                 tracing::error!("thirdweb guest_login: promise dropped");
                 return;
             };
 
+            // Reused by both arms to reach the node on the main thread: the
+            // success arm installs the wallet, and both emit the analytics signal.
+            let mut identity = Gd::<DclPlayerIdentity>::try_from_instance_id(instance_id).ok();
+
             match result {
-                Ok((address, ephemeral_auth_chain)) => {
-                    let address_str = format!("{:#x}", address);
-                    let ephemeral_chain_json = serde_json::to_string(&ephemeral_auth_chain)
+                Ok(outcome) => {
+                    let address_str = format!("{:#x}", outcome.address);
+                    let ephemeral_chain_json = serde_json::to_string(&outcome.chain)
                         .expect("serialize ephemeral auth chain");
 
-                    if let Ok(mut identity) =
-                        Gd::<DclPlayerIdentity>::try_from_instance_id(instance_id)
-                    {
+                    if let Some(identity) = identity.as_mut() {
                         // Thirdweb wallets are real custodial wallets — same model
                         // as WalletConnect / Apple / Google as far as Decentraland
                         // is concerned. The thirdweb "guest" label is just the auth
@@ -297,6 +317,17 @@ impl DclPlayerIdentity {
                         // deferred) wallet install, which resets it to `false`.
                         // Both run on the main thread in submission order.
                         identity.call_deferred("_set_thirdweb_guest_flag", &[true.to_variant()]);
+                        identity.call_deferred(
+                            "emit_signal",
+                            &[
+                                "guest_login_outcome".to_variant(),
+                                "success".to_variant(),
+                                outcome.is_new_user.to_variant(),
+                                GString::from("").to_variant(),
+                                (-1_i64).to_variant(),
+                                duration_ms.to_variant(),
+                            ],
+                        );
                     }
 
                     promise
@@ -305,6 +336,19 @@ impl DclPlayerIdentity {
                 }
                 Err(e) => {
                     tracing::error!("thirdweb guest_login failed: {:?}", e);
+                    if let Some(identity) = identity.as_mut() {
+                        identity.call_deferred(
+                            "emit_signal",
+                            &[
+                                "guest_login_outcome".to_variant(),
+                                "failure".to_variant(),
+                                false.to_variant(),
+                                e.reason.to_variant(),
+                                e.http_status.map(i64::from).unwrap_or(-1).to_variant(),
+                                duration_ms.to_variant(),
+                            ],
+                        );
+                    }
                     promise
                         .bind_mut()
                         .reject(GString::from(&format!("Guest login failed: {}", e)));
@@ -1282,9 +1326,18 @@ impl DclPlayerIdentity {
 /// usual ~30 day window. The thirdweb JWT itself is dropped after step 5 —
 /// every cold start re-runs steps 1–6 (idempotent because the anchor is
 /// stable, so thirdweb returns the same wallet address).
+/// Successful outcome of the guest-login flow. Carries `is_new_user` so
+/// analytics can tell a freshly minted wallet apart from a returning anchor
+/// re-logging into its existing wallet ("wallets created" = new mints only).
+struct GuestLoginOutcome {
+    address: H160,
+    chain: EphemeralAuthChain,
+    is_new_user: bool,
+}
+
 async fn perform_thirdweb_guest_login(
     device_anchor_id: String,
-) -> Result<(H160, EphemeralAuthChain), anyhow::Error> {
+) -> Result<GuestLoginOutcome, thirdweb_guest::GuestLoginError> {
     let anchor = device_anchor::resolve_anchor(&device_anchor_id);
     let session_id = device_anchor::compute_session_id(&anchor);
 
@@ -1292,13 +1345,21 @@ async fn perform_thirdweb_guest_login(
 
     let (ephemeral_message, ephemeral_keys, expiration) = generate_ephemeral_for_signing();
 
+    // The wallet already exists server-side at this point; a signing failure
+    // still fails the login, but under its own reason so the dashboard doesn't
+    // misattribute it to wallet creation.
     let signature_hex = thirdweb_guest::sign_message(
         &session.token,
         session.wallet_address,
         1,
         &ephemeral_message,
     )
-    .await?;
+    .await
+    .map_err(|e| thirdweb_guest::GuestLoginError {
+        reason: "sign_message",
+        http_status: None,
+        message: e.to_string(),
+    })?;
 
     let signer_address_str = format!("{:#x}", session.wallet_address);
     let chain = create_ephemeral_from_external_signature(
@@ -1307,7 +1368,12 @@ async fn perform_thirdweb_guest_login(
         &ephemeral_keys,
         expiration,
         &ephemeral_message,
-    )?;
+    )
+    .map_err(|e| thirdweb_guest::GuestLoginError {
+        reason: "ephemeral",
+        http_status: None,
+        message: e.to_string(),
+    })?;
 
     // Persist the JWT so future cold starts can renew the ephemeral
     // delegation without re-running `guest_login`. Failure is non-fatal:
@@ -1319,7 +1385,11 @@ async fn perform_thirdweb_guest_login(
         );
     }
 
-    Ok((session.wallet_address, chain))
+    Ok(GuestLoginOutcome {
+        address: session.wallet_address,
+        chain,
+        is_new_user: session.is_new_user,
+    })
 }
 
 /// Runs the "Upgrade to OTP" link end-to-end:

--- a/lib/src/auth/thirdweb_guest.rs
+++ b/lib/src/auth/thirdweb_guest.rs
@@ -102,6 +102,48 @@ pub struct ThirdwebGuestSession {
     pub is_new_user: bool,
 }
 
+/// Typed failure for `guest_login`, carrying a machine-stable `reason` code so
+/// analytics can bucket outcomes without parsing free-form error strings (the
+/// `?`/`anyhow` boundary erases whether a failure was a timeout, a network
+/// error, or an HTTP status). Implements `std::error::Error` so existing
+/// `anyhow`-based callers keep working via `?` / `Into`.
+#[derive(Debug)]
+pub struct GuestLoginError {
+    /// A machine-stable code. This function produces "http_4xx", "http_5xx",
+    /// "timeout", "network", "bad_response" or "invalid_address"; later steps
+    /// of the guest-login flow (see `perform_thirdweb_guest_login`) may also
+    /// construct this error with "sign_message" or "ephemeral". Kept as a
+    /// `&'static str` so the vocabulary is fixed at the call site.
+    pub reason: &'static str,
+    /// Upstream HTTP status when `reason` is "http_4xx"/"http_5xx". None otherwise.
+    pub http_status: Option<u16>,
+    /// Human-readable detail for logs (may include the upstream body). Not for
+    /// analytics grouping — use `reason`.
+    pub message: String,
+}
+
+impl std::fmt::Display for GuestLoginError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self.http_status {
+            Some(status) => write!(f, "{} (status={}): {}", self.reason, status, self.message),
+            None => write!(f, "{}: {}", self.reason, self.message),
+        }
+    }
+}
+
+impl std::error::Error for GuestLoginError {}
+
+/// Classifies a reqwest transport error (no HTTP response was produced) into a
+/// stable `reason` code. Status-based codes are handled separately by the
+/// caller, which has the response in hand.
+fn classify_reqwest_error(e: &reqwest::Error) -> &'static str {
+    if e.is_timeout() {
+        "timeout"
+    } else {
+        "network"
+    }
+}
+
 const SESSION_PATH: &str = "user://thirdweb_session.json";
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -163,7 +205,7 @@ pub fn load_session_from_disk() -> Option<ThirdwebGuestSession> {
 
 /// Logs in as a guest with a deterministic session id. The same session id
 /// always returns the same wallet address (server-side, custodial).
-pub async fn guest_login(session_id: &str) -> Result<ThirdwebGuestSession, anyhow::Error> {
+pub async fn guest_login(session_id: &str) -> Result<ThirdwebGuestSession, GuestLoginError> {
     let url = format!("{}/v1/auth/complete", THIRDWEB_API_BASE);
     let body = GuestLoginRequest {
         method: "guest",
@@ -176,33 +218,57 @@ pub async fn guest_login(session_id: &str) -> Result<ThirdwebGuestSession, anyho
         url
     );
 
-    let response = reqwest::Client::builder()
+    let client = reqwest::Client::builder()
         .timeout(REQUEST_TIMEOUT)
-        .build()?
+        .build()
+        .map_err(|e| GuestLoginError {
+            reason: "network",
+            http_status: None,
+            message: format!("client build failed: {e}"),
+        })?;
+
+    let response = client
         .post(&url)
         .header("x-client-id", THIRDWEB_CLIENT_ID)
         .header("Origin", THIRDWEB_ALLOWED_ORIGIN)
         .header("Content-Type", "application/json")
         .json(&body)
         .send()
-        .await?;
+        .await
+        .map_err(|e| GuestLoginError {
+            reason: classify_reqwest_error(&e),
+            http_status: None,
+            message: e.to_string(),
+        })?;
 
     let status = response.status();
     if !status.is_success() {
         let text = response.text().await.unwrap_or_default();
-        return Err(anyhow::anyhow!(
-            "thirdweb guest_login failed: status={}, body={}",
-            status,
-            text
-        ));
+        return Err(GuestLoginError {
+            reason: if status.is_server_error() {
+                "http_5xx"
+            } else {
+                "http_4xx"
+            },
+            http_status: Some(status.as_u16()),
+            message: format!("status={status}, body={text}"),
+        });
     }
 
-    let parsed: GuestLoginResponse = response.json().await?;
+    let parsed: GuestLoginResponse = response.json().await.map_err(|e| GuestLoginError {
+        reason: "bad_response",
+        http_status: Some(status.as_u16()),
+        message: format!("failed to parse response body: {e}"),
+    })?;
     let address = parsed
         .wallet_address
         .as_str()
         .as_h160()
-        .ok_or_else(|| anyhow::anyhow!("thirdweb returned invalid wallet address"))?;
+        .ok_or_else(|| GuestLoginError {
+            reason: "invalid_address",
+            http_status: None,
+            message: "thirdweb returned invalid wallet address".into(),
+        })?;
 
     tracing::info!(
         "thirdweb guest_login: success, address={:#x}, is_new_user={}",
@@ -291,7 +357,7 @@ pub async fn refresh_guest_session(
 ) -> Result<ThirdwebGuestSession, anyhow::Error> {
     let anchor = super::device_anchor::resolve_anchor(device_anchor_id);
     let session_id = super::device_anchor::compute_session_id(&anchor);
-    guest_login(&session_id).await
+    guest_login(&session_id).await.map_err(anyhow::Error::from)
 }
 
 /// Call A — sends a one-time code to `email`. No auth token required; the


### PR DESCRIPTION
Adds a dedicated `Guest Wallet Creation` Segment event, emitted once per thirdweb guest-login attempt, so the guest-wallet stability dashboard can be built downstream in Segment.

First-class properties: `outcome` (success/failure), `is_new_user` (new mint vs returning anchor), `failure_reason`, `http_status`, `duration_ms`.

Verified on an Android device: success path, failure path (offline → `network`), and retry-buffer drain on reconnect.

Closes #2415


# Test Plan
Since it's only analytics/metrics related, there is no in-app validation needed.


# Next Step
- [ ] Prepare dashboard with consuming this data.
