### PR TITLE
fix(xtask): retry flaky dependency downloads in CI

### DIFF
--- a/src/download_file.rs
+++ b/src/download_file.rs
@@ -1,8 +1,18 @@
-use crate::ui::create_download_progress;
+use crate::ui::{create_download_progress, print_message, MessageType};
 use reqwest::Url;
 use std::fs::File;
 use std::io::Write;
 use std::path::PathBuf;
+use std::time::Duration;
+
+/// Attempts (first try + retries) for any single HTTP operation.
+pub const MAX_HTTP_ATTEMPTS: u32 = 5;
+/// Backoff before each retry: 2s, 4s, 8s, 16s.
+const RETRY_BASE_DELAY: Duration = Duration::from_secs(2);
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(60);
+/// Total timeout for the small blocking requests (npm manifest, protocol tarball).
+/// Large file downloads go through `download_file`, which has no total timeout.
+const BLOCKING_REQUEST_TIMEOUT: Duration = Duration::from_secs(300);
 
 enum DownloadEvent {
     TotalSize(u64),
@@ -10,12 +20,110 @@ enum DownloadEvent {
     Result(Result<(), anyhow::Error>),
 }
 
+/// Error marker for failures that won't fix themselves on a retry (a 404 for a
+/// mistyped/unpublished artifact URL, for instance), so `retry_http` gives up
+/// right away instead of burning the whole backoff schedule.
+#[derive(Debug)]
+struct PermanentError(String);
+
+impl std::fmt::Display for PermanentError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl std::error::Error for PermanentError {}
+
+/// Runs `op`, retrying transient failures with exponential backoff.
+///
+/// Release CDNs (GitHub, npm, our own R2 buckets) intermittently drop
+/// connections mid-handshake — `http2 error: stream error received: refused
+/// stream ...` being the usual one in CI — which used to fail the whole
+/// `install` command on the first hiccup.
+pub fn retry_http<T>(
+    what: &str,
+    mut op: impl FnMut() -> Result<T, anyhow::Error>,
+) -> Result<T, anyhow::Error> {
+    let mut attempt = 1;
+    loop {
+        let err = match op() {
+            Ok(value) => return Ok(value),
+            Err(err) => err,
+        };
+
+        let permanent = err.downcast_ref::<PermanentError>().is_some();
+        if permanent || attempt >= MAX_HTTP_ATTEMPTS {
+            return Err(err.context(format!("{what} failed after {attempt} attempt(s)")));
+        }
+
+        let delay = RETRY_BASE_DELAY * 2u32.pow(attempt - 1);
+        print_message(
+            MessageType::Warning,
+            &format!(
+                "{what} failed (attempt {attempt}/{MAX_HTTP_ATTEMPTS}): {err}. Retrying in {}s...",
+                delay.as_secs()
+            ),
+        );
+        std::thread::sleep(delay);
+        attempt += 1;
+    }
+}
+
+/// Fails on non-success HTTP statuses, flagging client errors (other than the
+/// retryable 408/429) as permanent.
+fn check_status(status: reqwest::StatusCode, url: &str) -> Result<(), anyhow::Error> {
+    if status.is_success() {
+        return Ok(());
+    }
+
+    let retryable = !status.is_client_error()
+        || status == reqwest::StatusCode::REQUEST_TIMEOUT
+        || status == reqwest::StatusCode::TOO_MANY_REQUESTS;
+
+    let message = format!("unexpected HTTP status {status} for {url}");
+    if retryable {
+        Err(anyhow::anyhow!(message))
+    } else {
+        Err(anyhow::Error::new(PermanentError(message)))
+    }
+}
+
+/// Forces HTTP/1.1: the release CDNs answer HTTP/2 requests with sporadic
+/// `refused stream` errors, and multiplexing buys nothing for single large
+/// downloads anyway.
+fn async_client() -> Result<reqwest::Client, anyhow::Error> {
+    Ok(reqwest::Client::builder()
+        .http1_only()
+        .connect_timeout(CONNECT_TIMEOUT)
+        .build()?)
+}
+
+fn blocking_client() -> Result<reqwest::blocking::Client, anyhow::Error> {
+    Ok(reqwest::blocking::Client::builder()
+        .http1_only()
+        .connect_timeout(CONNECT_TIMEOUT)
+        .timeout(BLOCKING_REQUEST_TIMEOUT)
+        .build()?)
+}
+
+/// Blocking GET of a whole body into memory, with retries. `what` is used in
+/// the retry/failure messages.
+pub fn http_get_bytes(url: &str, what: &str) -> Result<Vec<u8>, anyhow::Error> {
+    let client = blocking_client()?;
+    retry_http(what, || {
+        let response = client.get(url).send()?;
+        check_status(response.status(), url)?;
+        Ok(response.bytes()?.to_vec())
+    })
+}
+
 async fn download_file_thread(
+    client: reqwest::Client,
     url: Url,
     path: PathBuf,
     sender: std::sync::mpsc::Sender<DownloadEvent>,
 ) {
-    let client = reqwest::Client::new();
+    let url_str = url.to_string();
     let mut response = match client.get(url).send().await {
         Ok(response) => response,
         Err(err) => {
@@ -23,6 +131,11 @@ async fn download_file_thread(
             return;
         }
     };
+
+    if let Err(err) = check_status(response.status(), &url_str) {
+        let _ = sender.send(DownloadEvent::Result(Err(err)));
+        return;
+    }
 
     // Send total size if available
     if let Some(len) = response.content_length() {
@@ -39,7 +152,18 @@ async fn download_file_thread(
         }
     };
 
-    while let Some(chunk) = response.chunk().await.unwrap() {
+    loop {
+        // A connection dropped mid-body is reported here: surface it as an
+        // error so the caller can retry (it used to panic on `unwrap`).
+        let chunk = match response.chunk().await {
+            Ok(Some(chunk)) => chunk,
+            Ok(None) => break,
+            Err(err) => {
+                let _ = sender.send(DownloadEvent::Result(Err(err.into())));
+                return;
+            }
+        };
+
         if let Err(err) = file.write_all(&chunk) {
             let _ = sender.send(DownloadEvent::Result(Err(err.into())));
             return;
@@ -50,13 +174,23 @@ async fn download_file_thread(
         let _ = sender.send(DownloadEvent::Progress(downloaded));
     }
 
+    if let Err(err) = file.flush() {
+        let _ = sender.send(DownloadEvent::Result(Err(err.into())));
+        return;
+    }
+
     let _ = sender.send(DownloadEvent::Result(Ok(())));
 }
 
-pub fn _download_file(url: &str, path: &str) -> Result<(), anyhow::Error> {
+fn download_file_attempt(
+    client: &reqwest::Client,
+    url: &str,
+    path: &str,
+) -> Result<(), anyhow::Error> {
     let (sender, receiver) = std::sync::mpsc::channel::<DownloadEvent>();
     // Append a cache-busting query param so any intermediate CDN/proxy
     // (and the upstream object store) always serves the latest object.
+    // Recomputed per attempt so a retry never gets a cached bad response.
     let ts = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .map(|d| d.as_millis())
@@ -68,9 +202,10 @@ pub fn _download_file(url: &str, path: &str) -> Result<(), anyhow::Error> {
     };
     let url = Url::parse(&busted_url)?;
     let path = PathBuf::from(path);
+    let client = client.clone();
 
     tokio::spawn(async move {
-        download_file_thread(url, path, sender).await;
+        download_file_thread(client, url, path, sender).await;
     });
 
     let mut progress_bar = None;
@@ -109,9 +244,18 @@ pub fn _download_file(url: &str, path: &str) -> Result<(), anyhow::Error> {
 }
 
 pub fn download_file(url: &str, path: &str) -> Result<(), anyhow::Error> {
-    tokio::runtime::Builder::new_multi_thread()
+    let runtime = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
-        .build()
-        .unwrap()
-        .block_on(async { _download_file(url, path) })
+        .build()?;
+    let client = runtime.block_on(async { async_client() })?;
+
+    retry_http(&format!("Download of {url}"), || {
+        let result = runtime.block_on(async { download_file_attempt(&client, url, path) });
+        if result.is_err() {
+            // Don't leave a truncated file behind: callers (android_deps.zip,
+            // the download cache) treat an existing file as a finished download.
+            let _ = std::fs::remove_file(path);
+        }
+        result
+    })
 }

--- a/src/install_dependency.rs
+++ b/src/install_dependency.rs
@@ -1,6 +1,5 @@
 use directories::ProjectDirs;
 use flate2::read::GzDecoder;
-use reqwest::blocking::Client;
 use std::env;
 use std::fs::{self, File};
 use std::io::{self};
@@ -9,7 +8,7 @@ use tar::Archive;
 use zip::ZipArchive;
 
 use crate::consts::*;
-use crate::download_file::download_file;
+use crate::download_file::{download_file, http_get_bytes};
 use crate::export::prepare_templates;
 use crate::helpers::BinPaths;
 use crate::platform::{
@@ -57,7 +56,10 @@ fn get_protocol_url() -> Result<String, anyhow::Error> {
     }
 
     let manifest_url = format!("https://registry.npmjs.org/@dcl/protocol/{PROTOCOL_NPM_DIST_TAG}");
-    let manifest: serde_json::Value = Client::new().get(&manifest_url).send()?.json()?;
+    let manifest: serde_json::Value = serde_json::from_slice(&http_get_bytes(
+        &manifest_url,
+        "Fetch of the @dcl/protocol npm manifest",
+    )?)?;
     manifest
         .get("dist")
         .and_then(|d| d.get("tarball"))
@@ -78,9 +80,7 @@ pub fn install_dcl_protocol() -> Result<(), anyhow::Error> {
 
     let spinner = create_spinner("Downloading protocol files...");
 
-    let client = Client::new();
-    let response = client.get(protocol_url).send()?;
-    let tarball = response.bytes()?;
+    let tarball = http_get_bytes(&protocol_url, "Download of the @dcl/protocol tarball")?;
 
     let decoder = GzDecoder::new(&tarball[..]);
     let mut archive = Archive::new(decoder);

--- a/src/run.rs
+++ b/src/run.rs
@@ -275,21 +275,13 @@ fn setup_v8_bindings(
     }
 
     // Download the binding file if it does not already exist.
+    // Uses `download_file` (instead of plain `curl`) so it retries transient
+    // GitHub failures and never leaves a partial/error-page file behind.
     if !binding_file_path.exists() {
-        let status = std::process::Command::new("curl")
-            .args([
-                "-L",
-                "-o",
-                binding_file_path.to_str().unwrap(),
-                &v8_binding_url,
-            ])
-            .status()?;
-        if !status.success() {
-            return Err(anyhow::anyhow!(
-                "Failed to download V8 binding file from {}",
-                v8_binding_url
-            ));
-        }
+        let destination = binding_file_path.to_str().unwrap();
+        crate::download_file::download_file(&v8_binding_url, destination).map_err(|err| {
+            anyhow::anyhow!("Failed to download V8 binding file from {v8_binding_url}: {err}")
+        })?;
     }
     Ok(())
 }


### PR DESCRIPTION
CI builds keep dying on the very first network hiccup while installing dependencies — `error sending request ... http2 error: stream error received: refused stream before processing any application logic` while downloading protoc, which hit the 1.12.1 RC several times ([latest example](https://github.com/decentraland/godot-explorer/actions/runs/31644197256/job/94273983150)). `cargo run -- install` had zero retries: one refused HTTP/2 stream from GitHub's CDN and the whole job failed. This makes every download in xtask retry up to 5 times with exponential backoff (2s → 4s → 8s → 16s) and forces HTTP/1.1, which is what the CDNs actually flake on (multiplexing buys nothing for single large file downloads anyway). It also fixes three related sharp edges found along the way: a dropped connection mid-body used to `panic!` instead of erroring, non-2xx responses were never checked (a 404 happily wrote an HTML error page into `tmp-file.zip` / the V8 binding file), and a failed download left a truncated file behind that the next run would treat as a finished download (`android_deps.zip`, the persistent download cache).

Closes #2695

## Changes

- `src/download_file.rs` → retry helper with exponential backoff + HTTP/1.1-only clients; HTTP status check (retries 5xx/408/429, fails fast on other 4xx so a genuinely wrong URL still errors in <1s); no more `unwrap()` on the body stream; partial file removed on failure. Adds `http_get_bytes()` for blocking one-shot GETs.
- `src/install_dependency.rs` → the `@dcl/protocol` npm manifest + tarball requests go through the retrying client.
- `src/run.rs` → the V8 binding download (Android/iOS builds, also from GitHub releases) uses `download_file` instead of a bare `curl -L`, so it retries and no longer silently saves an error page as the binding.

## Test plan

No QA needed — no runtime behavior change, this is build tooling only.

Verified locally with a throwaway test module against the real endpoints (removed before commit):

- [ ] Real GitHub release asset (the exact protoc URL from the failing job) downloads over forced HTTP/1.1 — 2,916,347 bytes in 0.65s.
- [ ] 404 on a nonexistent release asset fails in 0.31s with `unexpected HTTP status 404 Not Found ...` and leaves no partial file (no pointless 30s of backoff).
- [ ] Unreachable host retries 5× with the 2/4/8/16s backoff, printing a `⚠️ ... Retrying in Ns...` line per attempt, then fails with `... failed after 5 attempt(s)`.
- [ ] `http_get_bytes` against the npm registry returns the `@dcl/protocol@next` manifest.
- [ ] CI on this PR: all `cargo run -- install` steps (linux/macos/windows/android/ios/clippy/coverage) pass.
