### PR TITLE
fix: re-parented GLTF container pins the loading screen for 2 minutes

### DIFF
--- a/godot/src/decentraland_components/gltf_container.gd
+++ b/godot/src/decentraland_components/gltf_container.gd
@@ -26,14 +26,30 @@ func _ready():
 
 
 func _exit_tree():
-	# Detach from the shared load group
+	# Detach from the shared load group. Leaving the tree is NOT the same as
+	# finishing the load: `dcl_gltf_loading_state` deliberately stays LOADING so a
+	# re-parented container resumes rather than reporting a false FINISHED. Clearing
+	# `_requested_hash` is what marks it as "no longer attached to any group" —
+	# `_enter_tree` uses exactly that to re-request.
 	if not _requested_hash.is_empty():
 		GltfLoadingCoordinator.unregister(self, _requested_hash)
+		_requested_hash = ""
 
 	# Free pending orphan node (legacy path)
 	if dcl_pending_node != null:
 		dcl_pending_node.queue_free()
 		dcl_pending_node = null
+
+
+func _enter_tree():
+	# Re-parenting an entity (a normal SDK operation) takes its GltfContainer out of
+	# the tree and back in. `_ready` only ever runs once, so without this the load is
+	# never re-requested: the container sits in LOADING with no group behind it, Rust
+	# keeps counting it in `scene.gltf_loading`, and the loading screen stays pinned
+	# until the 120s per-container timeout. Only re-request when we are genuinely
+	# mid-load and detached — a FINISHED or errored container must not reload.
+	if dcl_gltf_loading_state == GltfContainerLoadingState.LOADING and _requested_hash.is_empty():
+		async_load_gltf.call_deferred()
 
 
 #region Loading Flow

