### PR TITLE
fix: generate local snapshot for own profile picture on account creation (#2359)

### DIFF
--- a/godot/src/ui/pages/auth/lobby.gd
+++ b/godot/src/ui/pages/auth/lobby.gd
@@ -794,6 +794,12 @@ func _on_button_lets_go_pressed():
 		Global.metrics.track_screen_viewed("AUTH_DEPLOY_SUCCESS", "")
 		Global.metrics.flush.call_deferred()
 
+		# ADR-290: generate local snapshot so the own profile picture is visible
+		# (deploy strips snapshots server-side, so do it after the deploy)
+		await Global.snapshot.async_generate_for_avatar(avatar, current_profile)
+		current_profile.set_avatar(avatar)
+		Global.player_identity.set_profile(current_profile)
+
 	show_discover_ftue_screen()
 
 


### PR DESCRIPTION
## Problem
#2359 — new accounts can't see their own profile picture. ADR-290 stopped uploading snapshots; clients generate them locally for immediate UI display. The account-creation flow in `lobby.gd` deployed the profile without generating the local snapshot, leaving `snapshots=None` → all profile-picture widgets bail out on the empty face URL.

## Fix
After a successful deploy in `_on_button_lets_go_pressed()`, generate the local snapshot and re-publish the profile — mirroring what `PlayerIdentity.async_save_profile()` already does:

```gdscript
await Global.snapshot.async_generate_for_avatar(avatar, current_profile)
current_profile.set_avatar(avatar)
Global.player_identity.set_profile(current_profile)
```

Done after the deploy because the deploy path strips snapshots server-side (on a copy) and the Rust success callback re-publishes the deployed profile without them.

## Testing
- [x] Manual: guest account creation → FTUE → own profile picture visible
- [x] Full pre-push suite PASS (fmt, lint, clippy, unit + integration tests)

Closes #2359

## QA Steps
1. Open the app and create a new account (guest or wallet)
2. Complete avatar customization + naming (Let's Go)
3. Check the profile picture in the navbar/profile button → should show the avatar face
4. Open own profile/passport → picture visible
