### PR TITLE
ci: never fail a mobile build on a Sentry symbol upload error

### DIFF
--- a/.github/workflows/android_builds.yml
+++ b/.github/workflows/android_builds.yml
@@ -358,9 +358,14 @@ jobs:
           path: android-debug-symbols/
           if-no-files-found: error
         
-      # Upload debug symbols to Sentry for production builds (main/release only)
+      # Upload debug symbols to Sentry for production builds (main/release only).
+      # continue-on-error: the APK/AAB are already built and uploaded by this point, so a
+      # Sentry hiccup (e.g. server-side "Reported checksum mismatch") must never fail the
+      # build — it only costs us symbolication. We notify instead.
       - name: Upload debug symbols to Sentry
+        id: sentry_symbols
         if: success() && (github.ref_name == 'main' || github.ref_name == 'release')
+        continue-on-error: true
         shell: bash
         run: |
           EXPLORER_VERSION=$(cargo run -- explorer-version)
@@ -457,6 +462,13 @@ jobs:
           else
             echo "Development build detected (-dev suffix found), skipping Sentry upload"
           fi
+
+      # Notify only — the step above is continue-on-error, so the job stays green.
+      - name: Sentry symbol upload failed — notify (non-blocking)
+        if: always() && steps.sentry_symbols.outcome == 'failure'
+        shell: bash
+        run: |
+          echo "::warning title=Sentry symbol upload failed::Android native symbols for ${{ github.ref_name }} were not uploaded — crashes may be unsymbolicated. The APK/AAB themselves are unaffected."
 
       # Build Report Comment
       - name: Prepare Build Report

--- a/.github/workflows/ios_r2_artifact.yml
+++ b/.github/workflows/ios_r2_artifact.yml
@@ -308,8 +308,13 @@ jobs:
 
       # libdclgodot.dylib is BUILT here, so its dSYM must be uploaded to Sentry from here
       # (the deploy repo only re-archives the already-built dylib). Best-effort.
+      # continue-on-error: a Sentry hiccup (e.g. server-side "Reported checksum mismatch")
+      # must never fail a build whose export already reached R2 — it only costs us
+      # symbolication. We notify instead.
       - name: Upload libdclgodot to Sentry
+        id: sentry_libdclgodot
         if: success() && ! inputs.dry_run
+        continue-on-error: true
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
@@ -327,3 +332,12 @@ jobs:
           else
             echo "⚠️  libdclgodot not found at $LIBDCLGODOT_PATH"
           fi
+
+      # Notify only — the step above is continue-on-error, so the job stays green.
+      - name: Sentry libdclgodot upload failed — notify (non-blocking)
+        if: always() && steps.sentry_libdclgodot.outcome == 'failure'
+        env:
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          echo "::warning title=Sentry libdclgodot upload failed::iOS native symbols for ${{ inputs.ref }} were not uploaded — crashes may be unsymbolicated. The build itself is unaffected."
+          bash .github/scripts/slack-reply.sh "⚠️ iOS — Sentry libdclgodot symbol upload failed (non-blocking), build unaffected — ${RUN_URL}"


### PR DESCRIPTION
## Problem

Sibling of decentraland/godot-asc-deploy#4, prompted by a real failure on the deploy side: that run **shipped build 1414 to TestFlight successfully** and then went red because the dSYM upload step exited 1 on a *server-side* Sentry error:

```
> Uploaded 1 missing debug information file
> File processing complete:

    ERROR decentraland-godot-client
        Reported checksum mismatch

Error: some symbols did not process correctly
```

`sentry-cli upload-dif --wait` blocks on Sentry's server-side processing and propagates its result, so a Sentry hiccup fails a job whose artifacts have already shipped.

Both symbol-upload steps in this repo have the same shape and the same exposure:

- **`ios_r2_artifact.yml`** → `Upload libdclgodot to Sentry`, which runs *after* the unsigned export is already in R2. Its comment even claimed "Best-effort", but a failure took the whole job down — and with it the hand-off to the signing pipeline.
- **`android_builds.yml`** → `Upload debug symbols to Sentry`, which runs *after* the APK/AAB are built and uploaded.

## Fix

Make both steps `continue-on-error: true` (each with an `id`) and notify instead:

- New `Sentry libdclgodot upload failed — notify (non-blocking)` step in the iOS leg: `::warning::` annotation + threaded Slack reply (that leg has the thread context).
- New `Sentry symbol upload failed — notify (non-blocking)` step in the Android leg: `::warning::` annotation (that workflow has no Slack wiring).

Both are gated on `steps.<id>.outcome == 'failure'` and state explicitly that the build artifacts are unaffected and only symbolication may be missing.

Losing symbolication is worth a warning, not a red build.

## Testing

YAML parsed and step order / conditions verified locally. Real validation is the next mobile build — Android's step only runs on `main`/`release`, so it won't be exercised by this PR's own CI.