### PR TITLE
chore: mute friends subscription reconnect-loop Sentry noise

### DIFF
--- a/godot/src/project_main_loop.gd
+++ b/godot/src/project_main_loop.gd
@@ -27,6 +27,11 @@ const NOISE_PATTERNS := [
 	"ClientMessagesHandler",
 	"StreamProtocol",
 	'Condition "active"',
+	# Friends subscription reconnect loop (#2590): known noise until the root
+	# fix lands (#2591). Covers the GDScript retry errors and the Rust-side
+	# "Failed to subscribe to friendship/connectivity/block updates" variants.
+	"FriendsPanel.SubscriptionState",
+	"Failed to subscribe to",
 ]
 # Keep this fraction of noise events as a canary — if the shape or volume of
 # engine/driver errors shifts we want to notice, but 100% is wasted quota.

--- a/godot/src/project_main_loop.gd
+++ b/godot/src/project_main_loop.gd
@@ -28,10 +28,13 @@ const NOISE_PATTERNS := [
 	"StreamProtocol",
 	'Condition "active"',
 	# Friends subscription reconnect loop (#2590): known noise until the root
-	# fix lands (#2591). Covers the GDScript retry errors and the Rust-side
-	# "Failed to subscribe to friendship/connectivity/block updates" variants.
+	# fix lands (#2591). Covers the GDScript retry errors, the Rust-side
+	# "Failed to subscribe to friendship/connectivity/block updates" variants,
+	# and the social-blacklist parse error from the empty BlockUpdate the
+	# server sends before closing a duplicate stream.
 	"FriendsPanel.SubscriptionState",
 	"Failed to subscribe to",
+	"Invalid address format",
 ]
 # Keep this fraction of noise events as a canary — if the shape or volume of
 # engine/driver errors shifts we want to notice, but 100% is wasted quota.


### PR DESCRIPTION
The friends subscription reconnect loop (#2590) floods Sentry with the same errors every few seconds from every logged-in player — over 10k events across ~15 issue groups in the last month. The root fix lives in #2591 but brought other issues, so until it lands this PR just mutes the noise: it adds the spamming message families to the existing `NOISE_PATTERNS` known-noise filter in `project_main_loop.gd` (same mechanism as `StreamProtocol`). Matching events are dropped in `_before_send`, with the existing 5% canary still letting a trickle through so we notice if the volume shifts. No subscription behavior changes; local logs are untouched.

Muted patterns (verified against the live Sentry issues):
- `FriendsPanel.SubscriptionState` — the GDScript retry errors ("friendship/connectivity subscribe rejected (attempt N/6)")
- `Failed to subscribe to` — the Rust-side variants from `social_service_manager.rs` and the "Social service operation failed" wrapper
- `Invalid address format` — the social-blacklist parse error caused by the empty `BlockUpdate` the server sends before closing a duplicate stream. This one spams the local console every cycle but currently produces zero Sentry events (checked errors + logs datasets, 30d); it is muted as a safeguard in case capture behavior changes.

## Test plan

No QA needed — no behavior change (Sentry event filtering only). Optional verification: after this reaches production, the `FriendsPanel.SubscriptionState` / `Failed to subscribe to` issue groups in Sentry should stop accumulating events except for the ~5% canary trickle.