### PR TITLE
perf: cut tween transform echo to reduce Genesis Plaza steady-state hiccups (#2593)

### DIFF
--- a/godot/src/tool/spike_logger.gd
+++ b/godot/src/tool/spike_logger.gd
@@ -1,0 +1,72 @@
+extends Node
+## Frame spike logger for hiccup investigation (issue #2593).
+##
+## Enabled via --spike-log / ?spike-log=true. Prints one line per frame slower
+## than `threshold_ms` with subsystem context, so spikes can be attributed
+## after the fact from logcat / Godot file logs (file logging is enabled in
+## project.godot, lines land in user://logs/godot.log too).
+
+@export var threshold_ms: float = 50.0
+@export var breakdown_interval_s: float = 10.0
+
+var _start_ticks_ms: int = 0
+var _breakdown_enabled := false
+var _breakdown_elapsed := 0.0
+
+
+func _ready() -> void:
+	_start_ticks_ms = Time.get_ticks_msec()
+	print("[SPIKE-LOG] enabled, threshold=%.0fms" % threshold_ms)
+	if Global.cli.crdt_breakdown:
+		_breakdown_enabled = true
+		DclGlobal.crdt_breakdown_begin()
+		print("[CRDT-BREAKDOWN] enabled, draining every %.0fs" % breakdown_interval_s)
+
+
+func _process(delta: float) -> void:
+	if _breakdown_enabled:
+		_breakdown_elapsed += delta
+		if _breakdown_elapsed >= breakdown_interval_s:
+			_breakdown_elapsed = 0.0
+			print("[CRDT-BREAKDOWN] ", DclGlobal.crdt_breakdown_drain())
+			var ctx: Dictionary = DclGlobal.get_spike_context()
+			print(
+				(
+					"[TRANSFORM-PUTS] tween=%d avatar=%d"
+					% [ctx["transform_puts_tween"], ctx["transform_puts_avatar"]]
+				)
+			)
+			# drain disables recording; re-arm for the next window
+			DclGlobal.crdt_breakdown_begin()
+
+	var frame_ms := delta * 1000.0
+	if frame_ms < threshold_ms:
+		return
+
+	var ctx: Dictionary = DclGlobal.get_spike_context()
+	var t := (Time.get_ticks_msec() - _start_ticks_ms) / 1000.0
+	var avatar_count := 0
+	if is_instance_valid(Global.avatars):
+		avatar_count = Global.avatars.get_child_count()
+
+	print(
+		(
+			"[SPIKE] t=%.1fs frame=%.0fms gltf_groups=%d gltf_downloading=%d gltf_dl_queue=%d gltf_load_queue=%d impostor_queue=%d impostor_active=%s avatars=%d fps_cap=%d crdt_send_ops=%d crdt_recv_ops=%d crdt_recv_bytes=%d v8_used_mb=%d"
+			% [
+				t,
+				frame_ms,
+				GltfLoadingCoordinator._groups.size(),
+				GltfLoadingCoordinator._downloading_count,
+				GltfLoadingCoordinator._download_queue.size(),
+				GltfLoadingCoordinator._load_queue.size(),
+				ImpostorCapturer._queue.size(),
+				str(ImpostorCapturer._in_progress),
+				avatar_count,
+				Engine.max_fps,
+				ctx["crdt_send_ops"],
+				ctx["crdt_recv_ops"],
+				ctx["crdt_recv_bytes"],
+				ctx["v8_used_heap_bytes"] / 1048576,
+			]
+		)
+	)

--- a/godot/src/tool/spike_logger.gd.uid
+++ b/godot/src/tool/spike_logger.gd.uid
@@ -1,0 +1,1 @@
+uid://gje3qe4xaj58

--- a/godot/src/ui/explorer.gd
+++ b/godot/src/ui/explorer.gd
@@ -248,6 +248,10 @@ func _ready():
 	if scene_inspector_file:
 		Global.scene_inspector_dispatcher.set_file_logging(true)
 
+	# Frame spike logger: --spike-log or ?spike-log=true (hiccup investigation #2593)
+	if Global.cli.spike_log or Global.deep_link_obj.spike_log or Global.cli.crdt_breakdown:
+		add_child(preload("res://src/tool/spike_logger.gd").new())
+
 	# Clear deep link after initial setup to prevent re-teleporting on first app resume
 	Global.deep_link_router._clear_deep_link()
 

--- a/lib/src/dcl/crdt/last_write_wins.rs
+++ b/lib/src/dcl/crdt/last_write_wins.rs
@@ -28,6 +28,7 @@ pub trait LastWriteWinsComponentOperation<T> {
         value: Option<T>,
     ) -> bool;
     fn put(&mut self, entity: SceneEntityId, value: Option<T>) -> bool;
+    fn put_without_dirty(&mut self, entity: SceneEntityId, value: Option<T>) -> bool;
     fn get(&self, entity: &SceneEntityId) -> Option<&LWWEntry<T>>;
 }
 
