### PR TITLE
fix(build): clear stale patched protos before compiling

### DIFF
--- a/lib/build.rs
+++ b/lib/build.rs
@@ -391,6 +391,8 @@ fn main() -> io::Result<()> {
         }
     }
 
+    clear_patched_proto_root();
+
     proto_files.push(
         format!("{PROTO_FILES_BASE_DIR}decentraland/kernel/comms/rfc5/ws_comms.proto").into(),
     );
@@ -452,7 +454,7 @@ fn main() -> io::Result<()> {
     prost_config.file_descriptor_set_path(&descriptor_path);
     // The patched root goes first so `decentraland/kernel/comms/rfc4/comms.proto`
     // resolves to the patched copy, not the npm one (same canonical path).
-    let proto_patched_root = Path::new(&env::var("OUT_DIR").unwrap()).join("proto_patched");
+    let proto_patched_root = patched_proto_root();
     prost_config.compile_protos(
         &proto_files,
         &[
@@ -493,6 +495,34 @@ fn main() -> io::Result<()> {
 /// patch a copy under OUT_DIR/proto_patched/ and compile that one (that root is
 /// listed first so the canonical path resolves to the patched copy). Each patch
 /// no-ops once the pinned build ships its fields — delete this when both do.
+/// Root of the build-time patched protos, listed first on protoc's include path
+/// (see `patched_rfc4_comms_proto`).
+fn patched_proto_root() -> std::path::PathBuf {
+    Path::new(&env::var("OUT_DIR").unwrap()).join("proto_patched")
+}
+
+/// Wipes the patched-proto root before this build repopulates it.
+///
+/// `OUT_DIR` survives across builds and — on the self-hosted CI runners, which
+/// reuse a single checkout and `target/` for every branch — is shared between
+/// branches. A patched copy written by *another* branch would otherwise linger
+/// here and, because this root comes first on the include path, shadow the npm
+/// file that this branch passes to protoc as an input:
+///
+/// ```text
+/// protoc failed: src/dcl/components/proto/decentraland/sdk/components/avatar_emote_command.proto:
+/// Input is shadowed in the --proto_path by ".../out/proto_patched/decentraland/sdk/components/avatar_emote_command.proto".
+/// ```
+///
+/// Every build re-derives the patches it needs from the npm tree, so starting
+/// from an empty root costs nothing and keeps the set exact.
+fn clear_patched_proto_root() {
+    let root = patched_proto_root();
+    if root.exists() {
+        fs::remove_dir_all(&root).expect("clear proto_patched dir");
+    }
+}
+
 fn patched_rfc4_comms_proto() -> std::path::PathBuf {
     const RFC4_REL: &str = "decentraland/kernel/comms/rfc4/comms.proto";
     let mut source = fs::read_to_string(format!("{PROTO_FILES_BASE_DIR}{RFC4_REL}"))
@@ -522,9 +552,7 @@ fn patched_rfc4_comms_proto() -> std::path::PathBuf {
         );
     }
 
-    let dest = Path::new(&env::var("OUT_DIR").unwrap())
-        .join("proto_patched")
-        .join(RFC4_REL);
+    let dest = patched_proto_root().join(RFC4_REL);
     fs::create_dir_all(dest.parent().unwrap()).expect("create proto_patched dir");
     fs::write(&dest, source).expect("write patched rfc4 comms.proto");
     dest


### PR DESCRIPTION
iOS CI has been failing on unrelated branches with `protoc failed: ... Input is shadowed in the --proto_path by ".../out/proto_patched/decentraland/sdk/components/avatar_emote_command.proto"`. The cause is leftover state, not the branch under test: `lib/build.rs` writes patched protos into `OUT_DIR/proto_patched`, that directory survives across builds, and the self-hosted runners reuse a single checkout and `target/` for every branch. #2690 adds a second patched file (`avatar_emote_command.proto`); once it built on the runner, that copy stayed behind, and since the patched root comes first on protoc's include path it shadows the npm file every *other* branch passes as an input — so every later build on that runner fails until something wipes `target/`. This wipes the patched root before repopulating it: each build re-derives the patches it needs from the npm tree, so starting from an empty root costs nothing and keeps the set exactly what this branch asked for.

## Changes

- `lib/build.rs` → `clear_patched_proto_root()` runs before the patched protos are written; the three copies of the `OUT_DIR/proto_patched` path are folded into one `patched_proto_root()` helper.

## Test plan

No QA needed — build-system only, no runtime behavior change. The generated protos are identical; only stale files from a *different* branch stop leaking in.

Verified locally by reproducing the CI failure and fixing it:

- [ ] On unmodified `main`, planting `avatar_emote_command.proto` in the active `OUT_DIR/proto_patched` (simulating what #2690 leaves behind) and rebuilding reproduces the exact CI error — `Input is shadowed in the --proto_path by .../out/proto_patched/decentraland/sdk/components/avatar_emote_command.proto`.
- [ ] With this change, the same polluted `OUT_DIR` builds clean, and afterwards `proto_patched/` holds only `decentraland/kernel/comms/rfc4/comms.proto`.
- [ ] `cargo fmt --all --check` and `cargo clippy` clean in `lib/`.

Affected failing runs for reference: [#2694 iOS](https://github.com/decentraland/godot-explorer/actions/runs/31652669476/job/94300362591) and [#2690's own branch re-run](https://github.com/decentraland/godot-explorer/actions/runs/31690648111) (passed only after the runner's `target/` was pruned).