### PR TITLE
fix: decompress VRAM-compressed body textures in impostor upload, drop duplicate social error log

### DIFF
--- a/lib/src/avatars/avatar_scene.rs
+++ b/lib/src/avatars/avatar_scene.rs
@@ -587,6 +587,20 @@ impl AvatarScene {
         };
 
         let mut img = image;
+        // Body textures fetched through the content pipeline arrive
+        // VRAM-compressed on mobile (ASTC/ETC2); resize/convert/mipmaps all
+        // reject compressed formats, so decompress first.
+        if img.is_compressed() {
+            let err = img.decompress();
+            if err != godot::global::Error::OK {
+                tracing::warn!(
+                    "set_impostor_texture: failed to decompress source image for slot {}: {:?}",
+                    impostor_id,
+                    err
+                );
+                return;
+            }
+        }
         if img.get_width() != IMPOSTOR_TEX_WIDTH || img.get_height() != IMPOSTOR_TEX_HEIGHT {
             img.resize(IMPOSTOR_TEX_WIDTH, IMPOSTOR_TEX_HEIGHT);
         }

--- a/lib/src/social/social_service_manager.rs
+++ b/lib/src/social/social_service_manager.rs
@@ -703,10 +703,7 @@ impl SocialServiceManager {
         let mut stream = service
             .subscribe_to_friendship_updates()
             .await
-            .map_err(|e| {
-                tracing::error!("Failed to subscribe to friendship updates: {:?}", e);
-                anyhow!("Failed to subscribe to friendship updates: {:?}", e)
-            })?;
+            .map_err(|e| anyhow!("Failed to subscribe to friendship updates: {:?}", e))?;
 
         let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
 


### PR DESCRIPTION
These two changes remove the biggest client-side Sentry quota burners (~8k events/day combined). On mobile, avatar body textures come out of the content pipeline ASTC/ETC2-compressed; the impostor upload path called `resize`/`convert`/`generate_mipmaps` directly on them, which spammed three engine errors per capture ("Cannot generate mipmaps from compressed image formats", "Image format must match texture's image format", "Cannot resize in compressed image formats" — ~6.4k/day) and then uploaded a mismatched layer, so the impostor billboard never got its texture and the disk cache stored garbage bytes. The image is now decompressed first (single warn + skip if that fails). Separately, friendship-subscribe failures were logged both at the failure site and at the promise boundary, producing two Sentry events per failure (~1.7k/day) — only the boundary logs now.

## Changes
- `lib/src/avatars/avatar_scene.rs` → decompress guard at the top of `set_impostor_texture`
- `lib/src/social/social_service_manager.rs` → removed duplicate `tracing::error!` on subscribe failure (kept in the propagated error, logged once by `resolve_simple_promise`)

## Test plan
- [ ] Open the app, teleport to Genesis Plaza (or any crowded spot), then walk away from a group of avatars until they switch to impostor billboards → the billboards show each avatar's body texture (not blank/dark).
- [ ] Sentry: builds from this branch stop emitting the three compressed-image errors above (filter by this release in Sentry).
- [ ] Regression: near↔far avatar LOD transition still fades normally (shared impostor path).

Social change is log-only — no QA needed for it.