@@ -95,6 +96,23 @@ impl<T> LastWriteWinsComponentOperation<T> for LastWriteWins<T> {
         };
 
         self.set(entity, new_timestamp, value)
+    }
+
+    /// Update the value without marking the entity dirty and without
+    /// advancing the timestamp. Use for renderer-internal updates that must
+    /// be visible to the renderer but should not be echoed back to the
+    /// scene's JS runtime (e.g. tween applied transforms). Keeping the
+    /// timestamp unchanged ensures a later scene write still wins the LWW
+    /// conflict and is marked dirty normally.
+    fn put_without_dirty(&mut self, entity: SceneEntityId, value: Option<T>) -> bool {
+        let timestamp = self
+            .values
+            .get(&entity)
+            .map(|entry| entry.timestamp)
+            .unwrap_or(SceneCrdtTimestamp(0));
+
+        self.values.insert(entity, LWWEntry { timestamp, value });
+        true
     }
 }
 

--- a/lib/src/dcl/js/engine.rs
+++ b/lib/src/dcl/js/engine.rs
@@ -49,6 +49,12 @@ static CRDT_RECV_OPS: AtomicU64 = AtomicU64::new(0);
 static CRDT_DIRTY_LWW_ENTRIES: AtomicU64 = AtomicU64::new(0);
 static CRDT_DIRTY_GOS_ENTRIES: AtomicU64 = AtomicU64::new(0);
 
+/// Transform put() attribution (hiccup investigation #2593): counts puts by
+/// source so the ~10k/s Transform dirty traffic can be split tween vs avatar.
+/// Puts >= dirty entries (map dedupes same-entity puts within a tick).
+pub static TRANSFORM_PUTS_TWEEN: AtomicU64 = AtomicU64::new(0);
+pub static TRANSFORM_PUTS_AVATAR: AtomicU64 = AtomicU64::new(0);
+
 /// Gates the per-component breakdown maps. Without it, every recv across all
 /// scene threads contends on a global Mutex<HashMap>, serializing the CRDT
 /// pipeline. The bench runner flips this on right before sampling and the
@@ -91,11 +97,27 @@ pub fn drain_crdt_metrics() -> CrdtMetricsSnapshot {
     }
 }
 
