### PR TITLE
fix(ios): use engine build with the pixelated startup logo fix

### DIFF
--- a/src/consts.rs
+++ b/src/consts.rs
@@ -28,10 +28,11 @@ pub const GODOT_BUILD_SHA: &str = "aed178f10";
 /// branch's CI build. An explicit `--branch` on the CLI still takes precedence over this.
 ///
 /// Reset to `None` once the branch is merged and `GODOT_BUILD_SHA` is bumped to the merge commit —
-/// leaving a branch pinned here makes every dev/CI pull an unmerged engine build. Currently `None`:
-/// the issue #2002 iOS main-thread-freeze fix (decentraland/godotengine#17) is merged and
-/// `GODOT_BUILD_SHA` above points at its merge commit.
-pub const GODOT_USE_BRANCH: Option<&str> = None;
+/// leaving a branch pinned here makes every dev/CI pull an unmerged engine build. Currently pinned
+/// to the iOS pixelated-startup-logo fix (decentraland/godotengine#18): it keeps the crisp
+/// launch-screen overlay above the Metal layer and drops it a beat after setup, so the soft iOS boot
+/// frame that #2561 left behind (issue #2386) is never revealed.
+pub const GODOT_USE_BRANCH: Option<&str> = Some("fix/pixelated-ios-startup-logo");
 
 /// Release tag identifying a specific fork build — `<version>.stable.gh.<sha>`, mirroring the
 /// `--version` string. Single source for the release URL path segment, the on-disk template SHA


### PR DESCRIPTION
## What?

Pins the Godot engine build to [decentraland/godotengine#18](https://github.com/decentraland/godotengine/pull/18) (`fix/pixelated-ios-startup-logo`) via `GODOT_USE_BRANCH`, so iOS builds pick up the engine-side half of #2386.

#2561 unified the startup logo on the app side but left one iOS-only frame untouched, as noted there: the engine boot image is drawn once on the not-yet-settled iOS swapchain (soft/pixelated), and removing the crisp launch-screen overlay the instant setup finishes exposes it for ~1 frame. Fixing it required an engine change.

The engine PR does two things in `godot_view_controller.mm`:
- forces the launch-screen overlay above the Metal rendering layer (added later as a sublayer, which otherwise composites over the overlay);
- defers the overlay removal a beat, so the crisp Godot `SplashOverlay` frame reaches the screen before the overlay drops.

## Notes

- Engine CI on that branch is green and its artifacts are published (editor + `ios.zip`, `android_*`, `macos.zip`), so `install` / `export` resolve from `branches/fix-pixelated-ios-startup-logo/`.
- **Do not merge as-is**: `GODOT_USE_BRANCH` must go back to `None` and `GODOT_BUILD_SHA` bumped to the engine merge commit once godotengine#18 lands — leaving a branch pinned makes every dev/CI pull an unmerged engine build.
- Branch builds are never SHA-marker-skipped, so each install re-downloads the templates (~2 GB for iOS).

## Test plan

- [ ] Fresh install on iOS, cold start: only the crisp isotype logo is visible — no pixelated/soft logo frame during the resized frame.
- [ ] Android startup is unchanged.