### PR TITLE
Test APK against Adreno ubershader crash-fix engine branch

### DIFF
--- a/src/consts.rs
+++ b/src/consts.rs
@@ -28,10 +28,9 @@ pub const GODOT_BUILD_SHA: &str = "aed178f10";
 /// branch's CI build. An explicit `--branch` on the CLI still takes precedence over this.
 ///
 /// Reset to `None` once the branch is merged and `GODOT_BUILD_SHA` is bumped to the merge commit —
-/// leaving a branch pinned here makes every dev/CI pull an unmerged engine build. Currently `None`:
-/// the issue #2002 iOS main-thread-freeze fix (decentraland/godotengine#17) is merged and
-/// `GODOT_BUILD_SHA` above points at its merge commit.
-pub const GODOT_USE_BRANCH: Option<&str> = None;
+/// leaving a branch pinned here makes every dev/CI pull an unmerged engine build. Currently pinned
+/// to the Adreno ubershader crash-fix backport (decentraland/godotengine#19) for on-device testing.
+pub const GODOT_USE_BRANCH: Option<&str> = Some("fix/adreno-ubershader-crash");
 
 /// Release tag identifying a specific fork build — `<version>.stable.gh.<sha>`, mirroring the
 /// `--version` string. Single source for the release URL path segment, the on-disk template SHA


### PR DESCRIPTION
## Summary

Pins `GODOT_USE_BRANCH` to `fix/adreno-ubershader-crash` so CI builds the APK against the engine backport in decentraland/godotengine#19 (fix for the Adreno 6xx ubershader startup crash).

Draft — not meant to merge. After the engine PR merges: bump `GODOT_BUILD_SHA` to its merge commit and reset the pin to `None`.

## What could break

If merged as-is, every dev/CI pulls an unmerged, mutable engine build. The Android job here fails if it runs before the engine branch finishes publishing artifacts — re-run it in that case.

## How to test

Install the APK from the build-report comment on a POCO X3 Pro: it must reach the lobby instead of crashing ~6 s after launch. Sanity-check a known-good device.