### PR TITLE
fix: Animator loop parameter not respected on mobile (#2497)

### DIFF
--- a/lib/src/godot_classes/animator_controller.rs
+++ b/lib/src/godot_classes/animator_controller.rs
@@ -671,10 +671,17 @@ pub fn apply_anims(gltf_container_node: Gd<Node3D>, value: &PbAnimator) {
             if let Some(clip_name) = resolved_clip {
                 let anim_name = StringName::from(&clip_name);
                 anim_player.set_speed_scale(state.speed.unwrap_or(1.0));
-                if state.r#loop.unwrap_or(true) {
-                    if let Some(mut anim) = anim_player.get_animation(&anim_name) {
-                        anim.set_loop_mode(godot::classes::animation::LoopMode::LINEAR);
-                    }
+                // Always set the loop mode explicitly. Only setting it when looping
+                // leaves the animation carrying whatever loop mode it was imported
+                // with, which on mobile can be a non-NONE mode, causing it to keep
+                // looping even when Loop is disabled.
+                if let Some(mut anim) = anim_player.get_animation(&anim_name) {
+                    let loop_mode = if state.r#loop.unwrap_or(true) {
+                        godot::classes::animation::LoopMode::LINEAR
+                    } else {
+                        godot::classes::animation::LoopMode::NONE
+                    };
+                    anim.set_loop_mode(loop_mode);
                 }
                 anim_player.play_ex().name(&anim_name).done();
             }

--- a/lib/src/godot_classes/animator_controller.rs
+++ b/lib/src/godot_classes/animator_controller.rs
@@ -641,8 +641,16 @@ pub fn apply_anims(gltf_container_node: Gd<Node3D>, value: &PbAnimator) {
         // Duplicate the AnimationLibrary so each instance has independent animation
         // state. PackedScene.instantiate() shares resources, so without this all
         // instances of the same GLTF would share the same animation objects.
+        //
+        // deep(true) (Godot's duplicate(subresources = true)) is required: a shallow
+        // duplicate copies the library container but keeps pointing at the SAME
+        // Animation sub-resources. Two GltfContainers referencing the same GLB content
+        // hash would then share one Animation, so set_loop_mode / set_speed_scale below
+        // on one instance would bleed into the other (e.g. a loop=false sibling forcing
+        // a loop=true clip to stop). See issue #2497.
         if let Some(shared_lib) = anim_player.get_animation_library("") {
-            let unique_lib: Gd<AnimationLibrary> = shared_lib.duplicate().unwrap().cast();
+            let unique_lib: Gd<AnimationLibrary> =
+                shared_lib.duplicate_ex().deep(true).done().unwrap().cast();
             anim_player.remove_animation_library("");
             anim_player.add_animation_library("", &unique_lib);
         }


### PR DESCRIPTION
## Issue

Fixes #2497

On mobile (Android/iOS) an `Animator` state with `loop` disabled and `playing` enabled keeps looping indefinitely instead of playing once and stopping. Desktop/PC behaves correctly. Reported as consistent (100%) on device.

## Root cause

In the single-animation path of `apply_anims` (`lib/src/godot_classes/animator_controller.rs`), the animation loop mode was only ever set to `LINEAR` when `loop` was `true` — it was **never reset to `NONE`** when `loop` was `false`:

```rust
if state.r#loop.unwrap_or(true) {
    anim.set_loop_mode(LoopMode::LINEAR);
}
```

So the clip kept whatever loop mode it was imported with. On desktop the GLTF import yields a non-looping default, but the **mobile GLTF import path can leave the clip with a looping mode**, so it loops forever regardless of the `loop` flag — hence the platform-specific bug.

## Fix

Set the loop mode explicitly in both cases (`LINEAR` when looping, `NONE` otherwise), so behavior no longer depends on the imported default:

```rust
if let Some(mut anim) = anim_player.get_animation(&anim_name) {
    let loop_mode = if state.r#loop.unwrap_or(true) {
        LoopMode::LINEAR
    } else {
        LoopMode::NONE
    };
    anim.set_loop_mode(loop_mode);
}
```

The multi-animation `AnimationTree` path is unaffected (it stops non-looping clips via `_animation_finished`), which is why this only surfaced for simple single-clip animators.

## QA — how to reproduce & verify

A dedicated test block was added to the test scene, deployed at coordinates **`-31,19`**.

1. Open the test scene on a **mobile device** (Android or iOS) — this is where the bug reproduces.
2. Walk to parcel **`-31,19`**.
3. In the test switcher panel (right side), tap the **"Issue 2497"** tab.
4. Two confetti bursts spawn side by side:
   - **Left** — labelled `loop = false (play once)`
   - **Right** — labelled `loop = true (control)`
5. **Expected (fixed):** the **left** burst plays its animation **once and stops**; the **right** burst keeps looping.
   **Before the fix:** the left burst also looped forever.
6. Tap **"Replay (loop=false)"** in the on-screen panel to re-fire the left (non-looping) clip and confirm it again plays a single burst and stops.
7. Confirm on **desktop** that behavior is unchanged (no regression): left plays once, right loops.