### PR TITLE
feat: drive Sentry error sampling from the sentry-sample-rate feature flag

### DIFF
--- a/godot/src/feature_flags.gd
+++ b/godot/src/feature_flags.gd
@@ -4,8 +4,9 @@ extends Node
 ## Remote feature flags fetched from the mobile-bff at app startup.
 ##
 ## The fetch is fire-and-forget: it starts when the node enters the tree
-## (global.gd) and comms-affecting flags are applied as soon as the response
-## arrives — normally long before the first comms connection. If a flag lands
+## (global.gd) and flags with runtime effects (comms, Sentry sampling) are
+## applied as soon as the response arrives — normally long before the first
+## comms connection. If a flag lands
 ## after comms already connected, the Rust-side runtime toggles reconcile
 ## gracefully (e.g. tearing archipelago down while keeping scene rooms alive).
 ##
@@ -21,6 +22,11 @@ const TIMEOUT_SECONDS := 5.0
 # Flag names exactly as served by the mobile-bff payload.
 const FLAG_ARCHIPELAGO := "archipielago"
 const FLAG_PULSE := "pulse"
+# Sentry error-event sampling, served as a number in [0, 1].
+const FLAG_SENTRY_SAMPLE_RATE := "sentry-sample-rate"
+# The bff also serves `sentry-traces-sample-rate`, but sentry-godot exposes no
+# performance-tracing API yet — there is nothing to apply it to until the SDK
+# grows one.
 
 var _flags: Dictionary = {}
 var _loaded := false
@@ -38,6 +44,15 @@ func is_loaded() -> bool:
 # flag is absent from the payload.
 func is_enabled(flag_name: String, default_value: bool = true) -> bool:
 	return bool(_flags.get(flag_name, default_value))
+
+
+# Numeric flags (e.g. sample rates). `default_value` is returned while the
+# flags aren't loaded yet, when the flag is absent, or when it isn't a number.
+func get_number(flag_name: String, default_value: float) -> float:
+	var value = _flags.get(flag_name)
+	if value is float or value is int:
+		return float(value)
+	return default_value
 
 
 # Extracts the flags dictionary from the mobile-bff response:
@@ -92,3 +107,13 @@ func _async_load() -> void:
 func _apply_flags() -> void:
 	Global.comms.set_archipelago_enabled(is_enabled(FLAG_ARCHIPELAGO, true))
 	Global.comms.set_pulse_flag_enabled(is_enabled(FLAG_PULSE, false))
+
+	# SentrySDK.init runs at process start (before this fetch resolves), so the
+	# remote rate is enforced through the _before_send gate, not the init option.
+	# The cast fails only outside a normal game run (editor tools/tests), where
+	# there is no Sentry to throttle.
+	var main_loop := get_tree() as ProjectMainLoop
+	if main_loop != null:
+		main_loop.set_sentry_sample_rate(
+			get_number(FLAG_SENTRY_SAMPLE_RATE, ProjectMainLoop.DEFAULT_SENTRY_SAMPLE_RATE)
+		)

--- a/godot/src/project_main_loop.gd
+++ b/godot/src/project_main_loop.gd
@@ -32,12 +32,22 @@ const NOISE_PATTERNS := [
 # engine/driver errors shifts we want to notice, but 100% is wasted quota.
 const NOISE_KEEP_RATE := 0.05
 
+# Error-sampling rate used until the `sentry-sample-rate` feature flag loads —
+# also the effective rate when the fetch fails or the flag is absent. The bff
+# can raise it (currently serves 1.0) or lower it to 0.0 as a kill switch.
+const DEFAULT_SENTRY_SAMPLE_RATE := 0.1
+
 # Environment detection based on version string suffix
 var is_dev_version = false
 var is_staging_version = false
 var is_prod_version = false
 
 var attach_log_sampled := false
+
+# Remote error-sampling rate from the `sentry-sample-rate` feature flag — lets
+# us throttle Sentry volume without shipping a build. Enforced in _before_send
+# because the flag fetch resolves after SentrySDK.init already ran.
+var sentry_sample_rate := DEFAULT_SENTRY_SAMPLE_RATE
 
 
 func _initialize() -> void:
@@ -79,8 +89,9 @@ func _initialize() -> void:
 				options.environment = "development"
 				options.debug = true
 
-			# 1.0 all errors, 0.5 -> 50% errors.
-			# for custom sampling rate, use _before_send
+			# Keep the SDK-level rate at 1.0 — the effective rate is the remote
+			# `sentry-sample-rate` feature flag, enforced in _before_send once
+			# the flags load.
 			options.sample_rate = 1.0
 	)
 
@@ -118,9 +129,19 @@ func _initialize() -> void:
 				SentrySDK.set_tag("commit_hash", commit_hash)
 
 
+## Called by FeatureFlags when the remote flags load.
+func set_sentry_sample_rate(rate: float) -> void:
+	sentry_sample_rate = clampf(rate, 0.0, 1.0)
+
+
 func _before_send(event: SentryEvent) -> SentryEvent:
 	# Discard events for dev builds - only prod and staging report to Sentry
 	if self.is_dev_version:
+		return null
+
+	# Remote throttle (`sentry-sample-rate` feature flag): 1.0 keeps every
+	# event, 0.0 drops them all.
+	if randf() >= sentry_sample_rate:
 		return null
 
 	if randf() >= NOISE_KEEP_RATE:


### PR DESCRIPTION
Sentry error sampling is now controlled by the `sentry-sample-rate` feature flag from the mobile-bff instead of a hardcoded 100%, so we can throttle error volume (or kill it with `0.0`) without shipping a build. The client defaults to **0.1** — that's the effective rate before the flags load, when the fetch fails, or if the flag is absent — and the bff currently serves `1.0`, which restores full reporting a few seconds into every session. Since `SentrySDK.init` runs before the flags fetch resolves, the rate is enforced in the `_before_send` gate rather than the init option. The bff also serves `sentry-traces-sample-rate`, but sentry-godot exposes no performance-tracing API yet, so that flag stays inert (documented in code) until the SDK grows one.

## Changes
- `godot/src/feature_flags.gd` — new `FLAG_SENTRY_SAMPLE_RATE` constant and a `get_number()` accessor for numeric flags (fail-open to the default on missing/non-numeric values); `_apply_flags` pushes the rate into the main loop.
- `godot/src/project_main_loop.gd` — `DEFAULT_SENTRY_SAMPLE_RATE := 0.1`, a clamped setter, and a sampling gate in `_before_send` (right after the dev-build discard).

Closes #2656

## Test plan

No QA needed — telemetry-only change, nothing user-visible on device.

- [ ] **Verification (Sentry access required):** with the bff serving `sentry-sample-rate: 1`, staging-build errors keep arriving in Sentry at the usual volume; errors fired in the first seconds of a session (before the flags load) drop to ~10%.
