### PR TITLE
fix(sentry): report release as clean semver so build/version filtering works

### DIFF
--- a/godot/src/project_main_loop.gd
+++ b/godot/src/project_main_loop.gd
@@ -46,7 +46,9 @@ func _initialize() -> void:
 	if DclGlobal.is_telemetry_disabled():
 		return
 
-	var release_string = "org.decentraland.godotexplorer@" + DclGlobal.get_version()
+	# Clean semver (`{version}+{build}`) so Sentry parses release.version / release.build.
+	# Commit hash and env are carried separately via `dist` / `environment` below.
+	var release_string = "org.decentraland.godotexplorer@" + DclGlobal.get_sentry_release()
 
 	# Detect environment from version string
 	self.is_dev_version = DclGlobal.is_dev()

--- a/lib/build.rs
+++ b/lib/build.rs
@@ -606,6 +606,29 @@ fn set_godot_explorer_version() {
 
     println!("cargo:rustc-env=GODOT_EXPLORER_VERSION={}", full_version);
 
+    // Sentry-friendly semver release: `{major.minor.patch}+{build}`.
+    //
+    // Sentry only exposes `release.version` / `release.build` (and adoption,
+    // regression detection, "resolved in next release") when the release parses
+    // as clean semver `pkg@major.minor.patch(+build)`. The full `GODOT_EXPLORER_VERSION`
+    // above does NOT: it trails the git hash + `-{env}` into the semver prerelease
+    // slot and puts the build in a 4th dotted segment, so `release.build` stays empty.
+    //
+    // Here the build number goes into the numeric `+build` metadata slot (build number
+    // is globally monotonic per commit, so `release.build:>=N` == "this build or newer").
+    // The commit hash and environment are intentionally dropped — they're already carried
+    // by Sentry `dist` and `environment` respectively (see project_main_loop.gd init).
+    // When no build number is allocated (local/fork builds) the bare `{version}` is still
+    // valid semver.
+    let sentry_release = match build_segment.strip_prefix('.') {
+        Some(build) if !build.is_empty() => format!("{}+{}", version, build),
+        _ => version.clone(),
+    };
+    println!(
+        "cargo:rustc-env=GODOT_EXPLORER_SENTRY_RELEASE={}",
+        sentry_release
+    );
+
     // Get full commit hash for Sentry tags
     let full_commit_hash = commit_hash.clone().unwrap_or_default();
 

--- a/lib/src/godot_classes/dcl_global.rs
+++ b/lib/src/godot_classes/dcl_global.rs
@@ -614,6 +614,16 @@ impl DclGlobal {
         env!("GODOT_EXPLORER_VERSION").into()
     }
 
+    /// Clean-semver release string for Sentry (`{major.minor.patch}+{build}`), so
+    /// `release.version` / `release.build` filtering, adoption and regression tracking
+    /// work. Distinct from `get_version()`, which keeps the human/log-facing full string
+    /// (commit hash + `-{env}` suffix). Commit hash and environment reach Sentry via
+    /// `dist` and `environment`. Built in build.rs (`GODOT_EXPLORER_SENTRY_RELEASE`).
+    #[func]
+    pub fn get_sentry_release() -> GString {
+        env!("GODOT_EXPLORER_SENTRY_RELEASE").into()
+    }
+
     /// Get version string with environment suffix (e.g., "v1.0.0 - zone")
     /// Hidden when environment is plain "org" (production default).
     #[func]


### PR DESCRIPTION
Makes Sentry able to filter by build/version. Today the release string (`...@1.11.0.1205-01da818-prod`) isn't valid semver, so `release.build:>=N` and `release.version:>=X` return nothing and adoption/regression tracking is disabled. This changes it to clean semver `...@1.11.0+1205`, moving the build number into the numeric `+build` slot. The commit hash and env aren't lost — they're already sent as Sentry `dist` and `environment`.

**Changes**
- `lib/build.rs` — emit `GODOT_EXPLORER_SENTRY_RELEASE = {version}+{build}`.
- `lib/src/godot_classes/dcl_global.rs` — add `DclGlobal.get_sentry_release()`.
- `godot/src/project_main_loop.gd` — use it for `options.release`.

`GODOT_EXPLORER_VERSION` (used by `is_production`, `version_gate`, UI, logs) is untouched.

**QA:** none needed — no behavior change, only the Sentry release string. Optional: after a build ships, check Sentry Releases shows `@<version>+<build>` and `release.build:>=<build>` returns results.