### PR TITLE
fix: preview-mode loading screen shows the scene's own thumbnail and title

### DIFF
--- a/godot/src/logic/scene_fetcher.gd
+++ b/godot/src/logic/scene_fetcher.gd
@@ -191,6 +191,15 @@ func get_scene_data(coord: Vector2i) -> SceneItem:
 	return loaded_scenes.get(scene_entity_id)
 
 
+## Returns the scene entity definition covering the given parcel, or null when
+## the coordinator has not (yet) mapped that parcel to a scene.
+func get_scene_definition_at(coord: Vector2i) -> DclSceneEntityDefinition:
+	var scene_entity_id := scene_entity_coordinator.get_scene_entity_id(coord)
+	if scene_entity_id.is_empty():
+		return null
+	return scene_entity_coordinator.get_scene_definition(scene_entity_id)
+
+
 func get_scene_data_by_scene_id(scene_id: int) -> SceneItem:
 	for scene: SceneItem in loaded_scenes.values():
 		if scene.scene_number_id == scene_id:

--- a/godot/src/ui/pages/loading_screen/loading_screen.gd
+++ b/godot/src/ui/pages/loading_screen/loading_screen.gd
@@ -220,6 +220,12 @@ func _on_scene_runner_loading_started(_session_id: int, _expected_count: int) ->
 	if _loading_cancelled or _place_data_set:
 		return
 	var pos = Global.scene_fetcher.current_position
+	# Local preview scenes are not in the places catalog — a position query would return
+	# whatever Genesis City scene owns that parcel. Use the preview scene's own
+	# scene.json metadata (display.title / display.navmapThumbnail) instead.
+	if Global.cli.preview_mode or not Global.deep_link_obj.preview.is_empty():
+		_set_place_data_from_scene_definition(pos)
+		return
 	# For genesis (no intended world realm) a valid parcel is required for the API call.
 	# For DCL worlds the fetch is by realm name and position is irrelevant.
 	if _intended_realm.is_empty() and pos == SceneFetcher.INVALID_PARCEL:
@@ -244,6 +250,24 @@ func _async_fetch_place_data(pos: Vector2i, generation: int) -> void:
 	if data_array.is_empty():
 		return
 	set_place_data(data_array[0])
+
+
+func _set_place_data_from_scene_definition(pos: Vector2i) -> void:
+	var scene_definition: DclSceneEntityDefinition = Global.scene_fetcher.get_scene_definition_at(
+		pos
+	)
+	if scene_definition == null:
+		return
+	var data := {"title": String(scene_definition.get_title())}
+	var thumbnail_file := String(scene_definition.get_navmap_thumbnail())
+	if not thumbnail_file.is_empty():
+		var content_mapping := scene_definition.get_content_mapping()
+		var file_hash := String(content_mapping.get_hash(thumbnail_file))
+		if file_hash.is_empty():
+			printerr("Preview scene thumbnail not in content mapping: ", thumbnail_file)
+		else:
+			data["image"] = String(content_mapping.get_base_url()) + file_hash
+	set_place_data(data)
 
 
 func set_place_data(data: Dictionary) -> void:

--- a/lib/src/dcl/common/scene.rs
+++ b/lib/src/dcl/common/scene.rs
@@ -66,8 +66,10 @@ pub struct SceneMetaScene {
 }
 
 #[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
 pub struct SceneDisplay {
     pub title: Option<String>,
+    pub navmap_thumbnail: Option<String>,
 }
 
 #[derive(Default, Serialize, Deserialize, Debug)]
@@ -169,5 +171,42 @@ impl serde::Serialize for SceneMetaScene {
 
         let original = OriginalSceneMetaScene { base, parcels };
         original.serialize(serializer)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn scene_display_parses_navmap_thumbnail() {
+        let json = serde_json::json!({
+            "display": {
+                "title": "Raft Game",
+                "navmapThumbnail": "images/raft_game.png"
+            },
+            "main": "bin/index.js",
+            "scene": { "base": "14,5", "parcels": ["14,5", "14,6"] }
+        });
+
+        let meta: SceneEntityMetadata = serde_json::from_value(json).unwrap();
+        let display = meta.display.unwrap();
+        assert_eq!(display.title.as_deref(), Some("Raft Game"));
+        assert_eq!(
+            display.navmap_thumbnail.as_deref(),
+            Some("images/raft_game.png")
+        );
+    }
+
+    #[test]
+    fn scene_display_without_thumbnail_parses() {
+        let json = serde_json::json!({
+            "display": { "title": "No Thumb" },
+            "main": "bin/index.js",
+            "scene": { "base": "0,0", "parcels": ["0,0"] }
+        });
+
+        let meta: SceneEntityMetadata = serde_json::from_value(json).unwrap();
+        assert_eq!(meta.display.unwrap().navmap_thumbnail, None);
     }
 }