--- a/lib/src/scene_runner/loading_session.rs
+++ b/lib/src/scene_runner/loading_session.rs
@@ -360,8 +360,15 @@ impl LoadingSession {
                 // Check if all registered assets are loaded
                 let total_expected: u32 = self.expected_assets.values().sum();
                 let total_loaded: u32 = self.loaded_assets.values().sum();
+                // A scene already in `ready_scenes` no longer gates this phase: either it
+                // genuinely finished, or `check_loading_timeouts` force-marked it ready after
+                // SCENE_TIMEOUT_SECS without progress. That timeout was the only escape from a
+                // stalled load, but it fed `ready_scenes` alone — so this gate stayed pinned on
+                // assets that were never going to arrive, and a single unresolved GLTF could hold
+                // the loading screen for minutes with the scene fully playable behind it.
                 let all_loaded = self.expected_assets.iter().all(|(scene_id, expected)| {
-                    self.loaded_assets.get(scene_id).unwrap_or(&0) >= expected
+                    self.ready_scenes.contains(scene_id)
+                        || self.loaded_assets.get(scene_id).unwrap_or(&0) >= expected
                 });
 
                 // Transition conditions:
@@ -497,6 +504,59 @@ mod tests {
         session.report_scene_ready(SceneId(1));
         session.check_phase_transition();
         assert_eq!(session.phase, LoadingPhase::Done);
+    }
+
+    /// A GLTF that never reports finished must not pin the Assets phase forever.
+    ///
+    /// Reproduces the observed stall: a scene loads 5 of 6 assets and the 6th never
+    /// resolves (its container was detached from the shared load group and left in
+    /// LOADING). The per-scene timeout marks the scene ready; the session must then
+    /// be able to complete instead of waiting on an asset that will never arrive.
+    #[test]
+    fn test_stalled_asset_does_not_pin_assets_phase() {
+        let mut session = LoadingSession::new(1, vec!["scene1".to_string()]);
+        session.report_scene_fetched("scene1");
+        session.check_phase_transition();
+        session.report_scene_spawned(SceneId(1), 0);
+        session.check_phase_transition();
+        assert_eq!(session.phase, LoadingPhase::Assets);
+
+        // Six assets discovered, only five ever complete.
+        for _ in 0..6 {
+            session.report_asset_loading_started(SceneId(1));
+        }
+        for _ in 0..5 {
+            session.report_asset_loaded(SceneId(1));
+        }
+
+        // Discovery has settled, so only the missing asset holds the phase.
+        session.assets_phase_start = Some(Instant::now() - std::time::Duration::from_secs(6));
+        session.last_asset_registered = Some(Instant::now() - std::time::Duration::from_secs(6));
+        session.check_phase_transition();
+        assert_eq!(
+            session.phase,
+            LoadingPhase::Assets,
+            "phase must hold while the scene still looks alive"
+        );
+
+        // The scene goes quiet past SCENE_TIMEOUT_SECS, so the timeout sweep force-marks
+        // it ready — the existing escape hatch that previously did not reach this gate.
+        let stalled =
+            Instant::now() - std::time::Duration::from_secs(LoadingSession::SCENE_TIMEOUT_SECS + 1);
+        session.scene_last_progress.insert(SceneId(1), stalled);
+        let timed_out = session.get_timed_out_scenes(Instant::now());
+        assert_eq!(timed_out, vec![SceneId(1)]);
+        session.mark_timed_out_scenes_ready(timed_out);
+
+        session.check_phase_transition();
+        assert_eq!(session.phase, LoadingPhase::Ready);
+        session.check_phase_transition();
+        assert_eq!(
+            session.phase,
+            LoadingPhase::Done,
+            "a permanently stalled asset must not hold the loading screen"
+        );
+        assert_eq!(session.calculate_progress(), 100.0);
     }
 
     #[test]


### PR DESCRIPTION
## Problem

A scene can sit on the loading screen for **~2 minutes** while it is already fully playable behind it — the "RUN ANYWAY" path works instantly and everything is there. Observed on an Android device against a local SDK preview, but neither defect is preview-specific.

The hang is not infinite: it ends at **125s**, terminated by the 120s per-container timeout in `gltf_container.gd`, not by anything recovering.

## Root cause

**1. A re-parented `GltfContainer` never resumes its load.**

Re-parenting an entity is a normal SDK operation, and it takes the container out of the scene tree and back in. `_exit_tree` detached the container from its shared `LoadGroup` but left `dcl_gltf_loading_state` at `LOADING` with `_requested_hash` still set — and `_ready`, the only caller of `async_load_gltf`, runs **once per node**, so re-entering the tree re-requested nothing.

The container was then in `LOADING` with no group behind it and no way back: Rust kept counting it in `scene.gltf_loading`, so the session's `expected_assets` never balanced and the Assets phase never cleared.

On-device trace that pinned it (instrumented build, since reverted). One `coin_01.glb` group:

```
12:18:00.829  CREATE   coin_01.glb
              ATTACH   x30
12:18:05.34–.43  UNREGISTER x30   group state=STATE_REALIZING(3), every waiter still LOADING
              ERASE-retire       waiters=0
              (zero further events for this group)
```

Entities 2341–2346 each show `ATTACH=1, UNREGISTER=1` and never re-register. Six containers, stuck forever.

**2. The Assets phase had no escape hatch, which turned 6 stuck assets into a full-screen stall.**

`check_loading_timeouts` already force-marks a scene ready after `SCENE_TIMEOUT_SECS` without progress — but it only fed `ready_scenes`, and the `all_loaded` gate never consulted that set. So the one existing recovery path could not actually release the phase, and **6 unresolved assets out of 231** held the entire loading screen.

## Fix

**`godot/src/decentraland_components/gltf_container.gd`**
- `_exit_tree` now clears `_requested_hash`, which is what marks the container as "detached from any group". The loading state deliberately **stays** `LOADING` across the detach, so a re-parent resumes rather than reporting a false `FINISHED`.
- New `_enter_tree` re-requests the load when it finds itself mid-load and detached. The guard is `state == LOADING and _requested_hash.is_empty()`, so a finished or errored container is never reloaded. On the very first tree entry `_enter_tree` runs before `_ready` while the state is still `UNKNOWN`, so the guard fails and no double request happens; `GltfLoadingCoordinator.request()` is idempotent anyway (`if group.waiters.has(container): return`).

**`lib/src/scene_runner/loading_session.rs`**
- A scene in `ready_scenes` no longer gates the Assets phase — either it genuinely finished, or the timeout sweep force-marked it ready. This connects the existing timeout to the gate it was always meant to release.

## Testing

- New `test_stalled_asset_does_not_pin_assets_phase` reproduces the scenario end to end: 6 assets started, 5 loaded, discovery settled, scene goes quiet past `SCENE_TIMEOUT_SECS` → the sweep marks it ready → the session must reach `Done` at 100%. Verified non-vacuous (fails on the pre-fix gate).
- `cargo test --lib loading_session` → 5/5 pass. `cargo clippy -- -D warnings` clean, `gdformat`/`gdlint` clean over `godot/`.
- **Not yet verified on device:** the GDScript side has no automated coverage. Repro is: start a local preview, enter the scene, kill the preview server mid-load — the loading screen should now dismiss instead of waiting out the 120s timeout. Adding the `build` label to get an APK for that check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
