### PR TITLE
fix: loading screen pinned forever when no island parcel is in view

### DIFF
--- a/lib/src/godot_classes/dcl_floating_islands_manager.rs
+++ b/lib/src/godot_classes/dcl_floating_islands_manager.rs
@@ -26,6 +26,11 @@ use crate::godot_classes::floating_islands::{
     PARCEL_HALF_SIZE, PARCEL_HEIGHT_BOUND, PARCEL_SIZE, TERRAIN_MATERIAL_PATH,
 };
 
+/// How long `tick_culling` must keep finding zero candidate parcels in view before it
+/// treats generation as finished. Debounced rather than immediate so a startup frame
+/// where the camera is not yet positioned cannot cut generation short.
+const EMPTY_VIEW_COMPLETE_MS: u64 = 1000;
+
 #[derive(GodotClass)]
 #[class(base=Node)]
 pub struct DclFloatingIslandsManager {
@@ -43,6 +48,9 @@ pub struct DclFloatingIslandsManager {
     generating: bool,
     generated_so_far: i32,
     generation_total: i32,
+    /// Ticks-msec of the first tick that found zero candidates in view while generating;
+    /// 0 whenever the last tick did find some. See `EMPTY_VIEW_COMPLETE_MS`.
+    empty_view_since_msec: u64,
 
     scenario: Rid,
     physics_space: Rid,
@@ -100,6 +108,7 @@ impl INode for DclFloatingIslandsManager {
             generating: false,
             generated_so_far: 0,
             generation_total: 0,
+            empty_view_since_msec: 0,
             scenario: Rid::Invalid,
             physics_space: Rid::Invalid,
             terrain_material: None,
@@ -214,6 +223,7 @@ impl DclFloatingIslandsManager {
         self.generating = true;
         self.generated_so_far = 0;
         self.generation_total = self.candidates.len() as i32;
+        self.empty_view_since_msec = 0;
     }
 
     #[func]
@@ -248,6 +258,7 @@ impl DclFloatingIslandsManager {
         self.generating = false;
         self.generated_so_far = 0;
         self.generation_total = 0;
+        self.empty_view_since_msec = 0;
         if let Some(worker) = &self.worker {
             while worker.rx.try_recv().is_ok() {}
         }
@@ -528,12 +539,44 @@ impl DclFloatingIslandsManager {
             );
         }
 
-        if self.generating
-            && in_view_candidates > 0
-            && self.in_view_all_materialized(player, view, &camera)
-        {
-            self.generating = false;
-            self.base_mut().emit_signal("generation_complete", &[]);
+        if self.generating {
+            if in_view_candidates > 0 {
+                self.empty_view_since_msec = 0;
+                if self.in_view_all_materialized(player, view, &camera) {
+                    self.generating = false;
+                    self.base_mut().emit_signal("generation_complete", &[]);
+                }
+            } else if self.empty_view_since_msec == 0 {
+                self.empty_view_since_msec = now_msec;
+            } else if now_msec.saturating_sub(self.empty_view_since_msec) >= EMPTY_VIEW_COMPLETE_MS
+            {
+                // Nothing has been in view for the whole debounce window, so there is
+                // nothing left to materialize and generation is vacuously done.
+                //
+                // Without this, `in_view_candidates == 0` made the branch above
+                // unsatisfiable: no parcel is enqueued, so `generation_progress` never
+                // fires either, and `generating` stays true forever. GDScript's
+                // `generation_complete` handler is the only thing that clears
+                // `waiting_for_floating_islands` on the loading session, and its Assets
+                // phase returns early while that flag is set — so the loading screen
+                // stayed pinned over a fully loaded, fully rendered scene until the user
+                // hit "START ANYWAY".
+                //
+                // Reproduced on a World whose parcels sat within view distance of the
+                // player but were all rejected by the camera-visibility test, with none
+                // in the `dist <= 1` ring that bypasses it. The session held at
+                // `all_loaded=true` for over 8 minutes.
+                tracing::debug!(
+                    "[LOADING] floating islands: completing with no candidates in view \
+                     (candidates={}, player={:?}, view={})",
+                    self.candidates.len(),
+                    (player.x, player.y),
+                    view
+                );
+                self.generating = false;
+                self.empty_view_since_msec = 0;
+                self.base_mut().emit_signal("generation_complete", &[]);
+            }
         }
     }
 


### PR DESCRIPTION
Fixes #2634 

## Problem

The loading screen can stay up **indefinitely** over a scene that is already fully loaded and rendered. The user only gets out via the "Loading is taking longer than expected → START ANYWAY" modal, and everything works instantly once they do.

Captured on a Samsung A54, instrumented build (instrumentation not included here). The session sat like this for over 8 minutes:

```
t=  4.1s  phase=Assets  assets=40/40  ready=1
          waiting_islands=true  islands=0/176
          grace_ms=4029 (passed=true)  stable=true  all_loaded=true
...
t=470.0s  phase=Assets  assets=40/40  ready=1
          waiting_islands=true  islands=0/176   ← unchanged
```

Every real gate condition is `true` from 4.1s on. The phase is held by one flag.

## Root cause

`tick_culling` only emits `generation_complete` when `in_view_candidates > 0`:

```rust
if self.generating
    && in_view_candidates > 0
    && self.in_view_all_materialized(player, view, &camera)
```

A candidate counts toward that number when it is within the `dist <= 1` ring **or** passes `parcel_in_camera_view`. When every nearby candidate fails the camera test and none sits in the inner ring, the counter stays at zero and the condition becomes unsatisfiable. The same pass enqueues nothing in that state, so `generation_progress` never fires either and `generated_so_far` stays at 0 — generation is stuck with no way out.

The observed run makes the distinction concrete. The candidates are **not** far away:

```
islands candidates set: n=176 player=(0, 0) view=7
                        sample=[(-1, -3), (14, 20), (-3, 13), (2, -2), ...]
islands tick: candidates=176 in_view=0 missing_enqueued=0 active=0 pending=0
              generated=0/176 player=(0, 0) materialized=false
```

`(-1,-3)` and `(2,-2)` are well inside `player ± 7`. They are excluded by the visibility filter, not by distance. Across 64 consecutive samples `in_view` was 0 every time, with zero early-return aborts — the tick ran fine, it just had nothing it considered visible.

This reaches the loading screen because `generation_complete` is the only thing that clears `waiting_for_floating_islands` on the loading session (`scene_fetcher.gd``_on_islands_generation_complete`), and `LoadingPhase::Assets` returns early while that flag is set:

```rust
LoadingPhase::Assets => {
    if self.waiting_for_floating_islands {
        return false;
    }
```

So the phase is held regardless of asset state — which is why the dump shows `all_loaded=true` going nowhere.

## Fix

Treat "no candidates in view" as vacuously complete, debounced by `EMPTY_VIEW_COMPLETE_MS` (1s) so a startup frame where the camera is not yet positioned cannot cut generation short. The debounce field resets in `set_candidate_parcels` and `clear_all`.

Terrain building is unaffected: enqueueing is not gated on `generating`, so parcels are still built as they come into view later. The fix changes when generation reports *done*, not what it builds.

## Testing

Verified on device (Samsung A54) against the World that reproduced the stall, same build otherwise:

```
islands START count=176 has_session=true
islands candidates set: n=176 player=(0, 0) view=7
islands tick: candidates=176 in_view=0 ... generated=0/176
islands COMPLETE via empty-view escape (candidates=176, player=(0, 0), view=7)
islands FINISH has_session=true
t=2.1s phase=Assets ... waiting_islands=false islands=176/176
```

Generation completes ~1s in, the flag clears, and the loading session proceeds and finishes on its own. Without the fix the identical path held for minutes.

No unit test: `DclFloatingIslandsManager` is a `#[class(base=Node)]` whose tick needs a live camera, scenario RID and physics space, so the stuck state is not reachable from a headless test.

## Notes

- This is **independent** of #2640, which fixes two other causes of a pinned loading screen. That PR's Assets-gate change does not help here, because the `waiting_for_floating_islands` early return happens *before* the gate it relaxes is evaluated.
- Not preview-specific — reproduced on a deployed World, no local preview involved.
- The upstream question of *why* `parcel_in_camera_view` rejects parcels that are a couple of tiles from the player is not addressed here and is worth its own look. This PR removes the unrecoverable state; it does not change which parcels are considered visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
