### PR TITLE
chore: reconcile release (1.11.1) into main + forward version to 1.12.0

### DIFF
--- a/godot/export_presets.cfg
+++ b/godot/export_presets.cfg
@@ -42,7 +42,7 @@ architectures/x86=false
 architectures/x86_64=true
 ; placeholder — the real store versionCode is stamped at export time from DCL_BUILD_NUMBER (Cloudflare Worker allocator); this committed value never ships
 version/code=1
-version/name="1.11.1"
+version/name="1.12.0"
 package/unique_name="org.decentraland.godotexplorer"
 package/name="Decentraland"
 package/signed=true
@@ -295,7 +295,7 @@ application/provisioning_profile_specifier_release=""
 application/export_method_release=1
 application/bundle_identifier="org.decentraland.godotexplorer"
 application/signature=""
-application/short_version="1.11.1"
+application/short_version="1.12.0"
 ; placeholder — the real CFBundleVersion is stamped at export time from DCL_BUILD_NUMBER (Cloudflare Worker allocator); this committed value never ships
 application/version="1"
 application/additional_plist_content="	<key>CFBundleURLTypes</key>

--- a/godot/export_presets.cfg
+++ b/godot/export_presets.cfg
@@ -42,7 +42,7 @@ architectures/x86=false
 architectures/x86_64=true
 ; placeholder — the real store versionCode is stamped at export time from DCL_BUILD_NUMBER (Cloudflare Worker allocator); this committed value never ships
 version/code=1
-version/name="1.11.0"
+version/name="1.11.1"
 package/unique_name="org.decentraland.godotexplorer"
 package/name="Decentraland"
 package/signed=true
@@ -295,7 +295,7 @@ application/provisioning_profile_specifier_release=""
 application/export_method_release=1
 application/bundle_identifier="org.decentraland.godotexplorer"
 application/signature=""
-application/short_version="1.11.0"
+application/short_version="1.11.1"
 ; placeholder — the real CFBundleVersion is stamped at export time from DCL_BUILD_NUMBER (Cloudflare Worker allocator); this committed value never ships
 application/version="1"
 application/additional_plist_content="	<key>CFBundleURLTypes</key>

--- a/godot/src/ui/components/molecules/guest_upgrade_card/guest_upgrade_card.tscn
+++ b/godot/src/ui/components/molecules/guest_upgrade_card/guest_upgrade_card.tscn
@@ -74,7 +74,7 @@ theme_override_styles/separator = SubResource("StyleBoxEmpty_qvy7f")
 custom_minimum_size = Vector2(0, 10)
 layout_mode = 2
 size_flags_vertical = 1
-text = "Add email to play across mobile and desktop, and claim an exclusive wearable."
+text = "Add email to play across mobile and desktop."
 label_settings = SubResource("LabelSettings_vwd20")
 autowrap_mode = 2
 

--- a/godot/src/ui/components/molecules/tip_card/tip_card.gd
+++ b/godot/src/ui/components/molecules/tip_card/tip_card.gd
@@ -3,7 +3,7 @@ extends PanelContainer
 
 const TIPS: Array[String] = [
 	"Wearables shape how you appear over time. Made by the community.",
-	"Use Emotes to wave, react, or celebrate. Press B to open the Emote Wheel.",
+	"Use Emotes to wave, react, or celebrate. Tap the Emote icon to open the Emote Wheel.",
 	"Use the Creator Hub to build your own places and experiences.",
 	"Decentraland is better with friends. Meet new people and see where they’re hanging out."
 ]

--- a/lib/Cargo.lock
+++ b/lib/Cargo.lock
@@ -861,7 +861,7 @@ dependencies = [
 
 [[package]]
 name = "dclgodot"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/lib/Cargo.lock
+++ b/lib/Cargo.lock
@@ -861,7 +861,7 @@ dependencies = [
 
 [[package]]
 name = "dclgodot"
-version = "1.11.1"
+version = "1.12.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dclgodot"
-version = "1.11.1"
+version = "1.12.0"
 edition = "2021"
 publish = false
 

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dclgodot"
-version = "1.11.0"
+version = "1.11.1"
 edition = "2021"
 publish = false
 


### PR DESCRIPTION
## What

Back-merge of `release` (**1.11.1**) into `main`, then forward the marketing version to **1.12.0**. Two commits:

1. **Merge `release` into `main`** — brings the 1.11.1 hotfix back while **preserving release's commit SHAs** (`#2549` `0887a52d`, release merge `50d17bb2`). The only net content is the guest-upgrade copy fix. The version-bearing files are resolved to release's `1.11.1` in the merge so the 1.11.1 change lands intact.
2. **`chore(release): forward version to 1.12.0`** — re-bumps `Cargo.toml`, `Cargo.lock`, and `export_presets.cfg` back to `1.12.0` so `main` stays ahead for the next release cycle.

> **Note (2026-07-20):** `release` was re-signed to GPG-sign a previously unsigned commit (`b2378463` → `65b9ffe0`), which rewrote its tip SHAs. This PR was rebuilt to merge the **re-signed** `release` tip (`50d17bb2`), so the SHAs above are the signed ones — net content is unchanged.

## Net effect on `main`

- **`guest_upgrade_card.tscn`** — drops the "and claim an exclusive wearable" line from the guest-upgrade copy (#2549).
- **Version** — no net change: `main` was already `1.12.0` (bumped in #2499); the merge dips it to `1.11.1` then commit 2 restores `1.12.0`.
- The `tip_card.gd` emote-wheel tip (#2520) already landed independently on `main`, so it auto-merged with no change.

Net diff vs `main`: **1 line** in `guest_upgrade_card.tscn`.

## Why a merge (not cherry-pick)

`main` and `release` had diverged. A true merge makes `main` a descendant of `release`, so after landing `main..release` is **empty** — the branches are genuinely reconciled and the 1.11.1 fix won't reappear in the next reconcile. This matches the repo convention (#2455, #2263, v67).

## ⚠️ Merge method

**Land with "Create a merge commit" — do NOT squash.** Squashing mints new SHAs and reintroduces phantom divergence between `main` and `release`.
