### PR TITLE
fix: long cache file names break preview asset loading (ENAMETOOLONG on Android)

### DIFF
--- a/godot/src/decentraland_components/video_player.gd
+++ b/godot/src/decentraland_components/video_player.gd
@@ -160,7 +160,7 @@ func _async_fetch_local_video() -> String:
 		video_state = VIDEO_STATE_ERROR
 		return ""
 
-	var local_video_path = "user://content/" + file_hash
+	var local_video_path = Global.content_provider.get_cache_file_path(file_hash)
 	return local_video_path.replace("user:/", OS.get_user_data_dir())
 
 
@@ -686,7 +686,7 @@ func async_request_video(file_hash):
 
 
 func _on_video_loaded(file_hash: String):
-	var local_video_path = "user://content/" + file_hash
+	var local_video_path = Global.content_provider.get_cache_file_path(file_hash)
 	var absolute_file_path = local_video_path.replace("user:/", OS.get_user_data_dir())
 	self.resolve_resource(absolute_file_path)
 

--- a/godot/src/logic/scene_fetcher.gd
+++ b/godot/src/logic/scene_fetcher.gd
@@ -941,7 +941,9 @@ func async_load_scene(
 	if scene_entity_definition.is_sdk7():
 		var script_path := scene_entity_definition.get_main_js_path()
 		script_promise = Global.content_provider.fetch_file(script_path, content_mapping)
-		local_main_js_path = "user://content/" + scene_entity_definition.get_main_js_hash()
+		local_main_js_path = Global.content_provider.get_cache_file_path(
+			scene_entity_definition.get_main_js_hash()
+		)
 	else:
 		if (
 			not FIXED_LOCAL_ADAPTATION_LAYER.is_empty()
@@ -976,7 +978,7 @@ func async_load_scene(
 	var main_crdt_file_hash := scene_entity_definition.get_main_crdt_hash()
 	var local_main_crdt_path: String = String()
 	if not main_crdt_file_hash.is_empty():
-		local_main_crdt_path = "user://content/" + main_crdt_file_hash
+		local_main_crdt_path = Global.content_provider.get_cache_file_path(main_crdt_file_hash)
 		var promise: Promise = Global.content_provider.fetch_file("main.crdt", content_mapping)
 
 		var res = await PromiseUtils.async_awaiter(promise)

--- a/godot/src/ui/components/organisms/debug_panel/debug_panel.gd
+++ b/godot/src/ui/components/organisms/debug_panel/debug_panel.gd
@@ -300,7 +300,7 @@ func _on_button_open_source_pressed():
 		printerr("no main js file found for current scene")
 		return
 
-	var js_file_path = "user://content/" + main_js_hash
+	var js_file_path = Global.content_provider.get_cache_file_path(main_js_hash)
 	var absolute_path = ProjectSettings.globalize_path(js_file_path)
 
 	if not FileAccess.file_exists(js_file_path):

--- a/lib/src/content/audio.rs
+++ b/lib/src/content/audio.rs
@@ -6,9 +6,9 @@ use godot::{
 };
 
 use super::{
-    content_mapping::ContentMappingAndUrlRef, content_provider::ContentProviderContext,
-    file_string::get_extension, packed_array::PackedByteArrayFromVec,
-    thread_safety::GodotSingleThreadSafety,
+    cache_file_name::cache_file_path, content_mapping::ContentMappingAndUrlRef,
+    content_provider::ContentProviderContext, file_string::get_extension,
+    packed_array::PackedByteArrayFromVec, thread_safety::GodotSingleThreadSafety,
 };
 
 pub async fn load_audio(
@@ -29,7 +29,7 @@ pub async fn load_audio(
         .ok_or(anyhow::Error::msg("File not found in the content mappings"))?;
 
     let url = format!("{}{}", content_mapping.base_url, file_hash);
-    let absolute_file_path = format!("{}{}", ctx.content_folder, file_hash);
+    let absolute_file_path = cache_file_path(&ctx.content_folder, file_hash);
 
     let bytes_vec = ctx
         .resource_provider

--- a/lib/src/content/cache_file_name.rs
+++ b/lib/src/content/cache_file_name.rs
@@ -19,11 +19,13 @@ use crate::godot_classes::dcl_hashing::hash_v1;
 /// Max length of a single path component on every filesystem we ship on.
 const MAX_FILE_NAME_BYTES: usize = 255;
 
-/// Budget reserved for what callers add around the hash: the `wearable_`/`emote_` prefixes and
-/// the `.scn` / `.tmp` (download in progress) suffixes.
-const RESERVED_BYTES: usize = 16;
-
-const MAX_HASH_BYTES: usize = MAX_FILE_NAME_BYTES - RESERVED_BYTES;
+/// Hard cap on the hash part of a cache file name. Well under `MAX_FILE_NAME_BYTES` on
+/// purpose: it leaves room for the `wearable_`/`emote_` prefixes and the `.scn` / `.tmp`
+/// suffixes callers add, and it keeps the *whole* path short on platforms that bound the
+/// full path too (Windows `MAX_PATH` is 260 for the entire string). Everything we hash
+/// legitimately is far below it — catalyst CIDs are 59 bytes and url-texture
+/// `hashed_{hex}_q{N}` names ~74 — so in practice only oversized preview hashes fold.
+const MAX_HASH_BYTES: usize = 128;
 
 /// File name to use inside the content cache folder for `hash`.
 ///
@@ -52,10 +54,15 @@ mod tests {
     }
 
     #[test]
-    fn short_hashes_are_used_verbatim() {
+    fn names_within_the_cap_are_used_verbatim() {
         let cid = "bafkreibmrvrdgqthfrvehyell552sk7ivuas2ozzjdmlojbzttqlcrxiya";
         assert_eq!(cache_file_name(cid), cid);
         assert!(matches!(cache_file_name(cid), Cow::Borrowed(_)));
+
+        // The cap is exact: MAX_HASH_BYTES still passes through, one more byte folds.
+        let at_cap = "a".repeat(MAX_HASH_BYTES);
+        assert_eq!(cache_file_name(&at_cap), at_cap.as_str());
+        assert_ne!(cache_file_name(&format!("{}a", at_cap)), at_cap.as_str());
     }
 
     #[test]
@@ -65,7 +72,7 @@ mod tests {
 
         let name = cache_file_name(&hash);
         assert_ne!(name, hash.as_str());
-        assert!(format!("wearable_{}.scn", name).len() <= MAX_FILE_NAME_BYTES);
+        assert!(format!("wearable_{}.scn", name).len() <= MAX_HASH_BYTES);
     }
 
     #[test]

--- a/lib/src/content/cache_file_name.rs
+++ b/lib/src/content/cache_file_name.rs
@@ -1,0 +1,92 @@
+//! Maps a content hash to the name it gets inside the content cache folder.
+//!
+//! Catalyst hashes are short CIDs (`bafkrei…`, 59 chars) and can be used verbatim, but the
+//! SDK preview server hashes a file as `b64-<base64(absolute_path + "-" + machine_id)>`
+//! (see `b64HashingFunction` in @dcl/sdk-commands). That name grows with the developer's
+//! project path: a scene living in a deep folder produces 250-300+ char hashes, past the
+//! 255-byte per-component filename limit of ext4/f2fs (Android), APFS and NTFS. `File::create`
+//! then fails with ENAMETOOLONG ("File name too long") and the asset never loads.
+//!
+//! Names that don't fit — or that contain a path separator, which base64 can emit — are folded
+//! into a short deterministic digest of the hash. The mapping is pure and stable across runs,
+//! so cache hits keep working; short hashes are returned untouched, so existing caches and the
+//! `-mobile.zip` / `.scn` naming built on top of them are unaffected.
+
+use std::borrow::Cow;
+
+use crate::godot_classes::dcl_hashing::hash_v1;
+
+/// Max length of a single path component on every filesystem we ship on.
+const MAX_FILE_NAME_BYTES: usize = 255;
+
+/// Budget reserved for what callers add around the hash: the `wearable_`/`emote_` prefixes and
+/// the `.scn` / `.tmp` (download in progress) suffixes.
+const RESERVED_BYTES: usize = 16;
+
+const MAX_HASH_BYTES: usize = MAX_FILE_NAME_BYTES - RESERVED_BYTES;
+
+/// File name to use inside the content cache folder for `hash`.
+///
+/// Only the on-disk name is folded — the hash itself stays the identity used for URLs,
+/// content mappings and in-flight bookkeeping.
+pub fn cache_file_name(hash: &str) -> Cow<'_, str> {
+    if hash.len() <= MAX_HASH_BYTES && !hash.contains(['/', '\\']) {
+        return Cow::Borrowed(hash);
+    }
+    Cow::Owned(format!("long-{}", hash_v1(hash.as_bytes())))
+}
+
+/// Absolute path of `hash` inside `content_folder` (which already ends with a separator).
+pub fn cache_file_path(content_folder: &str, hash: &str) -> String {
+    format!("{}{}", content_folder, cache_file_name(hash))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A preview hash for a file inside a deeply nested project. Verbatim it is longer than
+    /// any filesystem allows, which is what made every asset of such a scene fail to download.
+    fn long_preview_hash() -> String {
+        format!("b64-{}", "QUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVo=".repeat(8))
+    }
+
+    #[test]
+    fn short_hashes_are_used_verbatim() {
+        let cid = "bafkreibmrvrdgqthfrvehyell552sk7ivuas2ozzjdmlojbzttqlcrxiya";
+        assert_eq!(cache_file_name(cid), cid);
+        assert!(matches!(cache_file_name(cid), Cow::Borrowed(_)));
+    }
+
+    #[test]
+    fn long_hashes_fold_into_a_name_that_fits_with_room_for_prefixes_and_suffixes() {
+        let hash = long_preview_hash();
+        assert!(hash.len() > MAX_FILE_NAME_BYTES);
+
+        let name = cache_file_name(&hash);
+        assert_ne!(name, hash.as_str());
+        assert!(format!("wearable_{}.scn", name).len() <= MAX_FILE_NAME_BYTES);
+    }
+
+    #[test]
+    fn folding_is_stable_and_distinguishes_hashes() {
+        let hash = long_preview_hash();
+        let other = format!("{}x", hash);
+        assert_eq!(cache_file_name(&hash), cache_file_name(&hash));
+        assert_ne!(cache_file_name(&hash), cache_file_name(&other));
+    }
+
+    /// base64 can emit `/`, which would otherwise turn the cache file name into a
+    /// non-existent sub-directory.
+    #[test]
+    fn path_separators_are_folded_away() {
+        let name = cache_file_name("b64-abc/def");
+        assert!(!name.contains('/'));
+    }
+
+    #[test]
+    fn folded_names_are_stable_under_a_second_fold() {
+        let folded = cache_file_name(&long_preview_hash()).into_owned();
+        assert_eq!(cache_file_name(&folded), folded.as_str());
+    }
+}

--- a/lib/src/content/cache_file_name.rs
+++ b/lib/src/content/cache_file_name.rs
@@ -16,7 +16,8 @@ use std::borrow::Cow;
 
 use crate::godot_classes::dcl_hashing::hash_v1;
 
-/// Max length of a single path component on every filesystem we ship on.
+/// Max length of a single path component on every filesystem we ship on. The cap below has to
+/// stay under it — with room for what callers add around the hash.
 const MAX_FILE_NAME_BYTES: usize = 255;
 
 /// Hard cap on the hash part of a cache file name. Well under `MAX_FILE_NAME_BYTES` on
@@ -26,6 +27,8 @@ const MAX_FILE_NAME_BYTES: usize = 255;
 /// legitimately is far below it — catalyst CIDs are 59 bytes and url-texture
 /// `hashed_{hex}_q{N}` names ~74 — so in practice only oversized preview hashes fold.
 const MAX_HASH_BYTES: usize = 128;
+
+const _: () = assert!(MAX_HASH_BYTES < MAX_FILE_NAME_BYTES);
 
 /// File name to use inside the content cache folder for `hash`.
 ///

--- a/lib/src/content/content_provider.rs
+++ b/lib/src/content/content_provider.rs
@@ -38,6 +38,7 @@ use crate::godot_classes::dcl_resource_tracker::{
 
 use super::{
     audio::load_audio,
+    cache_file_name::{cache_file_name, cache_file_path},
     gltf::{
         build_dcl_emote_gltf, get_last_16_alphanumeric, load_and_save_emote_gltf,
         load_and_save_scene_gltf, load_and_save_wearable_gltf, DclEmoteGltf,
@@ -521,6 +522,17 @@ impl ContentProvider {
     pub fn get_scene_cache_path(&self, file_hash: GString) -> GString {
         let path = get_scene_path_for_hash(&self.content_folder, &file_hash.to_string());
         GString::from(path.as_str())
+    }
+
+    /// `user://content/<name>` for a downloaded file: the name a hash gets on disk.
+    ///
+    /// Preview hashes (`b64-<base64 of the scene's absolute path>`) can be longer than the
+    /// 255-byte filename limit, so they are folded — GDScript must go through here instead of
+    /// concatenating the raw hash, or it will look for a file the cache never wrote.
+    #[func]
+    pub fn get_cache_file_path(&self, file_hash: GString) -> GString {
+        let name = cache_file_name(&file_hash.to_string()).into_owned();
+        GString::from(format!("user://content/{}", name).as_str())
     }
 
     // =========================================================================
@@ -1263,7 +1275,7 @@ impl ContentProvider {
 
             loading_resources.fetch_add(1, Ordering::Relaxed);
 
-            let absolute_file_path = format!("{}{}", ctx.content_folder, hash_id);
+            let absolute_file_path = cache_file_path(&ctx.content_folder, &hash_id);
 
             if ctx
                 .resource_provider
@@ -1876,10 +1888,11 @@ impl ContentProvider {
     /// land. Powers the preview scene-stats Content size / External content rows.
     #[func]
     pub fn get_cache_size_for_base_names(&self, base_names: PackedStringArray) -> i64 {
+        // Match against the names the cache actually wrote: long preview hashes are folded.
         let wanted: std::collections::HashSet<String> = base_names
             .as_slice()
             .iter()
-            .map(|s| s.to_string())
+            .map(|s| cache_file_name(&s.to_string()).into_owned())
             .collect();
         self.resource_provider
             .get_cache_size_for_base_names(&wanted)
@@ -2437,7 +2450,7 @@ impl ContentProvider {
     #[func]
     pub fn purge_file(&mut self, file_hash: GString) -> Gd<Promise> {
         let file_hash_str = file_hash.to_string();
-        let absolute_file_path = format!("{}{}", self.content_folder, file_hash);
+        let absolute_file_path = cache_file_path(&self.content_folder, &file_hash_str);
 
         let resource_provider = self.resource_provider.clone();
         let (promise, get_promise) = Promise::make_to_async();

--- a/lib/src/content/gltf/common.rs
+++ b/lib/src/content/gltf/common.rs
@@ -21,8 +21,11 @@ use tokio::sync::Semaphore;
 use crate::content::texture::resize_image;
 
 use super::super::{
-    content_mapping::ContentMappingAndUrlRef, content_provider::SceneGltfContext,
-    file_string::get_base_dir, texture::create_compressed_texture,
+    cache_file_name::{cache_file_name, cache_file_path},
+    content_mapping::ContentMappingAndUrlRef,
+    content_provider::SceneGltfContext,
+    file_string::get_base_dir,
+    texture::create_compressed_texture,
 };
 
 #[cfg(feature = "use_resource_tracking")]
@@ -940,7 +943,7 @@ where
     // Download the main GLTF file
     let base_path = Arc::new(get_base_dir(&file_path));
     let url = format!("{}{}", content_mapping.base_url, file_hash);
-    let absolute_file_path = format!("{}{}", ctx.content_folder, file_hash);
+    let absolute_file_path = cache_file_path(&ctx.content_folder, &file_hash);
 
     #[cfg(feature = "use_resource_tracking")]
     report_resource_start(&file_hash, "gltf");
@@ -994,7 +997,7 @@ where
             report_resource_start(&dep_hash, "gltf_dep");
 
             let url = format!("{}{}", content_mapping.base_url, dep_hash);
-            let absolute_file_path = format!("{}{}", ctx.content_folder, dep_hash);
+            let absolute_file_path = cache_file_path(&ctx.content_folder, &dep_hash);
             let result = ctx
                 .resource_provider
                 .fetch_resource(url, dep_hash.clone(), absolute_file_path)
@@ -1031,11 +1034,16 @@ where
         let mut new_gltf = GltfDocument::new_gd();
         let mut new_gltf_state = GltfState::new_gd();
 
-        let mappings = VarDictionary::from_iter(
-            dependencies_hash
-                .iter()
-                .map(|(file_path, hash)| (file_path.to_variant(), hash.to_variant())),
-        );
+        // The importer rewrites each buffer/image `uri` to the value found here and Godot
+        // resolves it against `base_path` (the cache folder), so these must be the on-disk
+        // cache file names, not the raw hashes.
+        let mappings =
+            VarDictionary::from_iter(dependencies_hash.iter().map(|(file_path, hash)| {
+                (
+                    file_path.to_variant(),
+                    cache_file_name(hash).as_ref().to_variant(),
+                )
+            }));
 
         new_gltf_state.set_additional_data("base_path", &"some".to_variant());
         new_gltf_state.set_additional_data("mappings", &mappings.to_variant());

--- a/lib/src/content/mod.rs
+++ b/lib/src/content/mod.rs
@@ -1,4 +1,5 @@
 mod audio;
+pub mod cache_file_name;
 pub mod content_mapping;
 pub mod content_notificator;
 pub mod content_provider;

--- a/lib/src/content/resource_provider.rs
+++ b/lib/src/content/resource_provider.rs
@@ -12,6 +12,7 @@ use tokio::time::{timeout, Instant};
 
 #[cfg(feature = "use_resource_tracking")]
 use super::resource_download_tracking::ResourceDownloadTracking;
+use crate::content::cache_file_name::cache_file_name;
 use crate::content::semaphore_ext::CappedSemaphore;
 
 pub struct FileMetadata {
@@ -184,7 +185,7 @@ impl ResourceProvider {
     /// Delete a file from the cache by its hash.
     /// Returns the metadata if the file was found and deleted.
     pub async fn delete_file_by_hash(&self, file_hash: &str) -> Option<FileMetadata> {
-        let file_path = self.cache_folder.join(file_hash);
+        let file_path = self.cache_folder.join(cache_file_name(file_hash).as_ref());
         let file_path = file_path.to_str().unwrap().to_string();
         self.delete_file(&file_path).await
     }
@@ -468,7 +469,7 @@ impl ResourceProvider {
 
     pub async fn file_exists(&self, file_hash: &str) -> bool {
         let existing_files = self.existing_files.read().await;
-        let absolute_file_path = self.cache_folder.join(file_hash);
+        let absolute_file_path = self.cache_folder.join(cache_file_name(file_hash).as_ref());
         let absolute_file_path = absolute_file_path.to_str().unwrap().to_string();
         existing_files.contains_key(&absolute_file_path)
     }
@@ -489,7 +490,7 @@ impl ResourceProvider {
 
     pub async fn store_file(&self, file_hash: &str, bytes: &[u8]) -> Result<(), String> {
         self.ensure_initialized().await?;
-        let absolute_file_path = self.cache_folder.join(file_hash);
+        let absolute_file_path = self.cache_folder.join(cache_file_name(file_hash).as_ref());
 
         // Write the bytes to a temporary file first
         let tmp_dest = absolute_file_path.with_extension("tmp");

--- a/lib/src/content/scene_saver.rs
+++ b/lib/src/content/scene_saver.rs
@@ -14,6 +14,8 @@ use godot::classes::resource_saver::SaverFlags;
 use godot::classes::{Node, PackedScene, Resource, ResourceSaver};
 use godot::prelude::*;
 
+use super::cache_file_name::cache_file_name;
+
 /// Saves a Node3D as a PackedScene to the specified file path
 ///
 /// # Arguments
@@ -49,7 +51,7 @@ pub fn save_node_as_scene(node: Gd<Node3D>, file_path: &str) -> Result<(), Strin
 /// * `content_folder` - The cache folder path (e.g., "/path/to/cache/")
 /// * `hash` - The content hash
 pub fn get_scene_path_for_hash(content_folder: &str, hash: &str) -> String {
-    format!("{}{}.scn", content_folder, hash)
+    format!("{}{}.scn", content_folder, cache_file_name(hash))
 }
 
 /// Gets the absolute path for a cached wearable scene by its hash
@@ -58,7 +60,7 @@ pub fn get_scene_path_for_hash(content_folder: &str, hash: &str) -> String {
 /// * `content_folder` - The cache folder path (e.g., "/path/to/cache/")
 /// * `hash` - The content hash
 pub fn get_wearable_path_for_hash(content_folder: &str, hash: &str) -> String {
-    format!("{}wearable_{}.scn", content_folder, hash)
+    format!("{}wearable_{}.scn", content_folder, cache_file_name(hash))
 }
 
 /// Gets the absolute path for a cached emote scene by its hash
@@ -67,5 +69,5 @@ pub fn get_wearable_path_for_hash(content_folder: &str, hash: &str) -> String {
 /// * `content_folder` - The cache folder path (e.g., "/path/to/cache/")
 /// * `hash` - The content hash
 pub fn get_emote_path_for_hash(content_folder: &str, hash: &str) -> String {
-    format!("{}emote_{}.scn", content_folder, hash)
+    format!("{}emote_{}.scn", content_folder, cache_file_name(hash))
 }

--- a/lib/src/content/texture.rs
+++ b/lib/src/content/texture.rs
@@ -1,8 +1,8 @@
 use crate::utils::infer_mime;
 
 use super::{
-    content_provider::ContentProviderContext, packed_array::PackedByteArrayFromVec,
-    thread_safety::GodotSingleThreadSafety,
+    cache_file_name::cache_file_path, content_provider::ContentProviderContext,
+    packed_array::PackedByteArrayFromVec, thread_safety::GodotSingleThreadSafety,
 };
 use godot::{
     builtin::{GString, PackedByteArray, Variant, Vector2i},
@@ -243,7 +243,7 @@ pub async fn load_image_texture(
     file_hash: String,
     ctx: ContentProviderContext,
 ) -> Result<Option<Variant>, anyhow::Error> {
-    let absolute_file_path = format!("{}{}", ctx.content_folder, file_hash);
+    let absolute_file_path = cache_file_path(&ctx.content_folder, &file_hash);
     let bytes_vec = ctx
         .resource_provider
         .fetch_resource_with_data(&url, &file_hash, &absolute_file_path)

--- a/lib/src/content/video.rs
+++ b/lib/src/content/video.rs
@@ -1,4 +1,7 @@
-use super::{content_mapping::ContentMappingAndUrlRef, content_provider::ContentProviderContext};
+use super::{
+    cache_file_name::cache_file_path, content_mapping::ContentMappingAndUrlRef,
+    content_provider::ContentProviderContext,
+};
 use godot::builtin::Variant;
 
 pub async fn download_video(
@@ -7,7 +10,7 @@ pub async fn download_video(
     ctx: ContentProviderContext,
 ) -> Result<Option<Variant>, anyhow::Error> {
     let url = format!("{}{}", content_mapping.base_url, file_hash);
-    let absolute_file_path = format!("{}{}", ctx.content_folder, file_hash);
+    let absolute_file_path = cache_file_path(&ctx.content_folder, &file_hash);
     ctx.resource_provider
         .fetch_resource(url, file_hash, absolute_file_path)
         .await


### PR DESCRIPTION
## Problem

Previewing a scene from a deep folder loads almost none of its assets:

```
GLTF load error for assets/asset-packs/lava/lava.glb: File creation error:
Os { code: 36, kind: InvalidFilename, message: "File name too long" }
```

The SDK preview server hashes every file as `b64-<base64(absolutePath + "-" + os.hostname())>` (`b64HashingFunction` in `@dcl/sdk-commands`), and we used that hash verbatim as the file name inside the content cache folder. The name therefore grows with the developer's project path: a scene root of ~156 chars or more produces hashes past the **255-byte per-component filename limit** of ext4/f2fs (Android), APFS and NTFS, so every `File::create` in the cache fails with `ENAMETOOLONG`.

Reproduced on a **Samsung A54** with a scene whose root path is 128 chars: hashes came out 224–308 chars and **120 of the scene's 145 files were unreachable**. The ones that did load were exactly the short-path ones (`bin/index.js`, `main.crdt`) — which is why the scene ran but came up empty.

Not Android-specific: the same scene fails on macOS/Windows desktop preview too.

## Fix

New `lib/src/content/cache_file_name.rs` folds any hash over a hard cap of **128 bytes** — or one containing a path separator, which base64 can emit — into a short deterministic digest (`long-<hash_v1>`, 64 bytes). The cap is well under the 255-byte filesystem limit on purpose: it leaves room for the `wearable_`/`emote_` prefixes and `.scn` / `.tmp` suffixes callers add, and keeps the *whole* path short on platforms that bound the full string too (Windows `MAX_PATH` is 260). Everything we hash legitimately is far below it — catalyst CIDs are 59 bytes, url-texture `hashed_{hex}_q{N}` names ~74 — so existing caches and the `-mobile.zip` / `.scn` naming built on top of them are unaffected, and the fold is stable across runs so cache hits keep working.

Applied at every hash-to-path site:

- `resource_provider` (`file_exists` / `store_file` / `delete_file_by_hash`)
- `scene_saver` (`.scn`, `wearable_`, `emote_` paths)
- `texture`, `audio`, `video`
- `gltf/common` — main file, dependencies, and the `mappings` dict the custom importer resolves against the cache folder
- `content_provider` (`fetch_file_by_url`, `purge_file`, and the scene-stats size lookup)

GDScript also concatenated the raw hash in a few places (`main.js`, `main.crdt`, video), so those now go through a new `content_provider.get_cache_file_path()`.

The `<hash>-mobile.zip` optimized-asset paths are deliberately left alone: there the same string is also the download URL, and only catalyst CIDs ever reach it.

## Testing

- 5 unit tests in the new module (names at/over the cap, folding fits with room for the `wearable_`/`.scn`/`.tmp` decorations, stability, separator handling, idempotency).
- Verified on device (Samsung A54) against a local preview of the offending scene: the cache now holds the folded `long-bafkrei…` names — including `main.js` and `main.crdt`, which exercise the GDScript side — the scene loads and **0 GLTF load errors**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
