### PR TITLE
fix: match interaction-hint icon to SDK-replaced control icons

### DIFF
--- a/godot/src/ui/components/molecules/pointer_tooltip/tooltip_label.gd
+++ b/godot/src/ui/components/molecules/pointer_tooltip/tooltip_label.gd
@@ -22,6 +22,9 @@ var text_down := ""
 var text_up := ""
 var last_state_pressed := false
 var stylebox: StyleBox
+# Content hash of the scene-replaced (PBTouchScreenControls) icon we're currently loading,
+# so a stale async fetch can bail if the tooltip is reused for another action meanwhile.
+var _custom_icon_hash: String = ""
 
 @onready var label_action = %Label_Action
 @onready var texture_rect_action_icon = %TextureRect_ActionIcon
@@ -48,6 +51,8 @@ func set_tooltip_data(text_pet_down: String, text_pet_up, action: String):
 	text_up = text_pet_up if !text_pet_up.is_empty() else text_pet_down
 
 	var action_lower: String = action.to_lower()
+	# Reset any pending custom-icon load from a previous action on this reused node.
+	_custom_icon_hash = ""
 
 	if not label_text:
 		return
@@ -103,6 +108,39 @@ func set_tooltip_data(text_pet_down: String, text_pet_up, action: String):
 			action_to_trigger = ""
 			printerr("Action doesn't exist ", action)
 
+	# If a scene replaced this action's icon (PBTouchScreenControls), swap the default glyph
+	# for that same icon so the hint matches the on-screen gamepad button. The default stays
+	# visible until the texture finishes loading (and if it never does).
+	if action_to_trigger == action_lower:
+		_async_apply_custom_icon_override(action_lower)
+
+
+## Loads the scene-replaced icon for `action` (shared with the joypad via
+## SdkTouchControlsApplier) and shows it in the icon slot once ready. Mirrors joypad.gd's
+## _async_set_button_icon: sync cache hit applies immediately, otherwise awaits the fetch,
+## bailing if this node was reassigned to another action meanwhile.
+func _async_apply_custom_icon_override(action: String) -> void:
+	var custom_icon := SdkTouchControlsApplier.get_custom_icon_for_action(action)
+	if custom_icon.is_empty():
+		return
+
+	var icon_hash := String(custom_icon.get("hash", ""))
+	var icon_url := String(custom_icon.get("url", ""))
+	_custom_icon_hash = icon_hash
+
+	var cached: Texture2D = Global.content_provider.get_texture_from_hash(icon_hash)
+	if cached != null:
+		_show_keyboard_icon(cached)
+		return
+
+	var promise: Promise = Global.content_provider.fetch_texture_by_url(icon_hash, icon_url)
+	var res = await PromiseUtils.async_awaiter(promise)
+	# Bail if the tooltip was reused for another action while we were awaiting.
+	if _custom_icon_hash != icon_hash:
+		return
+	if not (res is PromiseError):
+		_show_keyboard_icon(res.texture)
+
 
 func _show_keyboard(text: String) -> void:
 	show()
@@ -123,6 +161,16 @@ func _show_keyboard_icon(icon: Texture2D) -> void:
 func _physics_process(_delta):
 	if action_to_trigger == "ia_any":
 		return
+
+	# React to live icon changes (e.g. the Controls Builder reassigning a glyph) while the
+	# tooltip stays on screen: if this action's scene-replaced icon changed (added, swapped,
+	# or removed), re-resolve the glyph. Cheap no-op when the hash is unchanged.
+	if not action_to_trigger.is_empty():
+		var desired_hash := String(
+			SdkTouchControlsApplier.get_custom_icon_for_action(action_to_trigger).get("hash", "")
+		)
+		if desired_hash != _custom_icon_hash:
+			set_tooltip_data(text_down, text_up, action_to_trigger)
 
 	var new_pressed = Input.is_action_pressed(action_to_trigger)
 	if last_state_pressed != new_pressed:

--- a/godot/src/ui/components/organisms/joypad/joypad.gd
+++ b/godot/src/ui/components/organisms/joypad/joypad.gd
@@ -313,9 +313,9 @@ func _apply_touch_controls() -> void:
 		var action := String(entry.get("action", ""))
 		if bool(entry.get("hide", false)):
 			hidden[action] = true
