### PR TITLE
fix(content): skip texture pipeline for impostor-only body snapshots

### DIFF
--- a/lib/src/avatars/avatar_scene.rs
+++ b/lib/src/avatars/avatar_scene.rs
@@ -587,6 +587,28 @@ impl AvatarScene {
         };
 
         let mut img = image;
+        // The entry image outlives this call (it stays in the content
+        // provider's promise cache): on mobile we compress it to ETC2 at the
+        // end of this function to reclaim RAM, so a recapture re-reads it
+        // compressed. resize/convert/mipmaps all reject compressed formats —
+        // decompress first.
+        if img.is_compressed() {
+            let err = img.decompress();
+            if err != godot::global::Error::OK {
+                tracing::warn!(
+                    "set_impostor_texture: failed to decompress source image for slot {}: {:?}",
+                    impostor_id,
+                    err
+                );
+                return;
+            }
+        }
+        // A recapture also inherits this function's own mutations from the
+        // previous pass (resized, mipmaps appended). Drop the mip chain or the
+        // PNG snapshot below would serialize the whole chain as mip0.
+        if img.has_mipmaps() {
+            img.clear_mipmaps();
+        }
         if img.get_width() != IMPOSTOR_TEX_WIDTH || img.get_height() != IMPOSTOR_TEX_HEIGHT {
             img.resize(IMPOSTOR_TEX_WIDTH, IMPOSTOR_TEX_HEIGHT);
         }
@@ -625,6 +647,21 @@ impl AvatarScene {
         // it gets a real slot (after frustum churn or session restart).
         if let Some(rgba) = png_payload {
             self.save_cached_texture_async(&cache_key, rgba);
+        }
+
+        // Reclaim RAM: the entry image stays alive in the content provider's
+        // promise cache all session. We're done reading pixels, so compress it
+        // (mobile only — a recapture enters through the decompress guard).
+        #[cfg(any(target_os = "ios", target_os = "android"))]
+        if !img.is_compressed() {
+            let err = img.compress(godot::classes::image::CompressMode::ETC2);
+            if err != godot::global::Error::OK {
+                tracing::warn!(
+                    "set_impostor_texture: failed to compress entry image for slot {}: {:?}",
+                    impostor_id,
+                    err
+                );
+            }
         }
     }
 

--- a/lib/src/content/content_provider.rs
+++ b/lib/src/content/content_provider.rs
@@ -1459,7 +1459,7 @@ impl ContentProvider {
                     "Failed to load baked texture {}, falling back to runtime decode",
                     godot_path
                 );
