### PR TITLE
feat: Preview Mode HUD layout

### DIFF
--- a/godot/src/logic/scene_fetcher.gd
+++ b/godot/src/logic/scene_fetcher.gd
@@ -1192,6 +1192,12 @@ func _on_try_spawn_scene(
 func reload_scene(scene_id: String) -> void:
 	var scene = loaded_scenes.get(scene_id)
 	if scene != null:
+		# Show the loading screen up front so killing the scene doesn't flash an empty parcel
+		# before it re-loads. Skipped for preview hot-reload, which is meant to be seamless.
+		if not _is_hot_reloading:
+			var explorer = Global.get_explorer()
+			if is_instance_valid(explorer):
+				explorer.loading_ui.enable_loading_screen("", "on_reload")
 		var scene_number_id: int = scene.scene_number_id
 		if scene_number_id != -1:
 			Global.scene_runner.kill_scene(scene_number_id)

--- a/godot/src/logic/scene_fetcher.gd
+++ b/godot/src/logic/scene_fetcher.gd
@@ -1194,6 +1194,10 @@ func reload_scene(scene_id: String) -> void:
 	if scene != null:
 		# Show the loading screen up front so killing the scene doesn't flash an empty parcel
 		# before it re-loads. Skipped for preview hot-reload, which is meant to be seamless.
+		# If the re-fetch fails it's still taken back down: a null definition completes the
+		# loading session (report_scene_fetched), and any deeper failure is caught by the
+		# loading screen's own watchdog (Timer_CheckProgressTimeout: inactivity / max-time
+		# -> timeout modal + hide), which starts when enable_loading_screen is shown.
 		if not _is_hot_reloading:
 			var explorer = Global.get_explorer()
 			if is_instance_valid(explorer):

--- a/godot/src/ui/components/organisms/debug_panel/debug_panel.gd
+++ b/godot/src/ui/components/organisms/debug_panel/debug_panel.gd
@@ -22,8 +22,6 @@ var icon_action_copy: Texture2D = preload(
 
 @onready var tree_console: Tree = %Tree_Console
 @onready var tab_container_debug_panel: TabContainer = %TabContainer_DebugPanel
-@onready var button_show_hide: Button = %Button_ShowHide
-@onready var button_reload_scene: Button = %Button_ReloadScene
 @onready var popup_menu: PopupMenu = %PopupMenu
 @onready var button_debug_js = %Button_DebugJS
 @onready var button_open_source = %Button_OpenSource
@@ -45,10 +43,8 @@ func _ready():
 			tab_container_debug_panel.set_tab_hidden(tab_idx, true)
 
 	clear_console()
-	# The Show/Hide button is a toggle: its pressed state mirrors console visibility
-	# (drives the pressed/normal styleboxes set in the editor). Start collapsed.
-	button_show_hide.toggle_mode = true
-	button_show_hide.button_pressed = false
+	# The console starts collapsed; the preview HUD toolbar's Console button drives its
+	# visibility via set_console_visible (this panel no longer has its own header).
 	tab_container_debug_panel.visible = false
 
 
@@ -152,11 +148,13 @@ func _on_line_edit_filter_text_changed(new_text):
 		item.visible = not should_hide
 
 
-func set_reload_scene_visible(visible: bool) -> void:
-	button_reload_scene.visible = visible
+## Show or hide the console (the tab container). Driven by the preview HUD toolbar's
+## Console button (issue #2679); this panel no longer has its own header.
+func set_console_visible(console_visible: bool) -> void:
+	tab_container_debug_panel.visible = console_visible
 
 
-func _on_button_reload_scene_pressed():
+func reload_current_scene() -> void:
 	var current_scene = Global.scene_fetcher.get_current_scene_data()
 	if current_scene == null:
 		var scenes = Global.scene_fetcher.loaded_scenes
@@ -166,10 +164,6 @@ func _on_button_reload_scene_pressed():
 		printerr("No current scene to reload")
 		return
 	Global.scene_fetcher.reload_scene(current_scene.id)
-
-
-func _on_button_show_hide_pressed():
-	tab_container_debug_panel.visible = button_show_hide.button_pressed
 
 
 func _on_tree_console_item_mouse_selected(tree_position, mouse_button_index):

--- a/godot/src/ui/components/organisms/debug_panel/debug_panel.tscn
+++ b/godot/src/ui/components/organisms/debug_panel/debug_panel.tscn
@@ -3,39 +3,15 @@
 [ext_resource type="Theme" uid="uid://yt0vgau51udk" path="res://src/ui/components/organisms/debug_panel/dark_theme/Dark.theme" id="1_c8oen"]
 [ext_resource type="Script" uid="uid://csxkemel3hrdv" path="res://src/ui/components/organisms/debug_panel/debug_panel.gd" id="2_juhlr"]
 [ext_resource type="Texture2D" uid="uid://7ixgxgtq3wlr" path="res://src/ui/components/organisms/debug_panel/icons/Search.svg" id="3_nth2r"]
-[ext_resource type="Texture2D" uid="uid://c7rx0q1yjyde0" path="res://assets/ui/console_icon.svg" id="4_21x4w"]
 [ext_resource type="Texture2D" uid="uid://ckn18yn0v8tsa" path="res://src/ui/components/organisms/debug_panel/icons/Clear.svg" id="4_k7442"]
 [ext_resource type="Texture2D" uid="uid://cqwsvinsujxri" path="res://src/ui/components/organisms/debug_panel/icons/ActionCopy.svg" id="5_0aohs"]
-[ext_resource type="Texture2D" uid="uid://c0n8k2q368jvf" path="res://assets/ui/reload_icon.svg" id="5_xx5uf"]
-[ext_resource type="Theme" uid="uid://bn7q4ap7m5gdu" path="res://assets/themes/dcl_theme.tres" id="7_nlnrl"]
-
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_y67x0"]
-bg_color = Color(0.078431375, 0.023529412, 0.1254902, 1)
-corner_radius_top_left = 100
-corner_radius_top_right = 100
-corner_radius_bottom_right = 100
-corner_radius_bottom_left = 100
-
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_4xydo"]
-bg_color = Color(0.078431375, 0.023529412, 0.1254902, 1)
-border_width_left = 2
-border_width_top = 2
-border_width_right = 2
-border_width_bottom = 2
-border_color = Color(0.87058824, 0.84313726, 0.9019608, 1)
-corner_radius_top_left = 100
-corner_radius_top_right = 100
-corner_radius_bottom_right = 100
-corner_radius_bottom_left = 100
 
 [node name="DebugPanel" type="Control" unique_id=1737764806]
-custom_minimum_size = Vector2(500, 300)
+custom_minimum_size = Vector2(490, 325)
 layout_mode = 3
-anchors_preset = 15
-anchor_right = 1.0
-anchor_bottom = 1.0
-grow_horizontal = 2
-grow_vertical = 2
+anchors_preset = 0
+offset_right = 490.0
+offset_bottom = 325.0
 mouse_filter = 2
 theme = ExtResource("1_c8oen")
 script = ExtResource("2_juhlr")
@@ -44,42 +20,37 @@ script = ExtResource("2_juhlr")
 unique_name_in_owner = true
 oversampling_override = 1.0
 
-[node name="MarginContainer" type="MarginContainer" parent="." unique_id=423347625]
+[node name="VBoxContainer" type="VBoxContainer" parent="." unique_id=1367164241]
 layout_mode = 1
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
-mouse_filter = 2
-
-[node name="VBoxContainer" type="VBoxContainer" parent="MarginContainer" unique_id=1367164241]
-custom_minimum_size = Vector2(328, 0)
-layout_mode = 2
 size_flags_horizontal = 0
 size_flags_vertical = 8
 mouse_filter = 2
 
-[node name="TabContainer_DebugPanel" type="TabContainer" parent="MarginContainer/VBoxContainer" unique_id=746749719]
+[node name="TabContainer_DebugPanel" type="TabContainer" parent="VBoxContainer" unique_id=746749719]
 unique_name_in_owner = true
-custom_minimum_size = Vector2(100, 350)
 layout_mode = 2
+size_flags_vertical = 3
 theme = ExtResource("1_c8oen")
 current_tab = 0
 tab_focus_mode = 0
 
-[node name="Console" type="VBoxContainer" parent="MarginContainer/VBoxContainer/TabContainer_DebugPanel" unique_id=859584269]
+[node name="Console" type="VBoxContainer" parent="VBoxContainer/TabContainer_DebugPanel" unique_id=859584269]
 layout_mode = 2
 metadata/_tab_index = 0
 
-[node name="HBoxContainer" type="HBoxContainer" parent="MarginContainer/VBoxContainer/TabContainer_DebugPanel/Console" unique_id=352400936]
+[node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer/TabContainer_DebugPanel/Console" unique_id=352400936]
 layout_mode = 2
 
-[node name="Label" type="Label" parent="MarginContainer/VBoxContainer/TabContainer_DebugPanel/Console/HBoxContainer" unique_id=846602549]
+[node name="Label" type="Label" parent="VBoxContainer/TabContainer_DebugPanel/Console/HBoxContainer" unique_id=846602549]
 layout_mode = 2
 text = "Filter:"
 
-[node name="LineEdit_Filter" type="LineEdit" parent="MarginContainer/VBoxContainer/TabContainer_DebugPanel/Console/HBoxContainer" unique_id=815906912]
+[node name="LineEdit_Filter" type="LineEdit" parent="VBoxContainer/TabContainer_DebugPanel/Console/HBoxContainer" unique_id=815906912]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
@@ -87,17 +58,17 @@ focus_mode = 1
 placeholder_text = "Filter Messages"
 right_icon = ExtResource("3_nth2r")
 
-[node name="Button_Clear" type="Button" parent="MarginContainer/VBoxContainer/TabContainer_DebugPanel/Console/HBoxContainer" unique_id=2609653]
+[node name="Button_Clear" type="Button" parent="VBoxContainer/TabContainer_DebugPanel/Console/HBoxContainer" unique_id=2609653]
 layout_mode = 2
 focus_mode = 0
 icon = ExtResource("4_k7442")
 
-[node name="Button_Copy" type="Button" parent="MarginContainer/VBoxContainer/TabContainer_DebugPanel/Console/HBoxContainer" unique_id=268697916]
+[node name="Button_Copy" type="Button" parent="VBoxContainer/TabContainer_DebugPanel/Console/HBoxContainer" unique_id=268697916]
 layout_mode = 2
 focus_mode = 0
 icon = ExtResource("5_0aohs")
 
-[node name="Tree_Console" type="Tree" parent="MarginContainer/VBoxContainer/TabContainer_DebugPanel/Console" unique_id=1202255006]
+[node name="Tree_Console" type="Tree" parent="VBoxContainer/TabContainer_DebugPanel/Console" unique_id=1202255006]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_vertical = 3
@@ -116,120 +87,58 @@ allow_rmb_select = true
 hide_root = true
 select_mode = 1
 
-[node name="Expression" type="VBoxContainer" parent="MarginContainer/VBoxContainer/TabContainer_DebugPanel" unique_id=1525805381]
+[node name="Expression" type="VBoxContainer" parent="VBoxContainer/TabContainer_DebugPanel" unique_id=1525805381]
 visible = false
 layout_mode = 2
 metadata/_tab_index = 1
 
-[node name="TextEdit_Expression" type="TextEdit" parent="MarginContainer/VBoxContainer/TabContainer_DebugPanel/Expression" unique_id=1912460038]
+[node name="TextEdit_Expression" type="TextEdit" parent="VBoxContainer/TabContainer_DebugPanel/Expression" unique_id=1912460038]
 unique_name_in_owner = true
 custom_minimum_size = Vector2(0, 100)
 layout_mode = 2
 size_flags_vertical = 3
 
-[node name="Label_Expression" type="TextEdit" parent="MarginContainer/VBoxContainer/TabContainer_DebugPanel/Expression" unique_id=1163594485]
+[node name="Label_Expression" type="TextEdit" parent="VBoxContainer/TabContainer_DebugPanel/Expression" unique_id=1163594485]
 unique_name_in_owner = true
 custom_minimum_size = Vector2(0, 100)
 layout_mode = 2
 size_flags_vertical = 3
 
-[node name="Misc&Debugger" type="VBoxContainer" parent="MarginContainer/VBoxContainer/TabContainer_DebugPanel" unique_id=798233632]
+[node name="Misc&Debugger" type="VBoxContainer" parent="VBoxContainer/TabContainer_DebugPanel" unique_id=798233632]
 visible = false
 layout_mode = 2
 metadata/_tab_index = 2
 
-[node name="Button_ShowNetwork" type="Button" parent="MarginContainer/VBoxContainer/TabContainer_DebugPanel/Misc&Debugger" unique_id=1965621359]
+[node name="Button_ShowNetwork" type="Button" parent="VBoxContainer/TabContainer_DebugPanel/Misc&Debugger" unique_id=1965621359]
 unique_name_in_owner = true
 layout_mode = 2
 focus_mode = 0
 text = "Open Network Inpector"
 
-[node name="Button_DebugJS" type="Button" parent="MarginContainer/VBoxContainer/TabContainer_DebugPanel/Misc&Debugger" unique_id=904865193]
+[node name="Button_DebugJS" type="Button" parent="VBoxContainer/TabContainer_DebugPanel/Misc&Debugger" unique_id=904865193]
 unique_name_in_owner = true
 layout_mode = 2
 focus_mode = 0
 text = "JS Debugger not available"
 
-[node name="Button_OpenSource" type="Button" parent="MarginContainer/VBoxContainer/TabContainer_DebugPanel/Misc&Debugger" unique_id=480276084]
+[node name="Button_OpenSource" type="Button" parent="VBoxContainer/TabContainer_DebugPanel/Misc&Debugger" unique_id=480276084]
 unique_name_in_owner = true
 layout_mode = 2
 focus_mode = 0
 text = "Open Scene Source Code"
 
-[node name="Label_DebugInfo" type="Label" parent="MarginContainer/VBoxContainer/TabContainer_DebugPanel/Misc&Debugger" unique_id=1806635216]
+[node name="Label_DebugInfo" type="Label" parent="VBoxContainer/TabContainer_DebugPanel/Misc&Debugger" unique_id=1806635216]
 unique_name_in_owner = true
 visible = false
 layout_mode = 2
 text = "Open chromium browser with url chrome://inspect and pick the scene debugger."
 
-[node name="MarginContainer_Header" type="MarginContainer" parent="MarginContainer/VBoxContainer" unique_id=1474819563]
-layout_mode = 2
-size_flags_vertical = 4
-mouse_filter = 2
-theme_override_constants/margin_top = 12
-theme_override_constants/margin_bottom = 0
-
-[node name="HBoxContainer_TopButtons" type="HBoxContainer" parent="MarginContainer/VBoxContainer/MarginContainer_Header" unique_id=1776876775]
-unique_name_in_owner = true
-layout_mode = 2
-size_flags_vertical = 0
-mouse_filter = 2
-theme_override_constants/separation = 12
-alignment = 2
-
-[node name="Button_ShowHide" type="Button" parent="MarginContainer/VBoxContainer/MarginContainer_Header/HBoxContainer_TopButtons" unique_id=1347699769]
-unique_name_in_owner = true
-custom_minimum_size = Vector2(66, 66)
-layout_mode = 2
-size_flags_vertical = 4
-focus_mode = 0
-theme = ExtResource("7_nlnrl")
-theme_type_variation = &"SecondaryLittle"
-theme_override_constants/icon_max_width = 38
-theme_override_styles/normal = SubResource("StyleBoxFlat_y67x0")
-theme_override_styles/pressed = SubResource("StyleBoxFlat_4xydo")
-theme_override_styles/pressed_mirrored = SubResource("StyleBoxFlat_4xydo")
-theme_override_styles/hover = SubResource("StyleBoxFlat_y67x0")
-theme_override_styles/hover_mirrored = SubResource("StyleBoxFlat_y67x0")
-theme_override_styles/hover_pressed = SubResource("StyleBoxFlat_4xydo")
-theme_override_styles/hover_pressed_mirrored = SubResource("StyleBoxFlat_4xydo")
-icon = ExtResource("4_21x4w")
-icon_alignment = 1
-expand_icon = true
-
-[node name="Button_ReloadScene" type="Button" parent="MarginContainer/VBoxContainer/MarginContainer_Header/HBoxContainer_TopButtons" unique_id=978841142]
-unique_name_in_owner = true
-custom_minimum_size = Vector2(66, 66)
-layout_mode = 2
-size_flags_vertical = 4
-focus_mode = 0
-theme = ExtResource("7_nlnrl")
-theme_type_variation = &"SecondaryLittle"
-theme_override_constants/icon_max_width = 38
-theme_override_styles/normal = SubResource("StyleBoxFlat_y67x0")
-theme_override_styles/normal_mirrored = SubResource("StyleBoxFlat_y67x0")
-theme_override_styles/pressed = SubResource("StyleBoxFlat_4xydo")
-theme_override_styles/pressed_mirrored = SubResource("StyleBoxFlat_4xydo")
-theme_override_styles/hover = SubResource("StyleBoxFlat_y67x0")
-theme_override_styles/hover_mirrored = SubResource("StyleBoxFlat_y67x0")
-theme_override_styles/hover_pressed = SubResource("StyleBoxFlat_4xydo")
-theme_override_styles/hover_pressed_mirrored = SubResource("StyleBoxFlat_4xydo")
-icon = ExtResource("5_xx5uf")
-icon_alignment = 1
-expand_icon = true
-
-[node name="Control" type="Control" parent="MarginContainer/VBoxContainer/MarginContainer_Header/HBoxContainer_TopButtons" unique_id=1895903232]
-custom_minimum_size = Vector2(49, 0)
-layout_mode = 2
-
 [connection signal="index_pressed" from="PopupMenu" to="." method="_on_popup_menu_index_pressed"]
-[connection signal="text_changed" from="MarginContainer/VBoxContainer/TabContainer_DebugPanel/Console/HBoxContainer/LineEdit_Filter" to="." method="_on_line_edit_filter_text_changed"]
-[connection signal="pressed" from="MarginContainer/VBoxContainer/TabContainer_DebugPanel/Console/HBoxContainer/Button_Clear" to="." method="_on_button_clear_pressed"]
-[connection signal="pressed" from="MarginContainer/VBoxContainer/TabContainer_DebugPanel/Console/HBoxContainer/Button_Copy" to="." method="_on_button_copy_pressed"]
-[connection signal="item_mouse_selected" from="MarginContainer/VBoxContainer/TabContainer_DebugPanel/Console/Tree_Console" to="." method="_on_tree_console_item_mouse_selected"]
-[connection signal="text_changed" from="MarginContainer/VBoxContainer/TabContainer_DebugPanel/Expression/TextEdit_Expression" to="." method="_on_text_edit_text_changed"]
-[connection signal="pressed" from="MarginContainer/VBoxContainer/TabContainer_DebugPanel/Misc&Debugger/Button_ShowNetwork" to="." method="_on_button_show_network_pressed"]
-[connection signal="pressed" from="MarginContainer/VBoxContainer/TabContainer_DebugPanel/Misc&Debugger/Button_DebugJS" to="." method="_on_button_debug_js_pressed"]
-[connection signal="pressed" from="MarginContainer/VBoxContainer/TabContainer_DebugPanel/Misc&Debugger/Button_OpenSource" to="." method="_on_button_open_source_pressed"]
-[connection signal="pressed" from="MarginContainer/VBoxContainer/MarginContainer_Header/HBoxContainer_TopButtons/Button_ShowHide" to="." method="_on_button_show_hide_pressed"]
-[connection signal="pressed" from="MarginContainer/VBoxContainer/MarginContainer_Header/HBoxContainer_TopButtons/Button_ReloadScene" to="." method="_on_button_reload_scene_pressed"]
+[connection signal="text_changed" from="VBoxContainer/TabContainer_DebugPanel/Console/HBoxContainer/LineEdit_Filter" to="." method="_on_line_edit_filter_text_changed"]
+[connection signal="pressed" from="VBoxContainer/TabContainer_DebugPanel/Console/HBoxContainer/Button_Clear" to="." method="_on_button_clear_pressed"]
+[connection signal="pressed" from="VBoxContainer/TabContainer_DebugPanel/Console/HBoxContainer/Button_Copy" to="." method="_on_button_copy_pressed"]
+[connection signal="item_mouse_selected" from="VBoxContainer/TabContainer_DebugPanel/Console/Tree_Console" to="." method="_on_tree_console_item_mouse_selected"]
+[connection signal="text_changed" from="VBoxContainer/TabContainer_DebugPanel/Expression/TextEdit_Expression" to="." method="_on_text_edit_text_changed"]
+[connection signal="pressed" from="VBoxContainer/TabContainer_DebugPanel/Misc&Debugger/Button_ShowNetwork" to="." method="_on_button_show_network_pressed"]
+[connection signal="pressed" from="VBoxContainer/TabContainer_DebugPanel/Misc&Debugger/Button_DebugJS" to="." method="_on_button_debug_js_pressed"]
+[connection signal="pressed" from="VBoxContainer/TabContainer_DebugPanel/Misc&Debugger/Button_OpenSource" to="." method="_on_button_open_source_pressed"]

--- a/godot/src/ui/components/organisms/preview_hud_panel/preview_hud_panel.gd
+++ b/godot/src/ui/components/organisms/preview_hud_panel/preview_hud_panel.gd
@@ -66,8 +66,6 @@ func _ready() -> void:
 ## realm or a `scene-stats=true` deep link offers it; the settings Scene Logs entry exposes
 ## Console + Reload only. The console/debug panel is never torn down — it stays static.
 func set_scene_status_available(available: bool) -> void:
-	if not is_node_ready():
-		await ready
 	button_scene_status.visible = available
 	if available:
 		if not is_instance_valid(scene_stats_panel):
@@ -86,8 +84,6 @@ func set_scene_status_available(available: bool) -> void:
 ## Point the scene-stats overlay at the scene being previewed (forwarded from explorer.gd
 ## on preview / scene changes). No-op until the overlay exists.
 func set_scene(scene_id: int) -> void:
-	if not is_node_ready():
-		await ready
 	if is_instance_valid(scene_stats_panel):
 		scene_stats_panel.set_scene(scene_id)
 

--- a/godot/src/ui/components/organisms/preview_hud_panel/preview_hud_panel.gd
+++ b/godot/src/ui/components/organisms/preview_hud_panel/preview_hud_panel.gd
@@ -1,0 +1,190 @@
+class_name PreviewHudPanel
+extends MarginContainer
+
+## Preview-mode HUD toolbar (issue #2679). Lives in the same bottom-left slot as the
+## ChatPanel and replaces it while active (settings Scene Logs, preview realm, or a
+## `scene-stats=true` deep link). Placed statically in explorer.tscn — its console
+## (debug_panel) is always present so it keeps capturing scene logs; only the scene-stats
+## overlay (and its header button) is created on demand, here inside the hub.
+##
+## Header buttons: Console (toggles the console), Scene Status (toggles the scene-stats
+## overlay; shown only in preview/deep-link), Reload (reloads the current scene). Console
+## and Scene Status share the same body position and are mutually exclusive — opening one
+## closes the other. Selected buttons tint red, default is white.
+
+const COLOR_ACTIVE: Color = Color("ff2d55")
+const COLOR_DEFAULT: Color = Color("fcfcfc")
+# Reload icon while the button is held down (it never toggles nor shows a border).
+const COLOR_RELOAD_PRESSED: Color = Color("df9cff")
+const BUTTON_STATES: Array[String] = [
+	"normal",
+	"pressed",
+	"pressed_mirrored",
+	"hover",
+	"hover_mirrored",
+	"hover_pressed",
+	"hover_pressed_mirrored",
+	"focus",
+]
+const SCENE_STATS_SCENE: PackedScene = preload(
+	"res://src/ui/components/organisms/scene_stats_panel/scene_stats_panel.tscn"
+)
+
+var scene_stats_panel: SceneStatsPanel = null
+# Each toggle button gets its own copy of the scene's border stylebox so its border color can
+# be set independently (the scene shares one stylebox across both) — recolored per open/close.
+var _console_box: StyleBoxFlat = null
+var _stats_box: StyleBoxFlat = null
+
+@onready var button_console: Button = %Button_Console
+@onready var button_scene_status: Button = %Button_SceneStatus
+@onready var button_reload: Button = %Button_Reload
+@onready var body: Control = %Body
+# Untyped: the DebugPanel script has no class_name, so its custom methods
+# (set_console_visible/reload_current_scene) dispatch cleanly.
+@onready var debug_panel = %DebugPanel
+
+
+func _ready() -> void:
+	button_console.toggle_mode = true
+	button_scene_status.toggle_mode = true
+	button_console.button_pressed = false
+	button_scene_status.button_pressed = false
+	button_console.pressed.connect(_on_console_pressed)
+	button_scene_status.pressed.connect(_on_scene_status_pressed)
+	button_reload.pressed.connect(_on_reload_pressed)
+	# Console starts collapsed; scene-stats is created on demand via set_scene_status_available.
+	debug_panel.hide()
+	button_scene_status.hide()
+	_console_box = _own_border_stylebox(button_console)
+	_stats_box = _own_border_stylebox(button_scene_status)
+	_setup_reload_style()
+	_refresh_toggle_colors()
+
+
+## Create or free the scene-stats overlay (and show/hide its header button). Only a preview
+## realm or a `scene-stats=true` deep link offers it; the settings Scene Logs entry exposes
+## Console + Reload only. The console/debug panel is never torn down — it stays static.
+func set_scene_status_available(available: bool) -> void:
+	if not is_node_ready():
+		await ready
+	button_scene_status.visible = available
+	if available:
+		if not is_instance_valid(scene_stats_panel):
+			scene_stats_panel = SCENE_STATS_SCENE.instantiate()
+			scene_stats_panel.hide()
+			body.add_child(scene_stats_panel)
+	else:
+		if button_scene_status.button_pressed:
+			button_scene_status.set_pressed_no_signal(false)
+		if is_instance_valid(scene_stats_panel):
+			scene_stats_panel.queue_free()
+			scene_stats_panel = null
+		_refresh_toggle_colors()
+
+
+## Point the scene-stats overlay at the scene being previewed (forwarded from explorer.gd
+## on preview / scene changes). No-op until the overlay exists.
+func set_scene(scene_id: int) -> void:
+	if not is_node_ready():
+		await ready
+	if is_instance_valid(scene_stats_panel):
+		scene_stats_panel.set_scene(scene_id)
+
+
+## Forward a scene console line to the embedded (always-present) debug panel.
+func on_console_add(scene_title: String, level: int, timestamp: float, text: String) -> void:
+	if not is_node_ready():
+		return
+	debug_panel.on_console_add(scene_title, level, timestamp, text)
+
+
+## Collapse back to header-only: both overlays closed, every toggle off. Called when the
+## toolbar is restored (e.g. after the navbar collapses), mirroring the chat returning to
+## its closed state.
+func reset() -> void:
+	if not is_node_ready():
+		return
+	button_console.set_pressed_no_signal(false)
+	button_scene_status.set_pressed_no_signal(false)
+	debug_panel.hide()
+	if is_instance_valid(scene_stats_panel):
+		scene_stats_panel.hide()
+	_refresh_toggle_colors()
+
+
+func _on_console_pressed() -> void:
+	Global.send_haptic_feedback()
+	if button_console.button_pressed:
+		button_scene_status.set_pressed_no_signal(false)
+		if is_instance_valid(scene_stats_panel):
+			scene_stats_panel.hide()
+		debug_panel.show()
+		debug_panel.set_console_visible(true)
+	else:
+		debug_panel.hide()
+	_refresh_toggle_colors()
+
+
+func _on_scene_status_pressed() -> void:
+	Global.send_haptic_feedback()
+	if button_scene_status.button_pressed:
+		button_console.set_pressed_no_signal(false)
+		debug_panel.hide()
+		if is_instance_valid(scene_stats_panel):
+			scene_stats_panel.show()
+	elif is_instance_valid(scene_stats_panel):
+		scene_stats_panel.hide()
+	_refresh_toggle_colors()
+
+
+func _on_reload_pressed() -> void:
+	Global.send_haptic_feedback()
+	debug_panel.reload_current_scene()
+
+
+## Give the button its own copy of the scene's border stylebox for every visual state, so its
+## border color can be set independently of the other toggle (they share one in the scene).
+## Preserves the scene's shape/width — we only recolor the border later.
+func _own_border_stylebox(button: Button) -> StyleBoxFlat:
+	var src: StyleBox = button.get_theme_stylebox(&"normal")
+	var box: StyleBoxFlat
+	if src is StyleBoxFlat:
+		box = src.duplicate() as StyleBoxFlat
+	else:
+		box = StyleBoxFlat.new()
+	for state_name in BUTTON_STATES:
+		button.add_theme_stylebox_override(state_name, box)
+	return box
+
+
+## Reload never shows a border: reuse its borderless scene stylebox for every state. Its icon
+## is white and turns lilac (#DF9CFF) while held (driven by the momentary pressed draw state).
+func _setup_reload_style() -> void:
+	_tint_icon(button_reload, COLOR_DEFAULT, COLOR_RELOAD_PRESSED)
+	var borderless: StyleBox = button_reload.get_theme_stylebox(&"normal")
+	for state_name in BUTTON_STATES:
+		button_reload.add_theme_stylebox_override(state_name, borderless)
+
+
+## Console/Scene Status: border + icon are red (#FF2D55) while open, white (#FCFCFC) while
+## closed. Re-applied on every open/close (incl. the mutually-excluded partner, which is
+## toggled off without a signal).
+func _refresh_toggle_colors() -> void:
+	_color_toggle(button_console, _console_box, button_console.button_pressed)
+	_color_toggle(button_scene_status, _stats_box, button_scene_status.button_pressed)
+
+
+func _color_toggle(button: Button, box: StyleBoxFlat, is_open: bool) -> void:
+	var color: Color = COLOR_ACTIVE if is_open else COLOR_DEFAULT
+	if box != null:
+		box.border_color = color
+	_tint_icon(button, color, color)
+
+
+func _tint_icon(button: Button, normal_color: Color, pressed_color: Color) -> void:
+	button.add_theme_color_override("icon_normal_color", normal_color)
+	button.add_theme_color_override("icon_hover_color", normal_color)
+	button.add_theme_color_override("icon_focus_color", normal_color)
+	button.add_theme_color_override("icon_pressed_color", pressed_color)
+	button.add_theme_color_override("icon_hover_pressed_color", pressed_color)

--- a/godot/src/ui/components/organisms/preview_hud_panel/preview_hud_panel.gd.uid
+++ b/godot/src/ui/components/organisms/preview_hud_panel/preview_hud_panel.gd.uid
@@ -1,0 +1,1 @@
+uid://k1ucbqns4fyy

--- a/godot/src/ui/components/organisms/preview_hud_panel/preview_hud_panel.tscn
+++ b/godot/src/ui/components/organisms/preview_hud_panel/preview_hud_panel.tscn
@@ -56,6 +56,7 @@ theme_override_constants/separation = 0
 
 [node name="MarginContainer" type="MarginContainer" parent="VBoxContainer" unique_id=806649657]
 layout_mode = 2
+mouse_filter = 2
 theme_override_constants/margin_top = 12
 theme_override_constants/margin_bottom = 25
 

--- a/godot/src/ui/components/organisms/preview_hud_panel/preview_hud_panel.tscn
+++ b/godot/src/ui/components/organisms/preview_hud_panel/preview_hud_panel.tscn
@@ -25,18 +25,6 @@ corner_radius_top_right = 100
 corner_radius_bottom_right = 100
 corner_radius_bottom_left = 100
 
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_pressed"]
-bg_color = Color(0.078431375, 0.023529412, 0.1254902, 1)
-border_width_left = 2
-border_width_top = 2
-border_width_right = 2
-border_width_bottom = 2
-border_color = Color(0.87058824, 0.84313726, 0.9019608, 1)
-corner_radius_top_left = 100
-corner_radius_top_right = 100
-corner_radius_bottom_right = 100
-corner_radius_bottom_left = 100
-
 [node name="PreviewHudPanel" type="MarginContainer" unique_id=1534114070]
 anchors_preset = 15
 anchor_right = 1.0
@@ -49,7 +37,6 @@ script = ExtResource("1_script")
 metadata/mobile_preview_orientation = "landscape"
 
 [node name="VBoxContainer" type="VBoxContainer" parent="." unique_id=900190433]
-custom_minimum_size = Vector2(0, 450)
 layout_mode = 2
 mouse_filter = 2
 theme_override_constants/separation = 0
@@ -81,12 +68,6 @@ theme = ExtResource("2_theme")
 theme_type_variation = &"SecondaryLittle"
 theme_override_constants/icon_max_width = 38
 theme_override_styles/normal = SubResource("StyleBoxFlat_normal")
-theme_override_styles/pressed = SubResource("StyleBoxFlat_normal")
-theme_override_styles/pressed_mirrored = SubResource("StyleBoxFlat_normal")
-theme_override_styles/hover = SubResource("StyleBoxFlat_normal")
-theme_override_styles/hover_mirrored = SubResource("StyleBoxFlat_normal")
-theme_override_styles/hover_pressed = SubResource("StyleBoxFlat_normal")
-theme_override_styles/hover_pressed_mirrored = SubResource("StyleBoxFlat_normal")
 icon = ExtResource("3_console")
 icon_alignment = 1
 expand_icon = true
@@ -101,12 +82,6 @@ theme = ExtResource("2_theme")
 theme_type_variation = &"SecondaryLittle"
 theme_override_constants/icon_max_width = 38
 theme_override_styles/normal = SubResource("StyleBoxFlat_normal")
-theme_override_styles/pressed = SubResource("StyleBoxFlat_normal")
-theme_override_styles/pressed_mirrored = SubResource("StyleBoxFlat_normal")
-theme_override_styles/hover = SubResource("StyleBoxFlat_normal")
-theme_override_styles/hover_mirrored = SubResource("StyleBoxFlat_normal")
-theme_override_styles/hover_pressed = SubResource("StyleBoxFlat_normal")
-theme_override_styles/hover_pressed_mirrored = SubResource("StyleBoxFlat_normal")
 icon = ExtResource("4_monitor")
 icon_alignment = 1
 expand_icon = true
@@ -121,12 +96,6 @@ theme = ExtResource("2_theme")
 theme_type_variation = &"SecondaryLittle"
 theme_override_constants/icon_max_width = 38
 theme_override_styles/normal = SubResource("StyleBoxFlat_bbus7")
-theme_override_styles/pressed = SubResource("StyleBoxFlat_pressed")
-theme_override_styles/pressed_mirrored = SubResource("StyleBoxFlat_pressed")
-theme_override_styles/hover = SubResource("StyleBoxFlat_normal")
-theme_override_styles/hover_mirrored = SubResource("StyleBoxFlat_normal")
-theme_override_styles/hover_pressed = SubResource("StyleBoxFlat_pressed")
-theme_override_styles/hover_pressed_mirrored = SubResource("StyleBoxFlat_pressed")
 icon = ExtResource("5_reload")
 icon_alignment = 1
 expand_icon = true

--- a/godot/src/ui/components/organisms/preview_hud_panel/preview_hud_panel.tscn
+++ b/godot/src/ui/components/organisms/preview_hud_panel/preview_hud_panel.tscn
@@ -1,0 +1,143 @@
+[gd_scene format=3 uid="uid://v3ktu5kra0ql"]
+
+[ext_resource type="Script" uid="uid://k1ucbqns4fyy" path="res://src/ui/components/organisms/preview_hud_panel/preview_hud_panel.gd" id="1_script"]
+[ext_resource type="Theme" uid="uid://bn7q4ap7m5gdu" path="res://assets/themes/dcl_theme.tres" id="2_theme"]
+[ext_resource type="Texture2D" uid="uid://c7rx0q1yjyde0" path="res://assets/ui/console_icon.svg" id="3_console"]
+[ext_resource type="Texture2D" uid="uid://dgchxj5lqd237" path="res://assets/ui/scene_stats_monitor.svg" id="4_monitor"]
+[ext_resource type="Texture2D" uid="uid://c0n8k2q368jvf" path="res://assets/ui/reload_icon.svg" id="5_reload"]
+[ext_resource type="PackedScene" uid="uid://dua04n3geh0yf" path="res://src/ui/components/organisms/debug_panel/debug_panel.tscn" id="6_debug"]
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_normal"]
+bg_color = Color(0.078431375, 0.023529412, 0.1254902, 1)
+border_width_left = 3
+border_width_top = 3
+border_width_right = 3
+border_width_bottom = 3
+corner_radius_top_left = 100
+corner_radius_top_right = 100
+corner_radius_bottom_right = 100
+corner_radius_bottom_left = 100
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_bbus7"]
+bg_color = Color(0.078431375, 0.023529412, 0.1254902, 1)
+corner_radius_top_left = 100
+corner_radius_top_right = 100
+corner_radius_bottom_right = 100
+corner_radius_bottom_left = 100
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_pressed"]
+bg_color = Color(0.078431375, 0.023529412, 0.1254902, 1)
+border_width_left = 2
+border_width_top = 2
+border_width_right = 2
+border_width_bottom = 2
+border_color = Color(0.87058824, 0.84313726, 0.9019608, 1)
+corner_radius_top_left = 100
+corner_radius_top_right = 100
+corner_radius_bottom_right = 100
+corner_radius_bottom_left = 100
+
+[node name="PreviewHudPanel" type="MarginContainer" unique_id=1534114070]
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+mouse_filter = 2
+theme_override_constants/margin_right = 0
+script = ExtResource("1_script")
+metadata/mobile_preview_orientation = "landscape"
+
+[node name="VBoxContainer" type="VBoxContainer" parent="." unique_id=900190433]
+custom_minimum_size = Vector2(0, 450)
+layout_mode = 2
+mouse_filter = 2
+theme_override_constants/separation = 0
+
+[node name="MarginContainer" type="MarginContainer" parent="VBoxContainer" unique_id=806649657]
+layout_mode = 2
+theme_override_constants/margin_top = 12
+theme_override_constants/margin_bottom = 25
+
+[node name="HBoxContainer_Header" type="HBoxContainer" parent="VBoxContainer/MarginContainer" unique_id=1388692376]
+layout_mode = 2
+size_flags_horizontal = 0
+mouse_filter = 2
+theme_override_constants/separation = 20
+
+[node name="Control" type="Control" parent="VBoxContainer/MarginContainer/HBoxContainer_Header" unique_id=849984911]
+custom_minimum_size = Vector2(101, 0)
+layout_mode = 2
+mouse_filter = 2
+
+[node name="Button_Console" type="Button" parent="VBoxContainer/MarginContainer/HBoxContainer_Header" unique_id=1761087111]
+unique_name_in_owner = true
+custom_minimum_size = Vector2(66, 66)
+layout_mode = 2
+size_flags_vertical = 4
+focus_mode = 0
+theme = ExtResource("2_theme")
+theme_type_variation = &"SecondaryLittle"
+theme_override_constants/icon_max_width = 38
+theme_override_styles/normal = SubResource("StyleBoxFlat_normal")
+theme_override_styles/pressed = SubResource("StyleBoxFlat_normal")
+theme_override_styles/pressed_mirrored = SubResource("StyleBoxFlat_normal")
+theme_override_styles/hover = SubResource("StyleBoxFlat_normal")
+theme_override_styles/hover_mirrored = SubResource("StyleBoxFlat_normal")
+theme_override_styles/hover_pressed = SubResource("StyleBoxFlat_normal")
+theme_override_styles/hover_pressed_mirrored = SubResource("StyleBoxFlat_normal")
+icon = ExtResource("3_console")
+icon_alignment = 1
+expand_icon = true
+
+[node name="Button_SceneStatus" type="Button" parent="VBoxContainer/MarginContainer/HBoxContainer_Header" unique_id=1272115698]
+unique_name_in_owner = true
+custom_minimum_size = Vector2(66, 66)
+layout_mode = 2
+size_flags_vertical = 4
+focus_mode = 0
+theme = ExtResource("2_theme")
+theme_type_variation = &"SecondaryLittle"
+theme_override_constants/icon_max_width = 38
+theme_override_styles/normal = SubResource("StyleBoxFlat_normal")
+theme_override_styles/pressed = SubResource("StyleBoxFlat_normal")
+theme_override_styles/pressed_mirrored = SubResource("StyleBoxFlat_normal")
+theme_override_styles/hover = SubResource("StyleBoxFlat_normal")
+theme_override_styles/hover_mirrored = SubResource("StyleBoxFlat_normal")
+theme_override_styles/hover_pressed = SubResource("StyleBoxFlat_normal")
+theme_override_styles/hover_pressed_mirrored = SubResource("StyleBoxFlat_normal")
+icon = ExtResource("4_monitor")
+icon_alignment = 1
+expand_icon = true
+
+[node name="Button_Reload" type="Button" parent="VBoxContainer/MarginContainer/HBoxContainer_Header" unique_id=265092282]
+unique_name_in_owner = true
+custom_minimum_size = Vector2(66, 66)
+layout_mode = 2
+size_flags_vertical = 4
+focus_mode = 0
+theme = ExtResource("2_theme")
+theme_type_variation = &"SecondaryLittle"
+theme_override_constants/icon_max_width = 38
+theme_override_styles/normal = SubResource("StyleBoxFlat_bbus7")
+theme_override_styles/pressed = SubResource("StyleBoxFlat_pressed")
+theme_override_styles/pressed_mirrored = SubResource("StyleBoxFlat_pressed")
+theme_override_styles/hover = SubResource("StyleBoxFlat_normal")
+theme_override_styles/hover_mirrored = SubResource("StyleBoxFlat_normal")
+theme_override_styles/hover_pressed = SubResource("StyleBoxFlat_pressed")
+theme_override_styles/hover_pressed_mirrored = SubResource("StyleBoxFlat_pressed")
+icon = ExtResource("5_reload")
+icon_alignment = 1
+expand_icon = true
+
+[node name="Body" type="VBoxContainer" parent="VBoxContainer" unique_id=1879917654]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 0
+mouse_filter = 2
+theme_override_constants/separation = 8
+
+[node name="DebugPanel" parent="VBoxContainer/Body" unique_id=287381210 instance=ExtResource("6_debug")]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_vertical = 3

--- a/godot/src/ui/components/organisms/scene_stats_panel/scene_stats_panel.gd
+++ b/godot/src/ui/components/organisms/scene_stats_panel/scene_stats_panel.gd
@@ -7,18 +7,15 @@ extends PanelContainer
 ##   green  = under the soft (recommended) limit
 ##   orange = between soft and hard
 ##   red    = over the hard limit — track dims and a warning icon appears
-## A circular "monitor" button (same size as the camera button, placed to its
-## left) shows/hides this panel: white icon when closed, ruby icon + ring when
-## open. The Performance row shows a "?" badge; tapping anywhere on that row
-## toggles a tooltip explaining the metric. Instantiated ONLY in preview by
-## explorer.gd; never created in production.
+## Visibility is driven by the preview HUD toolbar's Scene Status button
+## (PreviewHudPanel, issue #2679); this overlay only renders content. The
+## Performance row shows a "?" badge; tapping anywhere on that row toggles a
+## tooltip explaining the metric. Instantiated ONLY in preview by explorer.gd
+## (inside the preview HUD panel); never created in production.
 
 enum Status { GREEN, YELLOW, RED }
 
 const REFRESH_INTERVAL: float = 1.5
-const TOGGLE_SIZE: float = 65.0
-const TOGGLE_GAP: float = 12.0
-const MONITOR_ICON_PATH: String = "res://assets/ui/scene_stats_monitor.svg"
 const WARNING_ICON_PATH: String = "res://assets/ui/scene_stats_warning.svg"
 const TOOLTIP_ARROW_PATH: String = "res://assets/ui/scene_stats_tooltip_arrow.svg"
 
@@ -36,7 +33,6 @@ const COLOR_RED: Color = Color("ff2d55")
 const COLOR_TEXT: Color = Color("fcfcfc")
 const COLOR_SHADOW_BG: Color = Color("161518")
 const COLOR_SCROLLBAR: Color = Color("966ac5")
-const COLOR_MONITOR: Color = Color("ff2d55")
 
 const TOOLTIP_TEXT: String = "Percentage of the FPS target the client runs at for this scene"
 const TOOLTIP_MIN_SIZE: Vector2 = Vector2(260.0, 52.0)
@@ -53,8 +49,6 @@ var _rows: Dictionary = {}
 var _fill_styles: Dictionary = {}
 var _track_style: StyleBoxFlat = null
 var _track_style_red: StyleBoxFlat = null
-var _toggle_btn: Button = null
-var _toggle_icon: TextureRect = null
 var _fps_row: HBoxContainer = null
 var _tooltip: Control = null
 var _tooltip_bubble: PanelContainer = null
@@ -74,7 +68,7 @@ func _ready() -> void:
 	_build_styleboxes()
 	_build_rows()
 	_style_scrollbar()
-	_create_toggle_button()
+	visibility_changed.connect(_on_visibility_changed)
 	_timer.wait_time = REFRESH_INTERVAL
 	_timer.timeout.connect(_on_timer_timeout)
 	_timer.start()
@@ -99,14 +93,6 @@ func _input(event: InputEvent) -> void:
 	if mouse_press or touch_press:
 		_hide_tooltip()
 		get_viewport().set_input_as_handled()
-
-
-## Free the external toggle button (it lives under the camera button, not under
-## this panel) when the overlay is torn down.
-func _exit_tree() -> void:
-	if is_instance_valid(_toggle_btn):
-		_toggle_btn.queue_free()
-		_toggle_btn = null
 
 
 ## Point the overlay at a scene (called by explorer.gd on preview / scene change).
@@ -134,9 +120,9 @@ func _on_timer_timeout() -> void:
 	_refresh()
 
 
-func _on_toggle_pressed() -> void:
-	visible = not visible
-	_apply_toggle_state()
+## Visibility is driven externally by the preview HUD toolbar (issue #2679).
+## Refresh on show; drop any open tooltip on hide.
+func _on_visibility_changed() -> void:
 	if visible:
 		_refresh()
 	else:
@@ -298,20 +284,6 @@ func _make_fill(c: Color) -> StyleBoxFlat:
 	return sb
 
 
-func _make_circle(c: Color, ring: bool) -> StyleBoxFlat:
-	var sb: StyleBoxFlat = StyleBoxFlat.new()
-	sb.bg_color = c
-	sb.set_corner_radius_all(int(TOGGLE_SIZE / 2.0))
-	sb.content_margin_left = 12.0
-	sb.content_margin_right = 12.0
-	sb.content_margin_top = 12.0
-	sb.content_margin_bottom = 12.0
-	if ring:
-		sb.set_border_width_all(2)
-		sb.border_color = COLOR_MONITOR
-	return sb
-
-
 ## 4px scrollbar: dark track, purple grabber (Figma "Group 3107").
 func _style_scrollbar() -> void:
 	var vsb: VScrollBar = _scroll.get_v_scroll_bar()
@@ -323,71 +295,6 @@ func _style_scrollbar() -> void:
 	grabber.bg_color = COLOR_SCROLLBAR
 	for style_name in ["grabber", "grabber_highlight", "grabber_pressed"]:
 		vsb.add_theme_stylebox_override(style_name, grabber)
-
-
-## Build the monitor toggle button and place it to the LEFT of the camera
-## (1st/3rd person) button at the same size; fall back to the panel's parent.
-func _create_toggle_button() -> void:
-	_toggle_btn = Button.new()
-	_toggle_btn.custom_minimum_size = Vector2(TOGGLE_SIZE, TOGGLE_SIZE)
-	_toggle_btn.focus_mode = Control.FOCUS_NONE
-	_toggle_btn.pressed.connect(_on_toggle_pressed)
-
-	# Icon as a centered child TextureRect — guarantees centering and sizing
-	# regardless of Button icon-layout quirks.
-	_toggle_icon = TextureRect.new()
-	_toggle_icon.texture = load(MONITOR_ICON_PATH)
-	_toggle_icon.expand_mode = TextureRect.EXPAND_IGNORE_SIZE
-	_toggle_icon.stretch_mode = TextureRect.STRETCH_KEEP_ASPECT_CENTERED
-	_toggle_icon.set_anchors_preset(Control.PRESET_FULL_RECT)
-	_toggle_icon.offset_left = 15.0
-	_toggle_icon.offset_top = 15.0
-	_toggle_icon.offset_right = -15.0
-	_toggle_icon.offset_bottom = -15.0
-	_toggle_icon.mouse_filter = Control.MOUSE_FILTER_IGNORE
-	_toggle_btn.add_child(_toggle_icon)
-	_apply_toggle_state()
-
-	var cam: Control = _find_camera_button()
-	if cam != null:
-		cam.get_parent().add_child(_toggle_btn)
-		_toggle_btn.anchor_left = cam.anchor_left
-		_toggle_btn.anchor_top = cam.anchor_top
-		_toggle_btn.anchor_right = cam.anchor_right
-		_toggle_btn.anchor_bottom = cam.anchor_bottom
-		_toggle_btn.grow_horizontal = cam.grow_horizontal
-		_toggle_btn.offset_top = cam.offset_top
-		_toggle_btn.offset_bottom = cam.offset_bottom
-		_toggle_btn.offset_right = cam.offset_left - TOGGLE_GAP
-		_toggle_btn.offset_left = cam.offset_left - TOGGLE_GAP - TOGGLE_SIZE
-	else:
-		get_parent().add_child(_toggle_btn)
-		_toggle_btn.set_anchors_preset(Control.PRESET_TOP_RIGHT)
-		_toggle_btn.grow_horizontal = Control.GROW_DIRECTION_BEGIN
-		_toggle_btn.offset_right = -12.0
-		_toggle_btn.offset_left = -12.0 - TOGGLE_SIZE
-		_toggle_btn.offset_top = 40.0
-		_toggle_btn.offset_bottom = 40.0 + TOGGLE_SIZE
-
-
-## Closed: white icon on a plain dark circle. Open: ruby icon + ruby ring
-## (Figma "Performance-Close" / "Performance-Open" frames).
-func _apply_toggle_state() -> void:
-	if _toggle_btn == null:
-		return
-	var open: bool = visible
-	_toggle_btn.add_theme_stylebox_override("normal", _make_circle(Color(0, 0, 0, 0.62), open))
-	var active: StyleBoxFlat = _make_circle(Color(0.22, 0.22, 0.28, 0.85), open)
-	_toggle_btn.add_theme_stylebox_override("hover", active)
-	_toggle_btn.add_theme_stylebox_override("pressed", active)
-	_toggle_icon.modulate = COLOR_MONITOR if open else Color.WHITE
-
-
-func _find_camera_button() -> Control:
-	if not is_inside_tree():
-		return null
-	var node := get_tree().get_root().find_child("Button_Camera", true, false)
-	return node as Control
 
 
 func _build_rows() -> void:

--- a/godot/src/ui/components/organisms/scene_stats_panel/scene_stats_panel.tscn
+++ b/godot/src/ui/components/organisms/scene_stats_panel/scene_stats_panel.tscn
@@ -1,6 +1,6 @@
-[gd_scene format=3]
+[gd_scene format=3 uid="uid://briminynyjoew"]
 
-[ext_resource type="Script" path="res://src/ui/components/organisms/scene_stats_panel/scene_stats_panel.gd" id="1_script"]
+[ext_resource type="Script" uid="uid://cn54ffvovyot1" path="res://src/ui/components/organisms/scene_stats_panel/scene_stats_panel.gd" id="1_script"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_panel"]
 bg_color = Color(0, 0, 0, 0.5)
@@ -9,25 +9,30 @@ corner_radius_top_right = 8
 corner_radius_bottom_right = 8
 corner_radius_bottom_left = 8
 
-[node name="SceneStatsPanel" type="PanelContainer"]
+[node name="SceneStatsPanel" type="PanelContainer" unique_id=481300422]
 custom_minimum_size = Vector2(496, 0)
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
 size_flags_horizontal = 8
 size_flags_vertical = 0
 mouse_filter = 2
 theme_override_styles/panel = SubResource("StyleBoxFlat_panel")
 script = ExtResource("1_script")
 
-[node name="Scroll" type="ScrollContainer" parent="."]
+[node name="Scroll" type="ScrollContainer" parent="." unique_id=1057824766]
 unique_name_in_owner = true
 custom_minimum_size = Vector2(0, 324)
 layout_mode = 2
 horizontal_scroll_mode = 0
 
-[node name="RowsContainer" type="VBoxContainer" parent="Scroll"]
+[node name="RowsContainer" type="VBoxContainer" parent="Scroll" unique_id=238831336]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
 mouse_filter = 2
 
-[node name="Timer" type="Timer" parent="."]
+[node name="Timer" type="Timer" parent="." unique_id=2093963510]
 unique_name_in_owner = true

--- a/godot/src/ui/explorer.gd
+++ b/godot/src/ui/explorer.gd
@@ -25,7 +25,6 @@ var panel_bottom_left_height: int = 0
 var dirty_save_position: bool = false
 
 var multiplayer_debug_panel = null
-var scene_stats_panel = null
 var disable_move_to = false
 
 var virtual_joystick_orig_position: Vector2i
@@ -65,8 +64,6 @@ var _debug_panel_from_settings: bool = false
 
 @onready var ui_root: Control = %UI
 @onready var ui_safe_area: Control = %SceneUIContainer
-@onready var safe_margin_container_debug: SafeMarginContainer = %SafeMarginContainerDebug
-@onready var hbox_debug_tools: HBoxContainer = %HBoxContainer_DebugTools
 
 @onready var warning_messages = %WarningMessages
 @onready var label_crosshair = %Label_Crosshair
@@ -87,11 +84,9 @@ var _debug_panel_from_settings: bool = false
 @onready var safe_area_controls: MarginContainer = %SafeAreaControls
 @onready var safe_area_hud: MarginContainer = %SafeAreaHud
 @onready var hud_content: Control = %InteractableHUD
-## Static instance placed in the scene (top-left of the safe margin, inside
-## InteractableHUD). Never freed — just shown/hidden by _update_debug_ui; a hidden
-## Control subtree costs nothing and preview needs it available in prod builds too.
-## Untyped (the DebugPanel script has no class_name) so its own methods dispatch cleanly.
-@onready var debug_panel = %DebugPanel
+## Preview-mode HUD toolbar (console/scene-stats/reload). Static hidden InteractableHUD child
+## so its console keeps capturing logs; shown only while _preview_panel_active().
+@onready var preview_hud_panel = %PreviewHudPanel
 @onready var virtual_joystick: Control = %VirtualJoystick_Left
 @onready var profile_container: Control = %ProfileContainer
 
@@ -249,11 +244,9 @@ func _ready():
 	if Global.cli.debug_panel:
 		_debug_panel_from_settings = true
 
-	# Show debug panel and reload button if in preview mode or --debug-panel
-	_update_debug_ui()
-
-	# Preview-only scene-stats / limits overlay (never created in production)
-	_update_scene_stats_ui()
+	# Preview HUD toolbar (console/reload, plus scene-stats in preview/deep-link).
+	# Replaces the chat panel while active; never created in a normal production run.
+	_update_preview_hud()
 
 	# multiplayer_debug deep link parameter auto-enables the multiplayer debug panel.
 	# Checked via the comms flag too: a target-less deeplink is consumed while the
@@ -706,8 +699,8 @@ func _on_scene_console_message(scene_id: int, level: int, timestamp: float, text
 func _scene_console_message(scene_id: int, level: int, timestamp: float, text: String) -> void:
 	var title: String = Global.scene_runner.get_scene_title(scene_id)
 	title += str(Global.scene_runner.get_scene_base_parcel(scene_id))
-	if is_instance_valid(debug_panel):
-		debug_panel.on_console_add(title, level, timestamp, text)
+	if is_instance_valid(preview_hud_panel):
+		preview_hud_panel.on_console_add(title, level, timestamp, text)
 
 
 func _on_pointer_tooltip_changed():
@@ -1003,12 +996,13 @@ func _set_explorer_hud_elements_visible(full_hud: bool) -> void:
 		# SafeAreaHud stays visible (exception); we toggle its content group so the
 		# Show-UI button (a sibling of hud_content) survives and children keep their state.
 		hud_content.show()
-		# Invariant: showing the HUD always means the chat is visible. Hide-UI is applied
-		# on navbar-close, where _close_all_panels' normal "re-show the chat" is suppressed
-		# while hidden — so the chat is always left hidden by the time we restore, and we
-		# must re-assert it here. (Write-mode can't leak a hidden chatbar: writing hides the
-		# navbar, so Settings/hide-UI is unreachable while writing.)
-		chat_panel.show()
+		# Invariant: showing the HUD always means the bottom-left slot is restored. Hide-UI
+		# is applied on navbar-close, where _close_all_panels' normal "re-show" is suppressed
+		# while hidden — so it is always left hidden by the time we restore, and we must
+		# re-assert it here. In preview this shows the preview HUD toolbar instead of the chat.
+		# (Write-mode can't leak a hidden chatbar: writing hides the navbar, so Settings/hide-UI
+		# is unreachable while writing.)
+		_restore_bottom_left_hud()
 		# Re-assert the emote button too: an overlay (e.g. the navbar) may have left it
 		# hidden before Hide-UI was applied, and hud_content.show() won't re-show a child
 		# whose own visibility is false. Portrait owns it through the orientation flow.
@@ -1037,54 +1031,71 @@ func _set_explorer_hud_elements_visible(full_hud: bool) -> void:
 
 func _on_control_menu_request_debug_panel(enabled):
 	_debug_panel_from_settings = enabled
-	_update_debug_ui()
+	_update_preview_hud()
 
 
-## Whether the debug panel is enabled at all (dev toggle or preview realm). The
-## chat/hide-UI handlers use it to restore the panel to the right state.
-func _debug_should_show() -> bool:
-	return _debug_panel_from_settings or _is_in_preview_realm()
+## Whether the preview HUD toolbar should exist at all: the settings Scene Logs
+## toggle (or --debug-panel), a preview realm, or a `scene-stats=true` deep link.
+## The chat/hide-UI restore paths use it to pick chat vs toolbar in the bottom-left slot.
+func _preview_panel_active() -> bool:
+	return _debug_panel_from_settings or _is_in_preview_realm() or Global.deep_link_obj.scene_stats
 
 
-func _update_debug_ui():
-	var should_show = _debug_should_show()
-	debug_panel.visible = should_show
-	debug_panel.set_reload_scene_visible(should_show)
-	Global.set_scene_log_enabled(should_show)
-	_update_debug_layer_visibility()
+## Whether the scene-stats overlay (and its header button) is offered: only a preview
+## realm or a `scene-stats=true` deep link — not the settings Scene Logs entry, which
+## exposes console + reload only.
+func _scene_stats_available() -> bool:
+	return _is_in_preview_realm() or Global.deep_link_obj.scene_stats
 
 
-## Scene-stats overlay. Instantiated in preview, or in any realm when the
-## `scene-stats=true` deep link forces it on — in every build flavor,
-## production included, so creators can measure scenes on store builds. A
-## normal run (no preview, no deep link) still instantiates nothing, so the
-## zero-cost guarantee holds, mirroring _update_debug_ui.
-func _update_scene_stats_ui() -> void:
-	var should_show := _is_in_preview_realm() or Global.deep_link_obj.scene_stats
-	if should_show:
-		if not is_instance_valid(scene_stats_panel):
-			scene_stats_panel = (
-				load("res://src/ui/components/organisms/scene_stats_panel/scene_stats_panel.tscn")
-				. instantiate()
-			)
-			# Shares the top-right debug tools row with the console, so both
-			# lay out side by side instead of overlapping.
-			hbox_debug_tools.add_child(scene_stats_panel)
-		scene_stats_panel.set_scene(_preview_scene_id())
-	else:
-		if is_instance_valid(scene_stats_panel):
-			scene_stats_panel.queue_free()
-			scene_stats_panel = null
-	_update_debug_layer_visibility()
+## Keep the (static) preview HUD toolbar in sync: create/free the scene-stats overlay, point
+## it at the previewed scene, gate scene logs, and show/hide the toolbar. The console/debug
+## panel is always present (static) so it keeps capturing logs; only scene-stats is on demand.
+func _update_preview_hud() -> void:
+	if not is_instance_valid(preview_hud_panel):
+		return
+	var active: bool = _preview_panel_active()
+	preview_hud_panel.set_scene_status_available(_scene_stats_available())
+	if active:
+		preview_hud_panel.set_scene(_preview_scene_id())
+	Global.set_scene_log_enabled(active)
+	_restore_bottom_left_hud()
 
 
-## The debug layer hosts the console + scene-stats row; show it only while one
-## of them exists. It must be shown explicitly: it was once saved hidden in the
-## editor (PR #1894), which silently disabled the whole layer.
-func _update_debug_layer_visibility() -> void:
-	# Only the scene-stats monitor toggle lives in this top-right row now; the
-	# debug panel moved to the top-left of the HUD (a static InteractableHUD child).
-	safe_margin_container_debug.visible = is_instance_valid(scene_stats_panel)
+## True while a navbar side panel (or the dropdown) is open — the bottom-left slot hides then.
+func _bottom_left_slot_blocked() -> bool:
+	return (
+		navbar.is_open()
+		or friends_panel.visible
+		or notifications_panel.visible
+		or settings_panel.visible
+	)
+
+
+## Restore the bottom-left slot: while a navbar panel is open it stays hidden; otherwise the
+## active toolbar is shown (reset to header-only) and the chat hidden, else the chat owns the
+## slot. Hide-UI still wins (nothing force-shown while the HUD is hidden).
+func _restore_bottom_left_hud() -> void:
+	if _bottom_left_slot_blocked():
+		_hide_bottom_left_hud()
+		return
+	if _preview_panel_active():
+		if is_instance_valid(preview_hud_panel):
+			preview_hud_panel.reset()
+			preview_hud_panel.show()
+		chat_panel.hide()
+	elif not _session_hide_main_hud:
+		if is_instance_valid(preview_hud_panel):
+			preview_hud_panel.hide()
+		chat_panel.show()
+
+
+## Hide the whole bottom-left slot (chat and the preview toolbar, header included) while the
+## navbar is open with a side panel showing; the navbar-collapse path restores it.
+func _hide_bottom_left_hud() -> void:
+	chat_panel.hide()
+	if is_instance_valid(preview_hud_panel):
+		preview_hud_panel.hide()
 
 
 ## The single scene being previewed (one scene may span multiple parcels):
@@ -1179,8 +1190,7 @@ func _is_in_preview_realm() -> bool:
 
 
 func _update_preview_ui(_in_preview: bool) -> void:
-	_update_debug_ui()
-	_update_scene_stats_ui()
+	_update_preview_hud()
 
 
 func _on_notify_pending_loading_scenes(pending: bool) -> void:
@@ -1233,7 +1243,7 @@ func _open_friends_panel() -> void:
 	Global.open_friends_panel.emit()
 	emote_wheel.hide()
 	_hide_movement_controls()
-	chat_panel.hide()
+	_hide_bottom_left_hud()
 
 
 func _async_open_profile_by_address(user_address: String):
@@ -1506,13 +1516,14 @@ func _on_chat_write_mode_changed(is_writing: bool) -> void:
 	# (owned by _on_chat_focus_entered/_exited). Write mode additionally hides the navbar
 	# bar (focus only collapses its dropdown) and the extra HUD elements the keyboard
 	# needs gone; exiting write restores them while the chat stays focused.
+	# The preview HUD toolbar and the chat share the bottom-left slot and never
+	# coexist (the toolbar hides the chat), so chat write mode can't overlap it —
+	# no toolbar handling is needed here.
 	if is_writing:
 		navbar.hide()
-		debug_panel.hide()
 		_set_scene_ui_visible(false)
 	else:
 		navbar._on_size_changed()
-		debug_panel.visible = _debug_should_show()
 		_set_scene_ui_visible(_should_show_scene_ui())
 
 
@@ -1575,8 +1586,8 @@ func _on_notification_clicked(notification_d: Dictionary) -> void:
 			if Global.is_mobile():
 				release_mouse()
 			joypad.hide()
-			# Keep chat hidden while the navbar friends panel is open (redesigned HUD).
-			chat_panel.hide()
+			# Keep the bottom-left slot hidden while the navbar friends panel is open.
+			_hide_bottom_left_hud()
 
 
 func _notification(what: int) -> void:
@@ -1665,11 +1676,11 @@ func _close_all_panels():
 	_on_notifications_panel_closed()
 	_on_settings_panel_closed()
 	_refresh_hud_dismiss()
-	# Restore the chat and emote HUD hidden while the navbar was open, unless the main HUD
-	# is hidden. Keep the emote HUD and joystick hidden in portrait, where the orientation
-	# flow owns them.
+	# Restore the bottom-left slot (chat, or the preview HUD toolbar in preview) and the
+	# emote HUD hidden while the navbar was open, unless the main HUD is hidden. Keep the
+	# emote HUD and joystick hidden in portrait, where the orientation flow owns them.
 	if not _session_hide_main_hud:
-		chat_panel.show()
+		_restore_bottom_left_hud()
 		if not Global.is_orientation_portrait():
 			emote_wheel.show()
 			virtual_joystick.show()

--- a/godot/src/ui/explorer.tscn
+++ b/godot/src/ui/explorer.tscn
@@ -15,7 +15,6 @@
 [ext_resource type="PackedScene" uid="uid://cw8x2h5p3y6kn" path="res://src/ui/components/organisms/notifications/notifications_panel.tscn" id="14_notif_panel"]
 [ext_resource type="FontFile" uid="uid://drw8yv4w843s4" path="res://assets/themes/fonts/inter/Inter-SemiBold.ttf" id="16_karsc"]
 [ext_resource type="PackedScene" uid="uid://bmjwqm6jgri7c" path="res://src/ui/pages/loading_screen/loading_screen.tscn" id="17_0blod"]
-[ext_resource type="PackedScene" uid="uid://dua04n3geh0yf" path="res://src/ui/components/organisms/debug_panel/debug_panel.tscn" id="18_ky6fv"]
 [ext_resource type="Script" uid="uid://dqpk827xdxpcy" path="res://src/ui/components/organisms/voice_chat_recorder/voice_chat_recorder.gd" id="20_064cw"]
 [ext_resource type="PackedScene" uid="uid://e18p6cp0duuu" path="res://src/ui/components/organisms/recording_notification/recording_notification.tscn" id="20_uf6rv"]
 [ext_resource type="PackedScene" uid="uid://btl8ag3s7oanm" path="res://src/ui/components/organisms/navbar/navbar.tscn" id="21_admxk"]
@@ -31,6 +30,7 @@
 [ext_resource type="PackedScene" uid="uid://bycjwh7mskrsd" path="res://src/helpers_components/chat_handler.tscn" id="32_cq187"]
 [ext_resource type="PackedScene" uid="uid://cfuskyu58uo2v" path="res://src/ui/pages/settings/settings.tscn" id="33_settings"]
 [ext_resource type="Resource" uid="uid://ntu4pnce7xxr" path="res://src/ui/layouts/hud_margins.tres" id="34_hudmg"]
+[ext_resource type="PackedScene" uid="uid://v3ktu5kra0ql" path="res://src/ui/components/organisms/preview_hud_panel/preview_hud_panel.tscn" id="35_prevhud"]
 
 [sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_c5h7v"]
 
@@ -187,28 +187,6 @@ grow_horizontal = 2
 grow_vertical = 2
 mouse_filter = 2
 
-[node name="SafeMarginContainerDebug" type="MarginContainer" parent="UI" unique_id=868273897]
-unique_name_in_owner = true
-layout_mode = 1
-anchors_preset = 15
-anchor_right = 1.0
-anchor_bottom = 1.0
-grow_horizontal = 2
-grow_vertical = 2
-mouse_filter = 2
-script = ExtResource("5_c8ksg")
-margin_profile = ExtResource("34_hudmg")
-symmetric_horizontal = true
-metadata/_edit_lock_ = true
-
-[node name="HBoxContainer_DebugTools" type="HBoxContainer" parent="UI/SafeMarginContainerDebug" unique_id=169913972]
-unique_name_in_owner = true
-layout_mode = 2
-size_flags_horizontal = 8
-size_flags_vertical = 0
-mouse_filter = 2
-theme_override_constants/separation = 12
-
 [node name="HBoxContainer_VersionFPS" type="HBoxContainer" parent="UI" unique_id=193054843]
 layout_mode = 1
 anchors_preset = 7
@@ -277,6 +255,10 @@ mouse_filter = 2
 unique_name_in_owner = true
 layout_mode = 1
 
+[node name="PreviewHudPanel" parent="UI/SafeAreaHud/InteractableHUD" unique_id=1534114070 instance=ExtResource("35_prevhud")]
+unique_name_in_owner = true
+layout_mode = 1
+
 [node name="HBoxContainerLeftPanels" type="HBoxContainer" parent="UI/SafeAreaHud/InteractableHUD" unique_id=2005524203]
 unique_name_in_owner = true
 layout_mode = 1
@@ -341,10 +323,6 @@ anchor_right = 0.0
 anchor_bottom = 0.0
 grow_horizontal = 1
 grow_vertical = 1
-
-[node name="DebugPanel" parent="UI/SafeAreaHud/InteractableHUD" unique_id=1737764806 instance=ExtResource("18_ky6fv")]
-unique_name_in_owner = true
-layout_mode = 1
 
 [node name="Button_ShowUI" type="Button" parent="UI/SafeAreaHud" unique_id=1612256067]
 unique_name_in_owner = true

--- a/lib/src/hud_input_lint.rs
+++ b/lib/src/hud_input_lint.rs
@@ -88,6 +88,30 @@ fn debug_panel_body_does_not_block_scene_ui() {
     assert_click_through(find(&nodes, "VBoxContainer", "."), "debug_panel");
 }
 
+/// The preview HUD toolbar (issue #2679) sits in the bottom-left slot but its layout
+/// containers span the full HUD width while only the three header buttons (and the
+/// console/scene-stats bodies) are interactive. Every container must be IGNORE so the empty
+/// full-width strips don't eat taps meant for the scene UI underneath (same class as #2578).
+#[test]
+fn preview_hud_panel_containers_do_not_block_scene_ui() {
+    let nodes =
+        parse_tscn("../godot/src/ui/components/organisms/preview_hud_panel/preview_hud_panel.tscn");
+    assert_click_through(find(&nodes, "VBoxContainer", "."), "preview_hud_panel");
+    assert_click_through(
+        find(&nodes, "MarginContainer", "VBoxContainer"),
+        "preview_hud_panel",
+    );
+    assert_click_through(
+        find(
+            &nodes,
+            "HBoxContainer_Header",
+            "VBoxContainer/MarginContainer",
+        ),
+        "preview_hud_panel",
+    );
+    assert_click_through(find(&nodes, "Body", "VBoxContainer"), "preview_hud_panel");
+}
+
 /// The navbar's top-right corner Control hosts an 80x80 profile bubble but
 /// measures 120x136; both it and its full-rect toggle Button stole roughly
 /// 2.5x the drawn area from the scene UI underneath.

--- a/lib/src/hud_input_lint.rs
+++ b/lib/src/hud_input_lint.rs
@@ -78,25 +78,14 @@ fn assert_click_through(node: &TscnNode, scene: &str) {
     );
 }
 
-/// The debug panel body is a right-aligned VBox whose `Control_Panel` child
-/// reserves 500x280 even while the console is collapsed (`Button_ShowHide`
-/// only toggles the inner `TabContainer`). The VBox and the top-buttons row
-/// must be IGNORE so only the actual buttons/console claim input.
+/// The debug panel Control reserves ~500x300 even while the console is collapsed. Its body
+/// VBox must be IGNORE so the reserved-but-empty area doesn't eat input meant for what's
+/// behind it — only the actual console tab and its buttons claim input. (The console/reload
+/// header moved to the preview HUD toolbar in issue #2679, so there's no top-buttons row here.)
 #[test]
 fn debug_panel_body_does_not_block_scene_ui() {
     let nodes = parse_tscn("../godot/src/ui/components/organisms/debug_panel/debug_panel.tscn");
-    assert_click_through(
-        find(&nodes, "VBoxContainer", "MarginContainer"),
-        "debug_panel",
-    );
-    assert_click_through(
-        find(
-            &nodes,
-            "HBoxContainer_TopButtons",
-            "MarginContainer/VBoxContainer/MarginContainer_Header",
-        ),
-        "debug_panel",
-    );
+    assert_click_through(find(&nodes, "VBoxContainer", "."), "debug_panel");
 }
 
 /// The navbar's top-right corner Control hosts an 80x80 profile bubble but
@@ -119,36 +108,6 @@ fn navbar_profile_hitbox_matches_visible_bubble() {
         Some("15"),
         "navbar: the profile toggle Button must not be full-rect over the \
          corner Control (issue #2578).",
-    );
-}
-
-/// Later siblings draw and hit-test on top. The debug tools row (console +
-/// scene stats) must beat scene UI for input, but render *below* the
-/// Friends/Notifications/Settings panels and the navbar — so it has to sit
-/// after `SceneUIContainer` and before `SafeAreaHud`.
-#[test]
-fn debug_tools_sit_between_scene_ui_and_right_panels() {
-    let nodes = parse_tscn("../godot/src/ui/explorer.tscn");
-    let ui_children: Vec<&str> = nodes
-        .iter()
-        .filter(|n| n.parent.as_deref() == Some("UI"))
-        .map(|n| n.name.as_str())
-        .collect();
-    let idx = |name: &str| {
-        ui_children
-            .iter()
-            .position(|n| *n == name)
-            .unwrap_or_else(|| panic!("{name} not found under UI — was it renamed?"))
-    };
-    let scene_ui = idx("SceneUIContainer");
-    let debug_tools = idx("SafeMarginContainerDebug");
-    let hud_panels = idx("SafeAreaHud");
-    assert!(
-        scene_ui < debug_tools && debug_tools < hud_panels,
-        "explorer: SafeMarginContainerDebug (debug console + scene stats) must come \
-         after SceneUIContainer but before SafeAreaHud, so the debug \
-         tools receive input over scene UI yet render below the Friends/\
-         Notifications/Settings panels (issue #2578).",
     );
 }
 

--- a/lib/src/realm/scene_entity_coordinator.rs
+++ b/lib/src/realm/scene_entity_coordinator.rs
@@ -66,6 +66,9 @@ struct SceneEntityCoordinator {
 
     // Floating islands mode: fixed scene loading
     fixed_desired_entities: HashSet<String>,
+    // Entity hash -> its EntityBase for every fixed/global scene, so it can be re-fetched on
+    // reload (fixed and global scenes are not re-discovered by position, unlike city-mode).
+    reloadable_entity_bases: HashMap<String, EntityBase>,
     global_desired_entities: Vec<EntityBase>,
 
     // Scene data storage (shared by both modes)
@@ -113,6 +116,7 @@ impl SceneEntityCoordinator {
 
             global_desired_entities: Default::default(),
             fixed_desired_entities: Default::default(),
+            reloadable_entity_bases: Default::default(),
             requested_entity: Default::default(),
             cache_scene_data: Default::default(),
             entities_active_url: Default::default(),
@@ -162,6 +166,7 @@ impl SceneEntityCoordinator {
         self.should_load_city_scenes = should_load_city_scenes;
         self.global_desired_entities.clear();
         self.fixed_desired_entities.clear();
+        self.reloadable_entity_bases.clear();
         self.cache_city_pointers.clear();
         self.cache_scene_data.clear();
         self.requested_city_pointers.clear();
@@ -500,6 +505,8 @@ impl SceneEntityCoordinator {
 
         self.dirty_loadable_scenes = true;
         self.fixed_desired_entities.clear();
+        // reloadable_entity_bases is only cleared on realm change (_config): clearing it here
+        // would wipe the global-scene entries set by _set_fixed_desired_entities_global_urns.
 
         for urn_str in entities.iter() {
             let Some(entity_base) = EntityBase::from_urn(urn_str, &self.content_url) else {
@@ -508,24 +515,32 @@ impl SceneEntityCoordinator {
             };
 
             self.fixed_desired_entities.insert(entity_base.hash.clone());
+            // Remember how to re-fetch this scene (used by reload_scene_data).
+            self.reloadable_entity_bases
+                .insert(entity_base.hash.clone(), entity_base.clone());
             if self.cache_scene_data.contains_key(&entity_base.hash) {
                 continue;
             }
 
-            let url = format!("{}{}", entity_base.base_url, entity_base.hash);
-            let request = RequestOption::new(
-                Self::REQUEST_TYPE_SCENE_DATA,
-                url,
-                http::Method::GET,
-                ResponseType::AsJson,
-                None,
-                None,
-                None,
-            );
-
-            self.requested_entity.insert(request.id, entity_base);
-            self.do_request(request);
+            self.request_scene_data(entity_base);
         }
+    }
+
+    /// Fire a scene-data (entity definition) request and track it for the response handler.
+    fn request_scene_data(&mut self, entity_base: EntityBase) {
+        let url = format!("{}{}", entity_base.base_url, entity_base.hash);
+        let request = RequestOption::new(
+            Self::REQUEST_TYPE_SCENE_DATA,
+            url,
+            http::Method::GET,
+            ResponseType::AsJson,
+            None,
+            None,
+            None,
+        );
+
+        self.requested_entity.insert(request.id, entity_base);
+        self.do_request(request);
     }
 
     pub fn _set_fixed_desired_entities_global_urns(&mut self, entities: Vec<String>) {
@@ -540,6 +555,9 @@ impl SceneEntityCoordinator {
             let Some(entity_base) = EntityBase::from_urn(urn_str, &self.content_url) else {
                 continue;
             };
+            // Remember how to re-fetch this scene (used by reload_scene_data).
+            self.reloadable_entity_bases
+                .insert(entity_base.hash.clone(), entity_base.clone());
             if self.cache_scene_data.contains_key(urn_str) {
                 self.global_desired_entities.push(entity_base);
                 continue;
@@ -771,7 +789,16 @@ impl SceneEntityCoordinator {
         }
 
         self.cache_scene_data.remove(&scene_id);
-        self.update_position(self.current_position.0, self.current_position.1);
+
+        // Fixed scenes (Worlds / floating islands) are not re-discovered by position, so
+        // re-issue their entity fetch directly. City-mode scenes fall back to position
+        // re-discovery, which re-requests the pointers for the current parcel.
+        if let Some(entity_base) = self.reloadable_entity_bases.get(&scene_id).cloned() {
+            self.dirty_loadable_scenes = true;
+            self.request_scene_data(entity_base);
+        } else {
+            self.update_position(self.current_position.0, self.current_position.1);
+        }
     }
 
     #[func]

--- a/lib/src/realm/scene_entity_coordinator.rs
+++ b/lib/src/realm/scene_entity_coordinator.rs
@@ -524,6 +524,20 @@ impl SceneEntityCoordinator {
 
             self.request_scene_data(entity_base);
         }
+        self.prune_reloadable_entity_bases();
+    }
+
+    /// Drop reloadable bases for scenes no longer desired (fixed or global), so the map doesn't
+    /// grow across scene-set updates within a realm. Runs only on a desired-set change.
+    fn prune_reloadable_entity_bases(&mut self) {
+        let desired: HashSet<String> = self
+            .fixed_desired_entities
+            .iter()
+            .cloned()
+            .chain(self.global_desired_entities.iter().map(|e| e.hash.clone()))
+            .collect();
+        self.reloadable_entity_bases
+            .retain(|hash, _| desired.contains(hash));
     }
 
     /// Fire a scene-data (entity definition) request and track it for the response handler.
@@ -578,6 +592,7 @@ impl SceneEntityCoordinator {
             self.requested_entity.insert(request.id, entity_base);
             self.do_request(request);
         }
+        self.prune_reloadable_entity_bases();
     }
 
     /// Updates the player's current position and requests scenes if needed.


### PR DESCRIPTION
Closes #2679 

## Summary

Implements the **Preview Mode HUD layout** (#2679). A new `preview_hud_panel` organism hosts the **Console**, **Scene Status** and **Reload** controls in a single top-left toolbar that replaces the chat while active — in the settings **Dev Tools → Scene Logs** entry, in a **preview realm**, or via a `scene-stats=true` **deep link**.

- **New `preview_hud_panel` organism** (static, hidden `InteractableHUD` child): a 3-button header (Console / Scene Status / Reload) over a body that shows the console or the scene-stats overlay — mutually exclusive, same position (opening one closes the other).
- **Behaves like the chat vs. the navbar**: the whole toolbar (header included) is hidden while a navbar side panel is open, and restored header-only (toggles off) when the navbar collapses. It shares the bottom-left slot with the chat and never coexists with it.
- **Reuse, not rewrite**: `debug_panel` (console) and `scene_stats_panel` keep their own logic; their old headers / floating toggles were removed. The static `DebugPanel` moved out of `explorer.tscn` into the new organism. The console is always present so it keeps capturing scene logs; the scene-stats overlay is created on demand.
- **Availability**: Console + Reload show whenever the toolbar is active; the **Scene Status** button + panel appear only in preview / deep-link (settings Scene Logs exposes Console + Reload only).
- **Button states**: Console/Scene Status show a border + icon in `#FF2D55` (red) when open and `#FCFCFC` (white) when closed; Reload is borderless with a white icon that turns `#DF9CFF` (lilac) while held.
- Zero-cost in a normal production run: no preview, no settings toggle, no deep link → toolbar stays hidden and the chat behaves normally.

## Out of scope but required to make the toolbar usable

The relocated Reload button (and the console) were effectively unusable without two changes outside the pure-HUD scope of #2679, so they ride along in this PR:

- **Reload in Worlds** — `lib/src/realm/scene_entity_coordinator.rs`: `reload_scene_data` relied on `update_position`, which never re-fetches fixed/global scenes (Worlds are not re-discovered by parcel position, unlike Genesis City). Reloading a World scene therefore erased it and left an empty parcel. Added a `reloadable_entity_bases` map so a fixed/global scene re-issues its entity fetch on reload; city-mode keeps the position re-discovery path.
- **Loading screen on reload** — `godot/src/logic/scene_fetcher.gd`: show the loading screen up front on reload so killing the scene doesn't flash an empty parcel before it re-loads (skipped for preview hot-reload, which stays seamless).

**Design note (for reviewers):** a `scene-stats=true` deep link now shows the toolbar and hides the chat in *any* realm (production included), because the toolbar is the shared container for the Scene Status button. Flagging in case we'd rather have that deep link expose *only* the Scene Status button without disturbing the chat.

## Test plan

Verified on desktop against the deployed World `sebadl.dcl.eth` in preview (`--fake-deeplink "decentraland:///?realm=sebadl.dcl.eth" --preview`). Formal QA / on-device (iOS/Android) pass still pending.

- [ ] **Settings → Dev Tools → Scene Logs** (non-preview realm): toggling ON hides the chat and shows the toolbar with **Console + Reload only** (no Scene Status); Console toggles the console panel; toggling OFF restores the chat.
- [ ] **Preview realm / `--preview`**: toolbar shows **Console + Scene Status + Reload**; Console and Scene Status are mutually exclusive in the same spot.
- [ ] **`scene-stats=true` deep link**: the Scene Status button + panel are available.
- [ ] **Navbar interaction**: opening a navbar side panel (friends/notifications/settings) hides the entire toolbar; collapsing the navbar restores it header-only with all toggles off.
- [ ] **Reload**: reloads the current/previewed scene in **Genesis City** and **Worlds** (the World scene comes back rather than an empty parcel); the loading screen appears immediately (no empty-parcel flash); the console shows the reloaded scene's `console.log` output.
- [ ] **Colors**: Console/Scene Status border + icon are white when closed and red when open; Reload is borderless with a white icon that turns lilac while held.
- [ ] **Zero-cost / no regression**: a normal run (no preview, no settings toggle, no deep link) does not show the toolbar and the chat, hide-UI, and navbar flows behave as before.
- [ ] `cargo run -- check-gdscript`, `gdformat`/`gdlint godot/`, and `cd lib && cargo fmt --all && cargo clippy -- -D warnings` all pass; `hud_input_lint` tests pass.
