### PR TITLE
fix: stop Sentry error spam from empty block updates and compressed impostor textures

### DIFF
--- a/lib/src/avatars/avatar_scene.rs
+++ b/lib/src/avatars/avatar_scene.rs
@@ -587,6 +587,19 @@ impl AvatarScene {
         };
 
         let mut img = image;
+        // On mobile the content pipeline hands us VRAM-compressed (ETC2) images,
+        // which resize/convert/generate_mipmaps/update_layer all reject.
+        if img.is_compressed() {
+            let err = img.decompress();
+            if err != godot::global::Error::OK {
+                tracing::debug!(
+                    "Dropping compressed impostor image for slot {}: {:?}",
+                    impostor_id,
+                    err
+                );
+                return;
+            }
+        }
         if img.get_width() != IMPOSTOR_TEX_WIDTH || img.get_height() != IMPOSTOR_TEX_HEIGHT {
             img.resize(IMPOSTOR_TEX_WIDTH, IMPOSTOR_TEX_HEIGHT);
         }

--- a/lib/src/godot_classes/dcl_social_service.rs
+++ b/lib/src/godot_classes/dcl_social_service.rs
@@ -1338,6 +1338,14 @@ impl DclSocialService {
         let address = update.address;
         let is_blocked = update.is_blocked;
 
+        // The stream regularly delivers updates with an empty address (server-side
+        // noise, ~19/user/day). Emitting them just makes every consumer fail the
+        // H160 parse downstream, so drop them here.
+        if address.is_empty() {
+            tracing::debug!("Skipping block update with empty address");
+            return;
+        }
+
         node.call_deferred(
             "emit_signal",
             &[


### PR DESCRIPTION
Two small guards that eliminate our two biggest remaining Sentry spam sources (~90% of error volume together with the already-discarded issue): the social-service block-update stream regularly delivers updates with an **empty address** (~19/user/day), which every consumer rejected with `Invalid address format:` (94k events/14d); and on mobile the impostor capture path receives **ETC2-compressed** body textures that `resize`/`convert`/`generate_mipmaps`/`update_layer` all reject (4 issues, ~18k events/14d — [2CZ](https://dcl-regenesis-labs.sentry.io/issues/GODOT-EXPLORER-2CZ), [2D0](https://dcl-regenesis-labs.sentry.io/issues/GODOT-EXPLORER-2D0), [2CY](https://dcl-regenesis-labs.sentry.io/issues/GODOT-EXPLORER-2CY), [2B8](https://dcl-regenesis-labs.sentry.io/issues/GODOT-EXPLORER-2B8)). Follow-up (not this PR): ask the social-service team why the stream emits empty addresses at all.

## Changes
- `lib/src/godot_classes/dcl_social_service.rs` — skip block updates with an empty address before emitting `block_update_received` (debug log, no signal).
- `lib/src/avatars/avatar_scene.rs` — `Image.decompress()` compressed impostor images before the texture-array upload; drop the image (capture retries naturally) if decompression fails.

## Test plan
- [ ] (Mobile) Go to a crowded area (e.g. Genesis Plaza): distant avatars still render as impostor billboards, and the log shows none of: "Cannot generate mipmaps from compressed image formats" / "Cannot convert to (or from) compressed formats" / "Image format must match texture's image format" / "Cannot resize in compressed image formats".
- [ ] Open Friends → block a user, then unblock them: status updates correctly on both ends, no "Invalid address format:" in the log.
- [ ] Regression: mute/unmute a user still works (shares the blacklist code path).