### PR TITLE
fix: restore explorer focus when closing another player's profile

### DIFF
--- a/godot/src/ui/explorer.gd
+++ b/godot/src/ui/explorer.gd
@@ -1311,6 +1311,9 @@ func _on_profile_container_visibility_changed() -> void:
 		return
 	if not profile_container.visible:
 		_show_joypad()
+		# Profile page grabs keyboard focus when shown; restore it so jump works.
+		Global.explorer_grab_focus()
+		capture_mouse()
 
 
 func _open_friends_panel() -> void:


### PR DESCRIPTION
## Problem

After closing another player's profile (passport), the local player can't jump until they move the camera or walk.

Closes #2524

## Root cause

Jump only fires when `Global.explorer_has_focus()` is true (`player.gd:294`). When the profile page becomes visible it calls `grab_focus()` on itself (`profile.gd:430-432`), stealing keyboard focus from `explorer.ui_root`. On close, nothing hands focus back, so `explorer_has_focus()` stays `false` and jump is silently blocked. Moving the camera or walking re-grabs focus, which is why input recovers after those actions.

Every other overlay (friends/settings/notifications) already restores focus with `Global.explorer_grab_focus()` on close — the profile close flow was the only one missing it.

## Fix

In `explorer.gd`, `_on_profile_container_visibility_changed()` (fires on every close path — close button, backdrop tap, `close_profile` signal) now restores focus and mouse capture, matching the other panels.

## QA steps to reproduce

1. Go to Genesis Plaza
2. Point at another player
3. Open their user profile (passport)
4. Close it
5. Press jump

**Before:** jump does nothing until you move the camera or walk.
**After:** jump works immediately.