### PR TITLE
fix: make the Sentry noise filter actually match, and clamp the logger limiter

### DIFF
--- a/godot/src/project_main_loop.gd
+++ b/godot/src/project_main_loop.gd
@@ -93,6 +93,17 @@ func _initialize() -> void:
 			# `sentry-sample-rate` feature flag, enforced in _before_send once
 			# the flags load.
 			options.sample_rate = 1.0
+
+			# Clamp the logger's own limiter. The addon defaults (20 events per
+			# 10s, same source line re-reported every 1s) let a single device
+			# emit ~172k events/day when an engine ERR_FAIL_COND fires inside a
+			# per-frame loop, which is what drained the quota. These values cap
+			# a device at ~5 events/min (~7k/day) and re-report a given source
+			# line at most once a minute; _before_send still filters on top.
+			options.logger_limits.events_per_frame = 2
+			options.logger_limits.repeated_error_window_ms = 60000
+			options.logger_limits.throttle_events = 5
+			options.logger_limits.throttle_window_ms = 60000
 	)
 
 	# Tag every event so we can filter sampled-vs-unsampled in the Sentry UI.
@@ -145,7 +156,7 @@ func _before_send(event: SentryEvent) -> SentryEvent:
 		return null
 
 	if randf() >= NOISE_KEEP_RATE:
-		var msg: String = event.message
+		var msg := _event_text(event)
 		if not msg.is_empty():
 			for pattern in NOISE_PATTERNS:
 				if pattern in msg:
@@ -156,3 +167,15 @@ func _before_send(event: SentryEvent) -> SentryEvent:
 	#	event.message = event.message.replace("Bruno", "REDACTED")
 
 	return event
+
+
+# SentryGodotLogger builds engine/Rust errors with `add_exception()` and never
+# calls `set_message()`, so `event.message` is empty for every event the noise
+# filter is meant to catch. Read the exception value first and fall back to
+# `message` for events captured directly via SentrySDK.capture_message().
+func _event_text(event: SentryEvent) -> String:
+	if event.get_exception_count() > 0:
+		var value := event.get_exception_value(0)
+		if not value.is_empty():
+			return value
+	return event.message


### PR DESCRIPTION
Our Sentry quota drained twice in a few hours (even after raising the cap to \$150) because the `NOISE_PATTERNS` filter in `_before_send` has never worked. It reads `event.message`, but `SentryGodotLogger` builds every engine/Rust error with `add_exception()` and never calls `set_message()` — so `message` is always empty, the `if not msg.is_empty()` guard short-circuits, and all 16 patterns are dead code. Every `err != OK`, `!is_inside_tree`, `Skin bind` and friend went straight to Sentry at full volume. This reads the exception value instead, and clamps the addon's logger limiter, whose defaults (20 events / 10s, same source line re-reported every 1s) let one device emit ~172k events/day when an `ERR_FAIL_COND` fires inside a per-frame loop.

For scale: of 16,758 production error events accepted in the last 7 days, ~13,000 (78%) match a pattern that was supposed to have filtered them. 15,278 of those came from a single release (`1.12.0+1469`), 14,756 of them on Android.

## Changes

- `godot/src/project_main_loop.gd`
  - new `_event_text()` helper — reads `get_exception_value(0)`, falls back to `message` for events captured via `capture_message()`
  - `_before_send` uses it, so `NOISE_PATTERNS` matches for the first time
  - `options.logger_limits` clamped in the init callback: 2 events/frame, 5 events per 60s window, same source line re-reported at most once a minute (~7k/day/device ceiling, down from ~172k)

The `NOISE_KEEP_RATE = 0.05` canary is unchanged, so 5% of noise still flows through and the issues stay visible in the UI — just at 1/20th the cost.

## Test plan

- [ ] Open the app on Android, walk around a populated realm (e.g. Genesis Plaza) for ~5 minutes, then check Sentry for `release:<this build>` — the issues `Condition "err != OK" is true.`, `Condition "!is_inside_tree()" is true.` and `Skin bind #62 ...` should each show roughly 1/20th the events per user compared to `1.12.0+1469`, not zero.
- [ ] In the same Sentry view, confirm non-noise issues still arrive at full rate (e.g. `Can't change this state while flushing queries.`) — the filter must not have become a blanket mute.
- [ ] Force an error loop (join a scene with a broken wearable so `Skin bind` fires every frame) and confirm the client sends at most ~5 events per minute rather than a continuous stream.
- [ ] Regression: `_before_send` gates all Sentry reporting, so confirm a real crash still reports — run a dev build with the `sentry-sample-rate` flag at 1.0 and verify a deliberate `push_error("qa canary")` shows up in Sentry.

## Follow-ups (not in this PR)

- `Can't change this state while flushing queries.` (538 events) and the `get_node_or_null()` caller-thread error (311) are **our** bugs, not engine noise — they want a `call_deferred()` fix rather than a filter entry.
- The `dcl_social_service` / `FriendsPanel.SubscriptionState` retry errors (~600 events) are a genuine connectivity problem worth looking at separately.
- Old releases (`0.68.0-6737787-prod`, `1.11.0.1205-...`, `1.11.1.1291-...`) are still reporting — the release inbound filter globs need another look.