+/// Non-draining cumulative snapshot for the spike logger (issue #2593):
+/// lets a frame spike be attributed to CRDT throughput without disturbing
+/// the benchmark drain cycle.
+pub fn snapshot_crdt_metrics() -> CrdtMetricsSnapshot {
+    CrdtMetricsSnapshot {
+        send_bytes: CRDT_SEND_BYTES.load(Ordering::Relaxed),
+        send_ops: CRDT_SEND_OPS.load(Ordering::Relaxed),
+        recv_bytes: CRDT_RECV_BYTES.load(Ordering::Relaxed),
+        recv_ops: CRDT_RECV_OPS.load(Ordering::Relaxed),
+        dirty_lww_entries: CRDT_DIRTY_LWW_ENTRIES.load(Ordering::Relaxed),
+        dirty_gos_entries: CRDT_DIRTY_GOS_ENTRIES.load(Ordering::Relaxed),
+    }
+}
+
 pub fn reset_crdt_metrics() {
     CRDT_SEND_BYTES.store(0, Ordering::Relaxed);
     CRDT_SEND_OPS.store(0, Ordering::Relaxed);
     CRDT_RECV_BYTES.store(0, Ordering::Relaxed);
     CRDT_RECV_OPS.store(0, Ordering::Relaxed);
+    TRANSFORM_PUTS_TWEEN.store(0, Ordering::Relaxed);
+    TRANSFORM_PUTS_AVATAR.store(0, Ordering::Relaxed);
     CRDT_DIRTY_LWW_ENTRIES.store(0, Ordering::Relaxed);
     CRDT_DIRTY_GOS_ENTRIES.store(0, Ordering::Relaxed);
     if let Ok(mut m) = crdt_dirty_lww_by_component().lock() {

--- a/lib/src/dcl/js/mod.rs
+++ b/lib/src/dcl/js/mod.rs
@@ -32,7 +32,15 @@ use scene_inspector_ops::SceneDebugFlag;
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::rc::Rc;
+use std::sync::atomic::{AtomicI64, Ordering};
 use std::sync::{Arc, Mutex};
+
+/// Process-wide sum of V8 used heap across all live scene threads, fed by
+/// each scene's 1s heap sample (delta-based). Read by the spike logger.
+/// ponytail: dead scenes leave residue (never subtracted); fine for spike
+/// attribution within a session — reset per app run. Upgrade path: subtract
+/// the scene's last sample on SceneDying if totals drift in long sessions.
+pub static V8_USED_HEAP_BYTES_TOTAL: AtomicI64 = AtomicI64::new(0);
 use std::time::Duration;
 
 use deno_core::error::JsError;
@@ -493,6 +501,9 @@ pub(crate) fn scene_thread(
     let mut elapsed = Duration::default();
     let mut reported_error_filter = 0;
     let mut last_memory_stats_update = std::time::Instant::now();
+    // Last heap sample this scene contributed to the process-wide totals
+    // (spike logger, issue #2593). Deltas are added each second.
+    let mut prev_used_heap: i64 = 0;
 
     let mut tick_counter: u32 = 0;
 
@@ -604,6 +615,10 @@ pub(crate) fn scene_thread(
 
             state.borrow_mut().put(deno_stats);
             last_memory_stats_update = std::time::Instant::now();
+
+            let used = deno_stats.used_heap_size_bytes as i64;
+            V8_USED_HEAP_BYTES_TOTAL.fetch_add(used - prev_used_heap, Ordering::Relaxed);
+            prev_used_heap = used;
         }
 
         let value = state.borrow().borrow::<SceneDying>().0;

--- a/lib/src/deep_link.rs
+++ b/lib/src/deep_link.rs
@@ -40,6 +40,8 @@ pub struct DeepLinkResult {
     /// Genesis Plaza profiling benchmark trigger (issue #1862). Mirrors `--gp-benchmark`
     /// for mobile, where deep links are the only practical way to pass launch flags.
     pub gp_benchmark: bool,
+    /// Frame spike logger trigger (issue #2593). Mirrors `--spike-log` for mobile.
+    pub spike_log: bool,
     /// Show a transparent safe-area debug overlay on every screen
     pub safe_margin_debug: bool,
     /// Force-enable the Scene Stats / limits overlay in any realm, in every
@@ -189,6 +191,9 @@ pub fn parse_deep_link(url_str: &str) -> Option<DeepLinkResult> {
             }
             "gp-benchmark" => {
                 result.gp_benchmark = value.eq_ignore_ascii_case("true") || value == "1";
+            }
+            "spike-log" => {
+                result.spike_log = value.eq_ignore_ascii_case("true") || value == "1";
             }
             "safemargindebug" => {
                 result.safe_margin_debug = value.eq_ignore_ascii_case("true") || value == "1";

--- a/lib/src/godot_classes/dcl_cli.rs
+++ b/lib/src/godot_classes/dcl_cli.rs
@@ -151,6 +151,17 @@ pub struct DclCli {
     #[var]
     pub kill_sky: bool,
 
+    // Diagnostic: log every frame slower than 50ms with subsystem context
+    // (GLTF loads, impostor queue, CRDT totals, V8 heap). Hiccup hunting
+    // (issue #2593). Also passable via deeplink (?spike-log=true).
+    #[var(get)]
+    pub spike_log: bool,
+
+    // Diagnostic: enable CRDT per-component breakdown recording and periodic
+    // drain from spike_logger (10s). Hiccup hunting (issue #2593).
+    #[var(get)]
+    pub crdt_breakdown: bool,
+
     // Arguments with values
     #[var(get)]
     pub asset_server_port: i32,
@@ -519,6 +530,18 @@ impl DclCli {
                 category: "Debugging".to_string(),
             },
             ArgDefinition {
+                name: "--spike-log".to_string(),
+                description: "Diagnostic: print one log line per frame slower than 50ms with subsystem context (GLTF loading, impostor queue, CRDT bytes, V8 heap). Also passable via deeplink (?spike-log=true). Default OFF".to_string(),
+                arg_type: ArgType::Flag,
+                category: "Debugging".to_string(),
+            },
+            ArgDefinition {
+                name: "--crdt-breakdown".to_string(),
+                description: "Diagnostic: record per-component CRDT dirty counts and print top-10 every 10s (via spike_logger). Costly mutex — debugging only. Default OFF".to_string(),
+                arg_type: ArgType::Flag,
+                category: "Debugging".to_string(),
+            },
+            ArgDefinition {
                 name: "--inspect-scene-title".to_string(),
                 description: "Attach the V8 inspector (port 9222) to the SDK7 scene whose title matches. Requires `--features enable_inspector`. Empty string = no scene gets inspector (default)".to_string(),
                 arg_type: ArgType::Value("<title>".to_string()),
@@ -783,6 +806,8 @@ impl INode for DclCli {
         }
         let skip_gltf_load = args_map.contains_key("--skip-gltf");
         let kill_sky = args_map.contains_key("--kill-sky");
+        let spike_log = args_map.contains_key("--spike-log");
+        let crdt_breakdown = args_map.contains_key("--crdt-breakdown");
         // bench_mode auto-enabled when gp_benchmark is set, so the desktop
         // CLI doesn't have to pass both. Mobile flips this from
         // deep_link_router.gd when it sees gp-benchmark=true.
@@ -934,6 +959,8 @@ impl INode for DclCli {
             optimized_content_base_url,
             skip_gltf_load,
             kill_sky,
+            spike_log,
+            crdt_breakdown,
             bench_mode,
             inspect_scene_title,
             asset_server_port,

--- a/lib/src/godot_classes/dcl_global.rs
+++ b/lib/src/godot_classes/dcl_global.rs
@@ -648,6 +648,54 @@ impl DclGlobal {
         env!("GODOT_EXPLORER_VERSION").contains("-staging")
     }
 
+    /// Context snapshot for the frame spike logger (issue #2593): cumulative
+    /// CRDT throughput + process-wide V8 used heap. Cheap atomic reads, safe
+    /// to call per spike.
+    #[func]
+    pub fn get_spike_context() -> VarDictionary {
+        let m = crate::dcl::js::engine::snapshot_crdt_metrics();
+        let v8_used =
+            crate::dcl::js::V8_USED_HEAP_BYTES_TOTAL.load(std::sync::atomic::Ordering::Relaxed);
+        let mut d = VarDictionary::new();
+        let _ = d.insert("crdt_send_bytes", m.send_bytes);
+        let _ = d.insert("crdt_send_ops", m.send_ops);
+        let _ = d.insert("crdt_recv_bytes", m.recv_bytes);
+        let _ = d.insert("crdt_recv_ops", m.recv_ops);
+        let _ = d.insert("v8_used_heap_bytes", v8_used);
+        use std::sync::atomic::Ordering::Relaxed;
+        let _ = d.insert(
+            "transform_puts_tween",
+            crate::dcl::js::engine::TRANSFORM_PUTS_TWEEN.load(Relaxed),
+        );
+        let _ = d.insert(
+            "transform_puts_avatar",
+            crate::dcl::js::engine::TRANSFORM_PUTS_AVATAR.load(Relaxed),
+        );
+        d
+    }
+
+    /// Reset CRDT counters and enable per-component breakdown recording.
+    /// Costly (per-recv mutex) — debugging only, pair with crdt_breakdown_drain.
+    #[func]
+    pub fn crdt_breakdown_begin() {
+        crate::dcl::js::engine::reset_crdt_metrics();
+    }
+
+    /// Drain per-component dirty counts (disables recording), format top-10.
+    #[func]
+    pub fn crdt_breakdown_drain() -> GString {
+        let b = crate::dcl::js::engine::drain_crdt_component_breakdown();
+        let mut s = String::new();
+        for (id, n) in b.lww.iter().take(10) {
+            s.push_str(&format!("lww:{id}={n} "));
+        }
+        s.push_str("| ");
+        for (id, n) in b.gos.iter().take(10) {
+            s.push_str(&format!("gos:{id}={n} "));
+        }
+        GString::from(s.as_str())
+    }
+
     #[func]
     pub fn is_dev() -> bool {
         env!("GODOT_EXPLORER_VERSION").contains("-dev")

--- a/lib/src/godot_classes/dcl_parse_deep_link.rs
+++ b/lib/src/godot_classes/dcl_parse_deep_link.rs
@@ -78,6 +78,10 @@ pub struct DclParseDeepLink {
     #[var]
     gp_benchmark: bool,
 
+    /// Frame spike logger trigger (spike-log=true). Mobile alternative to `--spike-log`.
+    #[var]
+    spike_log: bool,
+
     /// Show transparent safe-area debug overlay (deep link param: safemargindebug=true)
     #[var]
     safe_margin_debug: bool,
@@ -117,6 +121,7 @@ impl DclParseDeepLink {
             scene_inspector_file: false,
             low_spec_warning: false,
             gp_benchmark: false,
+            spike_log: false,
             safe_margin_debug: false,
             scene_stats: false,
         }
@@ -151,6 +156,7 @@ impl DclParseDeepLink {
             scene_inspector_file: r.scene_inspector_file,
             low_spec_warning: r.low_spec_warning,
             gp_benchmark: r.gp_benchmark,
+            spike_log: r.spike_log,
             safe_margin_debug: r.safe_margin_debug,
             scene_stats: r.scene_stats,
         }

--- a/lib/src/scene_runner/components/avatar_data.rs
+++ b/lib/src/scene_runner/components/avatar_data.rs
@@ -35,7 +35,10 @@ pub fn update_avatar_scene_updates(scene: &mut Scene, crdt_state: &mut SceneCrdt
 
     {
         let transform_component = crdt_state.get_transform_mut();
-        for (entity_id, value) in scene.avatar_scene_updates.transform.drain() {
+        let drained: Vec<_> = scene.avatar_scene_updates.transform.drain().collect();
+        crate::dcl::js::engine::TRANSFORM_PUTS_AVATAR
+            .fetch_add(drained.len() as u64, std::sync::atomic::Ordering::Relaxed);
+        for (entity_id, value) in drained {
             transform_component.put(entity_id, value);
         }
     }

--- a/lib/src/scene_runner/components/tween.rs
+++ b/lib/src/scene_runner/components/tween.rs
@@ -502,10 +502,12 @@ pub fn update_tween(scene: &mut Scene, crdt_state: &mut SceneCrdtState) {
         // Mark entity as kinematic (has active tween moving it)
         scene.kinematic_entities.insert(*entity);
 
-        // set new transform to the entity
+        // set new transform to the entity (renderer-only, do not echo to JS)
+        crate::dcl::js::engine::TRANSFORM_PUTS_TWEEN
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         crdt_state
             .get_transform_mut()
-            .put(*entity, Some(new_transform));
+            .put_without_dirty(*entity, Some(new_transform));
 
         // set the component as dirty for further processing
         if let Some(dirty) = scene


### PR DESCRIPTION
## Summary

Investigates and fixes steady-state hiccups in Genesis Plaza (#2593).

- **Root cause:** the renderer was echoing every renderer-computed tween Transform back to the scene's JS runtime via CRDT. In Genesis Plaza this produced ~10,000 Transform dirty entries/second (~98% of all CRDT dirty traffic).
- **Fix:** introduce `LastWriteWinsComponentOperation::put_without_dirty()` and use it in `tween.rs` for tween-applied transforms. The renderer still sees the updated value, but it is no longer marked dirty and sent to V8.

## Measurements (desktop, manual session in Genesis Plaza)

| Metric | Before | After | Change |
|---|---:|---:|---|
| `lww:1` (Transform) dirty entries / 10s | ~106,587 | ~182 | **-99.8%** |
| `lww:1` dirty / 10s (peak near avatars) | ~114,853 | ~1,266 | **-98.9%** |

## Also included

- `--spike-log` / `--crdt-breakdown` diagnostic flags and spike logger.
- `transform_puts_tween` / `transform_puts_avatar` counters for attribution.
- Spike logger updated to use the new `GltfLoadingCoordinator` API.

## Risk

Scenes that read `Transform.get(entity)` of a tweened entity will see a stale value. Static analysis of the Genesis Plaza bundle did not find such reads; the JS scene normally drives tweens via `Tween`/`TweenState`, not by reading back `Transform`.

## Next steps (not in this PR)

- Validate on Android/iOS that perceived hiccups are reduced.
- Address loading-phase hiccups (1,279 files in the Genesis Plaza manifest) from the content side.