--- a/lib/src/realm/dcl_scene_entity_definition.rs
+++ b/lib/src/realm/dcl_scene_entity_definition.rs
@@ -51,6 +51,19 @@ impl DclSceneEntityDefinition {
         scene_display.to_godot()
     }
 
+    /// Relative path (within the scene's content mapping) of the scene.json
+    /// `display.navmapThumbnail` image, or empty when the scene defines none.
+    #[func]
+    fn get_navmap_thumbnail(&self) -> GString {
+        self.inner
+            .scene_meta_scene
+            .display
+            .as_ref()
+            .and_then(|d| d.navmap_thumbnail.as_deref())
+            .unwrap_or("")
+            .into()
+    }
+
     #[func]
     fn is_global(&self) -> bool {
         self.inner.is_global


### PR DESCRIPTION
## Problem

Entering a scene via preview mode (`decentraland://open?preview=http://<host>:8000&position=x,y`) showed the **Genesis City** place data on the loading screen — Genesis Plaza's thumbnail for scenes based at `0,0` — instead of the previewed scene's own thumbnail, even when the scene has `display.navmapThumbnail` set.

Fixes #2598

## Root cause

Two independent gaps:

1. **The loading screen only knew the Places API.** `loading_screen.gd` fetches place data by parcel position (`PlacesHelper.async_get_by_position`). A local preview realm is not in that catalog, so the query returns whatever **deployed Genesis scene owns those coordinates** — exactly the "coordinate-based lookup collision" theorized in the issue (verified: for a preview at `14,5` the API returns the unrelated Genesis scene at that parcel).
2. **`navmapThumbnail` was dropped at parse time.** The Rust scene-metadata parser (`SceneDisplay` in `lib/src/dcl/common/scene.rs`) only kept `display.title`, so the client had no access to the scene's own thumbnail even if the UI had wanted it.

## Fix

- **`lib/src/dcl/common/scene.rs`** — parse `display.navmapThumbnail` (serde camelCase) + unit tests.
- **`lib/src/realm/dcl_scene_entity_definition.rs`** — new `get_navmap_thumbnail()` `#[func]` binding.
- **`godot/src/logic/scene_fetcher.gd`** — `get_scene_definition_at(parcel)` helper (coordinator parcel → entity definition lookup).
- **`godot/src/ui/pages/loading_screen/loading_screen.gd`** — in preview mode (`Global.cli.preview_mode` or deeplink `preview=`), skip the Places API and populate the place UI from the local scene entity definition: title from `display.title`, background from `navmapThumbnail` resolved through the scene's content mapping (`base_url + hash`). Scenes without a thumbnail get a neutral loading state instead of Genesis data (also requested in #2598).

Timing is safe: `loading_started` fires from `start_loading_session`, which only runs after the coordinator has the scene definitions cached (`cache_city_pointers` and `cache_scene_data` are populated together in `handle_scene_data` / `handle_entity_pointers`).

## Verification

Live run against a real SDK preview server (`--preview --realm http://<lan-ip>:8000 --location 14,5`) — the loading screen shows the scene's title and its `navmapThumbnail`, fetched from the preview content server (screenshot in the issue thread).

- Confirmed via scene-inspector `eval` on the live client: `get_navmap_thumbnail()` → `images/raft_game.png`, resolved URL → `http://<preview>/content/contents/<hash>`, background texture applied (1364×768).
- The thumbnail file (2,458,125 bytes) lands in the texture cache during a real load.

## Test plan

- [x] `cargo test --lib` — 236 passed (includes 2 new serde tests for `navmapThumbnail`)
- [x] `cargo clippy` / `cargo fmt --all` clean
- [x] `gdformat` / `gdlint` clean on touched files
- [x] Desktop preview run: thumbnail + title shown; no errors from the new path
- [ ] Mobile deeplink QA pass (`decentraland://open?preview=...&position=...`) on device
- [ ] Preview scene *without* `navmapThumbnail`: neutral loading state (no Genesis data)
- [ ] Regression: Genesis + Worlds loading screens still show Places API data
