### PR TITLE
feat: disable touch feedback by default, enable via deeplink

### DIFF
--- a/godot/src/deep_link_router.gd
+++ b/godot/src/deep_link_router.gd
@@ -52,9 +52,9 @@ func process_deep_link(url: String) -> void:
 		print("[DEEPLINK] kill-sky=", Global.cli.get_kill_sky())
 
 	# Touch-feedback debug overlay (issue #2562): off by default, enabled on demand.
-	var touch_feedback_value = Global.deep_link_obj.params.get("touch-feedback", "")
+	var touch_feedback_value: String = Global.deep_link_obj.params.get("touch-feedback", "")
 	if not touch_feedback_value.is_empty():
-		var touch_feedback_enable := touch_feedback_value.to_lower() in ["true", "1", "yes"]
+		var touch_feedback_enable: bool = touch_feedback_value.to_lower() in ["true", "1", "yes"]
 		TouchFeedback.set_enabled(touch_feedback_enable)
 		print("[DEEPLINK] touch-feedback=", touch_feedback_enable)
 

--- a/godot/src/deep_link_router.gd
+++ b/godot/src/deep_link_router.gd
@@ -51,6 +51,13 @@ func process_deep_link(url: String) -> void:
 		Global.cli.set_kill_sky(kill_sky_value.to_lower() in ["true", "1", "yes"])
 		print("[DEEPLINK] kill-sky=", Global.cli.get_kill_sky())
 
+	# Touch-feedback debug overlay (issue #2562): off by default, enabled on demand.
+	var touch_feedback_value = Global.deep_link_obj.params.get("touch-feedback", "")
+	if not touch_feedback_value.is_empty():
+		var touch_feedback_enable := touch_feedback_value.to_lower() in ["true", "1", "yes"]
+		TouchFeedback.set_enabled(touch_feedback_enable)
+		print("[DEEPLINK] touch-feedback=", touch_feedback_enable)
+
 	# Opt-in gate for deleting an UPGRADED (email-linked) guest. Sticky-on for the
 	# session; only takes effect on a NON-production build (see
 	# Global.is_upgraded_deletion_enabled() + account_deletion_popup.gd).

--- a/godot/src/ui/touch_feedback/touch_feedback_draw.gd
+++ b/godot/src/ui/touch_feedback/touch_feedback_draw.gd
@@ -1,7 +1,8 @@
 extends Control
 
 ## Tracks active touch points and draws one circle per finger. Hosted by the
-## TouchFeedback CanvasLayer (production-only); see touch_feedback_overlay.gd.
+## TouchFeedback CanvasLayer (deeplink-activated, never on production); see
+## touch_feedback_overlay.gd.
 
 const RADIUS := 44.0
 const FILL_COLOR := Color(1.0, 1.0, 1.0, 0.22)

--- a/godot/src/ui/touch_feedback/touch_feedback_overlay.gd
+++ b/godot/src/ui/touch_feedback/touch_feedback_overlay.gd
@@ -1,29 +1,42 @@
 extends CanvasLayer
 
-## Dev-only touch-feedback debug tool.
+## Touch-feedback debug tool.
 ##
 ## Draws a translucent circle at each active touch point, on a CanvasLayer above the
-## entire game/UI. Registered as the `TouchFeedback` autoload. It only activates on
-## development builds (debug build and not production) — mirroring the DebugWs gate — so
-## it never ships to end users.
+## entire game/UI. Registered as the `TouchFeedback` autoload. Disabled by default on
+## every build; enabled at runtime via the `touch-feedback=true` deeplink param (see
+## deep_link_router.gd). Never activates on production builds (see set_enabled).
 
 const TouchFeedbackDrawScript := preload("res://src/ui/touch_feedback/touch_feedback_draw.gd")
 
 ## Above all game and UI CanvasLayers (which use small layer numbers).
 const OVERLAY_LAYER := 128
 
+# The draw node while enabled, null while disabled.
+var _draw_node: Control = null
+
 
 func _ready() -> void:
-	# Dev-only: active on debug builds, never in production (same gate as DebugWs).
-	if not (OS.is_debug_build() and not Global.is_production()):
-		return
-
 	layer = OVERLAY_LAYER
 	follow_viewport_enabled = false
 
-	var draw_node: Control = TouchFeedbackDrawScript.new()
-	draw_node.name = "TouchFeedbackDraw"
-	draw_node.set_anchors_preset(Control.PRESET_FULL_RECT)
-	# Never intercept input: this overlay only observes touches, the game still receives them.
-	draw_node.mouse_filter = Control.MOUSE_FILTER_IGNORE
-	add_child(draw_node)
+
+## Toggle the touch-feedback overlay at runtime. Idempotent; never enables on production.
+func set_enabled(enable: bool) -> void:
+	if enable and Global.is_production():
+		return
+
+	var currently_enabled := is_instance_valid(_draw_node)
+	if currently_enabled == enable:
+		return
+
+	if enable:
+		_draw_node = TouchFeedbackDrawScript.new()
+		_draw_node.name = "TouchFeedbackDraw"
+		_draw_node.set_anchors_preset(Control.PRESET_FULL_RECT)
+		# Never intercept input: this overlay only observes touches, the game still receives them.
+		_draw_node.mouse_filter = Control.MOUSE_FILTER_IGNORE
+		add_child(_draw_node)
+	else:
+		_draw_node.queue_free()
+		_draw_node = null


### PR DESCRIPTION
## What

  The touch-feedback debug tool (translucent circles drawn under each active finger) is now **disabled by default on every build**. It is enabled on demand via a deeplink param and never activates on production
  builds.

  Closes #2562

  ## Changes
  - `touch_feedback_overlay.gd`: removed auto-activation; added `set_enabled()` (idempotent, blocked on production)
  - `deep_link_router.gd`: wired the `touch-feedback` deeplink param
  - `touch_feedback_draw.gd`: doc comment fix

  ## Deeplink
  
  decentraland://open?touch-feedback=true   # enable
  decentraland://open?touch-feedback=false  # disable

  ## QA steps
  
  1. Launch the app on a mobile device (non-production build) and tap/drag on screen — **no circles should appear** (previously they showed automatically).
  2. Open the enable deeplink (scan the QR code below) to return to the app, then tap/drag — a translucent circle should now follow each finger.
  3. Multi-touch: place several fingers down — one circle per finger.
  4. Open the disable deeplink (second QR below) — circles should stop appearing on touch.
  5. Confirm normal touch input still works throughout (buttons, camera drag, etc.) — the overlay only observes and never intercepts input.

  ### QR codes

  <!-- QA: add the QR code images here -->
  <!-- Enable QR  -> decentraland://open?touch-feedback=true  -->
  <!-- Disable QR -> decentraland://open?touch-feedback=false -->

  **Enable (touch-feedback=true):**

<img width="222" height="222" alt="imagen" src="https://github.com/user-attachments/assets/7a63946c-198d-4f12-a109-fae5736c249e" />

  **Disable (touch-feedback=false):**

<img width="222" height="222" alt="imagen" src="https://github.com/user-attachments/assets/080878ad-0213-48ee-890f-d5f0bbe5a604" />