-                let result = load_image_texture(url, hash_id.clone(), ctx).await;
+                let result = load_image_texture(url, hash_id.clone(), ctx, true).await;
                 then_promise(get_promise, result);
             });
         } else {
@@ -1478,7 +1478,7 @@ impl ContentProvider {
 
                 loading_resources.fetch_add(1, Ordering::Relaxed);
 
-                let result = load_image_texture(url, hash_id.clone(), ctx).await;
+                let result = load_image_texture(url, hash_id.clone(), ctx, true).await;
 
                 #[cfg(feature = "use_resource_tracking")]
                 if let Err(error) = &result {
@@ -1557,7 +1557,7 @@ impl ContentProvider {
 
             loading_resources.fetch_add(1, Ordering::Relaxed);
 
-            let result = load_image_texture(url, hash_id.clone(), ctx).await;
+            let result = load_image_texture(url, hash_id.clone(), ctx, true).await;
 
             #[cfg(feature = "use_resource_tracking")]
             if let Err(error) = &result {
@@ -1610,7 +1610,8 @@ impl ContentProvider {
 
             loading_resources.fetch_add(1, Ordering::Relaxed);
 
-            let result = load_image_texture(url, sent_file_hash, content_provider_context).await;
+            let result =
+                load_image_texture(url, sent_file_hash, content_provider_context, true).await;
 
             #[cfg(feature = "use_resource_tracking")]
             if let Err(error) = &result {
@@ -2191,7 +2192,7 @@ impl ContentProvider {
             let texture_hash = format!("avatar_face_{:x}", user_id_h160);
 
             // Step 3: Fetch the texture
-            let result = load_image_texture(face256_url, texture_hash, ctx).await;
+            let result = load_image_texture(face256_url, texture_hash, ctx, true).await;
 
             if let Err(e) = &result {
                 tracing::error!(
@@ -2292,7 +2293,9 @@ impl ContentProvider {
 
             let texture_hash = format!("avatar_body_{:x}", user_id_h160);
 
-            let result = load_image_texture(body_url_raw, texture_hash, ctx).await;
+            // Impostors only consume the raw pixels (resize/mips/PNG cache);
+            // the texture itself is never rendered. Skip ETC2 compression.
+            let result = load_image_texture(body_url_raw, texture_hash, ctx, false).await;
 
             loaded_resources.fetch_add(1, Ordering::Relaxed);
             then_promise(get_promise, result);
@@ -2377,7 +2380,8 @@ impl ContentProvider {
 
             let texture_hash = format!("avatar_body_default_{}", slot);
 
-            let result = load_image_texture(body_url_raw, texture_hash, ctx).await;
+            // Same as fetch_avatar_body_texture: impostor-only, no compression.
+            let result = load_image_texture(body_url_raw, texture_hash, ctx, false).await;
 
             loaded_resources.fetch_add(1, Ordering::Relaxed);
             then_promise(get_promise, result);

--- a/lib/src/content/texture.rs
+++ b/lib/src/content/texture.rs
@@ -238,10 +238,18 @@ fn decode_animated_webp_to_texture(
     Ok((animated_texture.upcast(), original_size, first_frame))
 }
 
+/// Loads an image into a TextureEntry (image + texture).
+///
+/// `compress`: on mobile, ETC2-compress the image for VRAM savings. Pass false
+/// when only the raw pixels (`TextureEntry.image`) are consumed and the texture
+/// is never rendered — compressing would be pure waste (extra CPU + a PCT2 held
+/// in memory for nothing) and leaves `image` in a format that rejects
+/// resize/convert/mipmaps (the avatar-impostor upload path).
 pub async fn load_image_texture(
     url: String,
     file_hash: String,
     ctx: ContentProviderContext,
+    compress: bool,
 ) -> Result<Option<Variant>, anyhow::Error> {
     let absolute_file_path = cache_file_path(&ctx.content_folder, &file_hash);
     let bytes_vec = ctx
@@ -381,9 +389,15 @@ pub async fn load_image_texture(
     let original_size = image.get_size();
 
     let max_size = ctx.texture_quality.to_max_size();
-    let mut texture: Gd<Texture2D> = if std::env::consts::OS == "ios"
-        || std::env::consts::OS == "android"
-    {
+    let mut texture: Gd<Texture2D> = if !compress {
+        // compress=false means: the caller only reads the raw `image` pixels and
+        // nothing ever renders this `texture` (avatar body snapshots: the
+        // impostor copies the pixels into its own TextureArray). So we skip
+        // building a real texture entirely — no VRAM, no compression. If a
+        // future caller does render it, they'll see magenta pixels: build a
+        // real texture here instead.
+        create_placeholder_texture()
+    } else if std::env::consts::OS == "ios" || std::env::consts::OS == "android" {
         create_compressed_texture(&mut image, max_size)
     } else {
         resize_image(&mut image, max_size);


### PR DESCRIPTION
## Problem

On mobile, avatar body snapshots go through the generic content pipeline, which ETC2-compresses the shared `Gd<Image>` in-place to build the entry's texture. The impostor capturer then reads `TextureEntry.image` and `set_impostor_texture` calls `resize`/`convert`/`generate_mipmaps` on it — all three reject compressed formats, spamming Sentry (~6.4k events/day: "Cannot resize in compressed image formats", "Cannot generate mipmaps from compressed image formats", "Image format must match texture's image format") and leaving impostor billboards untextured.

But the body snapshot's `texture` is **never rendered**: the impostor uploads the raw pixels into its own TextureArray. The compression was pure waste for this path — compress in the loader, decompress in the consumer.

## Fix

- `load_image_texture` gains a `compress` flag; `fetch_avatar_body_texture` and `fetch_default_avatar_body_texture` pass `false`
- `compress=false` keeps the image raw (RGBA8) and ships a 2x2 placeholder texture — the entry's texture is never rendered, so no real texture is built at all (saves VRAM + a compress)
- `set_impostor_texture` compresses the entry image to ETC2 **after** consuming it (mobile only), so session-cached promise entries reclaim the same RAM as before; a recapture enters through the `decompress()` guard and drops the inherited mip chain before re-uploading

Net: no compress→decompress cycle on first capture, same steady-state RAM, no error spam.

## Test plan

- [ ] Crowded spot (Genesis Plaza), walk away until avatars switch to impostor billboards → billboards show body textures, no compressed-image errors in logs
- [ ] Sentry: the three compressed-image errors stop for this build
- [ ] Regression: near↔far LOD transition still fades normally; impostor recapture after LRU eviction still textures correctly