-		var icon_hash := String(entry.get("icon_hash", ""))
-		if not icon_hash.is_empty():
-			icons[action] = {"hash": icon_hash, "url": String(entry.get("icon_url", ""))}
+		var custom_icon := SdkTouchControlsApplier.get_custom_icon_for_action(action)
+		if not custom_icon.is_empty():
+			icons[action] = custom_icon
 
 	_layout(hidden, icons, main_action)
 

--- a/godot/src/ui/components/utils/sdk_touch_controls_applier.gd
+++ b/godot/src/ui/components/utils/sdk_touch_controls_applier.gd
@@ -22,6 +22,23 @@ func _init(virtual_joystick: Control, label_crosshair: Control) -> void:
 	_label_crosshair = label_crosshair
 
 
+## Returns the scene-replaced icon `{ "hash", "url" }` a PBTouchScreenControls set for
+## `action` (e.g. "ia_primary"), or an empty Dictionary when the controls are inactive or
+## the action has no custom icon. Single source of truth shared by the joypad buttons and
+## the pointer tooltip so both render the same replaced glyph.
+static func get_custom_icon_for_action(action: String) -> Dictionary:
+	if not Global.touch_controls_active:
+		return {}
+	for entry in Global.touch_controls_inputs:
+		if String(entry.get("action", "")) != action:
+			continue
+		var icon_hash := String(entry.get("icon_hash", ""))
+		if icon_hash.is_empty():
+			return {}
+		return {"hash": icon_hash, "url": String(entry.get("icon_url", ""))}
+	return {}
+
+
 ## `hidden_for_hide_ui` is the explorer's "hide UI" state, which wins when restoring.
 func apply(hidden_for_hide_ui: bool) -> void:
 	_apply_joystick(hidden_for_hide_ui)


### PR DESCRIPTION
## What

  When the crosshair points at an interactable 3D entity, the interaction hint ("over highlight") now shows the same icon a scene set for that action via `PBTouchScreenControls` — matching the replaced glyph on
  the on-screen gamepad button — instead of the default keyboard letter / built-in glyph.

  ## Changes

  - `sdk_touch_controls_applier.gd`: add shared static `get_custom_icon_for_action()` — single source of truth for an action's scene-replaced icon (`{hash, url}`), reading `Global.touch_controls_*`.
  - `joypad.gd`: build its per-action icon map via the shared helper (no behavior change).
  - `tooltip_label.gd`: after computing the default glyph, async-load the scene-replaced icon (mirrors the joypad's content-provider fetch) and swap it in on both mobile and desktop. The default stays visible 
  until the texture loads (no flicker) and if it never does. `_physics_process` re-resolves the glyph when the action's icon changes live (e.g. from the Controls Builder) while the tooltip is on screen.

<img width="1125" height="765" alt="imagen" src="https://github.com/user-attachments/assets/d14464ae-e7f4-4bff-9dec-118bdf42f7de" />


 ## QA testing steps

  Test scene is deployed at **`-31,19`**.

  1. Enter the test scene and select the **Controls Builder** block (the "Control Creator" dashboard — it's the default block).
  2. A row of colored interactive spheres appears, one per button (JUMP, POINTER, E, F, 1–4).
  3. Point the crosshair at a sphere → the interaction hint appears with that button's **default** glyph (keyboard letter / built-in icon).
  4. In the Controls Builder panel, assign a custom icon to that button (cycle its icon to fishing / binocular).
  5. Verify the hint icon now matches the icon shown on the on-screen gamepad button for that action — on both desktop and mobile.
  6. **Live update:** with the crosshair still on the sphere, change that button's icon in the panel → the hint icon updates in place (no need to look away and back).
  7. Remove the custom icon (set it back to none) → the hint reverts to the default glyph.
  8. Regression: hover an interactable in a scene with no `PBTouchScreenControls` → the hint behaves exactly as before (keyboard letters on desktop, mapped glyphs on mobile).

  Closes #2557