### PR TITLE
Release Candidate 1.12.2 (crash guards + Sentry quota)

### DIFF
--- a/godot/export_presets.cfg
+++ b/godot/export_presets.cfg
@@ -42,7 +42,7 @@ architectures/x86=false
 architectures/x86_64=true
 ; placeholder — the real store versionCode is stamped at export time from DCL_BUILD_NUMBER (Cloudflare Worker allocator); this committed value never ships
 version/code=1
-version/name="1.12.1"
+version/name="1.12.2"
 package/unique_name="org.decentraland.godotexplorer"
 package/name="Decentraland"
 package/signed=true
@@ -295,7 +295,7 @@ application/provisioning_profile_specifier_release=""
 application/export_method_release=1
 application/bundle_identifier="org.decentraland.godotexplorer"
 application/signature=""
-application/short_version="1.12.1"
+application/short_version="1.12.2"
 ; placeholder — the real CFBundleVersion is stamped at export time from DCL_BUILD_NUMBER (Cloudflare Worker allocator); this committed value never ships
 application/version="1"
 application/additional_plist_content="	<key>CFBundleURLTypes</key>

--- a/godot/src/decentraland_components/avatar/avatar_emote_controller.gd
+++ b/godot/src/decentraland_components/avatar/avatar_emote_controller.gd
@@ -468,6 +468,13 @@ func _async_load_emote(emote_urn: String):
 	# Standard wearable emote loading
 	await WearableRequest.async_fetch_emote(emote_urn)
 
+	# The fetch spans a network round-trip during which the avatar can be freed
+	# (player left, realm change). This controller is RefCounted, so the engine's
+	# freed-instance resume abort never fires for it — re-validate before touching
+	# the avatar (see NodeGuard, #2714).
+	if not NodeGuard.is_alive(avatar, "AvatarEmoteController._async_load_emote"):
+		return
+
 	var emote = Global.content_provider.get_wearable(emote_urn)
 	if emote == null:
 		printerr("Error: emote is null for URN: " + emote_urn)
@@ -592,6 +599,14 @@ func load_emote_from_dcl_emote_gltf(urn: String, obj: DclEmoteGltf, file_hash: S
 func _load_emote_from_gltf_internal(
 	urn: String, obj: DclEmoteGltf, file_hash: String, from_scene: bool, looping: bool
 ):
+	# Reached only after several awaits (emote download + GLTF processing), so the
+	# avatar — and with it animation_player / animation_tree, children of its scene —
+	# may be freed by now. RefCounted self gets no freed-instance resume abort, and
+	# avatar.add_child() on a freed avatar is a native crash (Node::_update_children_cache)
+	# under the release template. Bail out instead — see NodeGuard, #2714.
+	if not NodeGuard.is_alive(avatar, "AvatarEmoteController._load_emote_from_gltf_internal"):
+		return
+
 	# Avoid adding the emote twice
 	if _has_emote(urn):
 		return

--- a/godot/src/feature_flags.gd
+++ b/godot/src/feature_flags.gd
@@ -11,9 +11,9 @@ extends Node
 ## gracefully (e.g. tearing archipelago down while keeping scene rooms alive).
 ##
 ## Fail-open: on timeout, network error or malformed payload every flag keeps
-## its default and the feature stays enabled. Exception: `pulse` is fail-closed —
-## the transport activates only when the payload explicitly enables it (see
-## _apply_flags).
+## its default and the feature stays enabled. Exceptions: `pulse` and
+## `sentry-error-events` are fail-closed — they activate only when the payload
+## explicitly enables them (see _apply_flags).
 
 signal flags_loaded
 
@@ -24,6 +24,9 @@ const FLAG_ARCHIPELAGO := "archipielago"
 const FLAG_PULSE := "pulse"
 # Sentry error-event sampling, served as a number in [0, 1].
 const FLAG_SENTRY_SAMPLE_RATE := "sentry-sample-rate"
+# Report ERROR-level Sentry events (the engine/Rust error firehose). Fail-closed:
+# absent flag = crash/fatal-only reporting — see ProjectMainLoop._before_send.
+const FLAG_SENTRY_ERROR_EVENTS := "sentry-error-events"
 # The bff also serves `sentry-traces-sample-rate`, but sentry-godot exposes no
 # performance-tracing API yet — there is nothing to apply it to until the SDK
 # grows one.
@@ -117,3 +120,4 @@ func _apply_flags() -> void:
 		main_loop.set_sentry_sample_rate(
 			get_number(FLAG_SENTRY_SAMPLE_RATE, ProjectMainLoop.DEFAULT_SENTRY_SAMPLE_RATE)
 		)
+		main_loop.set_sentry_error_events_enabled(is_enabled(FLAG_SENTRY_ERROR_EVENTS, false))

--- a/godot/src/project_main_loop.gd
+++ b/godot/src/project_main_loop.gd
@@ -93,6 +93,17 @@ func _initialize() -> void:
 			# `sentry-sample-rate` feature flag, enforced in _before_send once
 			# the flags load.
 			options.sample_rate = 1.0
+
+			# Clamp the logger's own limiter. The addon defaults (20 events per
+			# 10s, same source line re-reported every 1s) let a single device
+			# emit ~172k events/day when an engine ERR_FAIL_COND fires inside a
+			# per-frame loop, which is what drained the quota. These values cap
+			# a device at ~5 events/min (~7k/day) and re-report a given source
+			# line at most once a minute; _before_send still filters on top.
+			options.logger_limits.events_per_frame = 2
+			options.logger_limits.repeated_error_window_ms = 60000
+			options.logger_limits.throttle_events = 5
+			options.logger_limits.throttle_window_ms = 60000
 	)
 
 	# Tag every event so we can filter sampled-vs-unsampled in the Sentry UI.

--- a/godot/src/project_main_loop.gd
+++ b/godot/src/project_main_loop.gd
@@ -145,7 +145,7 @@ func _before_send(event: SentryEvent) -> SentryEvent:
 		return null
 
 	if randf() >= NOISE_KEEP_RATE:
-		var msg: String = event.message
+		var msg := _event_text(event)
 		if not msg.is_empty():
 			for pattern in NOISE_PATTERNS:
 				if pattern in msg:
@@ -156,3 +156,15 @@ func _before_send(event: SentryEvent) -> SentryEvent:
 	#	event.message = event.message.replace("Bruno", "REDACTED")
 
 	return event
+
+
+# SentryGodotLogger builds engine/Rust errors with `add_exception()` and never
+# calls `set_message()`, so `event.message` is empty for every event the noise
+# filter is meant to catch. Read the exception value first and fall back to
+# `message` for events captured directly via SentrySDK.capture_message().
+func _event_text(event: SentryEvent) -> String:
+	if event.get_exception_count() > 0:
+		var value := event.get_exception_value(0)
+		if not value.is_empty():
+			return value
+	return event.message

--- a/godot/src/project_main_loop.gd
+++ b/godot/src/project_main_loop.gd
@@ -32,10 +32,13 @@ const NOISE_PATTERNS := [
 # engine/driver errors shifts we want to notice, but 100% is wasted quota.
 const NOISE_KEEP_RATE := 0.05
 
-# Error-sampling rate used until the `sentry-sample-rate` feature flag loads —
-# also the effective rate when the fetch fails or the flag is absent. The bff
-# can raise it (currently serves 1.0) or lower it to 0.0 as a kill switch.
-const DEFAULT_SENTRY_SAMPLE_RATE := 0.1
+# Sampling rate used until the `sentry-sample-rate` feature flag loads — also
+# the effective rate when the fetch fails or the flag is absent. 1.0 because
+# crash-only mode (below) is the volume control now: pre-flag traffic is just
+# crashes and NodeGuard messages, and sampling those would randomly drop the
+# events we care about most (early-session crashes). The bff flag remains the
+# remote kill switch (0.0 drops everything).
+const DEFAULT_SENTRY_SAMPLE_RATE := 1.0
 
 # Environment detection based on version string suffix
 var is_dev_version = false
@@ -48,6 +51,14 @@ var attach_log_sampled := false
 # us throttle Sentry volume without shipping a build. Enforced in _before_send
 # because the flag fetch resolves after SentrySDK.init already ran.
 var sentry_sample_rate := DEFAULT_SENTRY_SAMPLE_RATE
+
+# When false (default), only crashes reach Sentry as events: exception events
+# below FATAL — the engine/Rust error firehose captured by SentryGodotLogger —
+# are dropped in _before_send. The `sentry-error-events` feature flag turns
+# ERROR reporting back on remotely (e.g. to debug a release for a day) without
+# shipping a build. Errors keep flowing as breadcrumbs either way (the logger's
+# breadcrumb mask is untouched), so crash events retain the recent-error trail.
+var sentry_error_events_enabled := false
 
 
 func _initialize() -> void:
@@ -145,10 +156,25 @@ func set_sentry_sample_rate(rate: float) -> void:
 	sentry_sample_rate = clampf(rate, 0.0, 1.0)
 
 
+## Called by FeatureFlags when the remote flags load.
+func set_sentry_error_events_enabled(enabled: bool) -> void:
+	sentry_error_events_enabled = enabled
+
+
 func _before_send(event: SentryEvent) -> SentryEvent:
 	# Discard events for dev builds - only prod and staging report to Sentry
 	if self.is_dev_version:
 		return null
+
+	# Crash-only mode (default): drop sub-fatal exception events — engine and
+	# Rust errors auto-captured by SentryGodotLogger. FATAL events (native
+	# crashes; the OS-level crash handler may also bypass this callback
+	# entirely, which is fine) and exception-less events (explicit
+	# capture_message instrumentation, e.g. NodeGuard — deliberate and
+	# self-rate-limited) always pass.
+	if not sentry_error_events_enabled:
+		if event.get_exception_count() > 0 and event.level != SentrySDK.LEVEL_FATAL:
+			return null
 
 	# Remote throttle (`sentry-sample-rate` feature flag): 1.0 keeps every
 	# event, 0.0 drops them all.

--- a/godot/src/ui/components/molecules/dropdown_list/dropdown_list.gd
+++ b/godot/src/ui/components/molecules/dropdown_list/dropdown_list.gd
@@ -215,7 +215,10 @@ func _async_open_popup() -> void:
 
 	# Sync shadow rect with popup panel (position, size, and offset)
 	await get_tree().process_frame
-	if _shadow_rect:
+	# Closing the dropdown during that frame frees the popup — see NodeGuard.
+	if not NodeGuard.is_alive(_popup_panel, "DropdownList._async_open_popup"):
+		return
+	if is_instance_valid(_shadow_rect):
 		# Get corner radius from popup style
 		var popup_style_shadow: StyleBoxFlat = (
 			_popup_panel.get_theme_stylebox("panel") as StyleBoxFlat

--- a/godot/src/ui/components/organisms/modal/modal_manager.gd
+++ b/godot/src/ui/components/organisms/modal/modal_manager.gd
@@ -159,9 +159,11 @@ func _ready() -> void:
 ## Shows an EXTERNAL_LINK type modal
 ## @param external_url: The external URL to open
 func async_show_external_link_modal(external_url: String) -> void:
-	if not current_modal:
+	if not is_instance_valid(current_modal):
 		if not await _async_create_modal():
 			print("NOT CREATED MODAL")
+			return
+		if not NodeGuard.is_alive(current_modal, "ModalManager.async_show_external_link_modal"):
 			return
 
 	current_modal.set_title(EXTERNAL_LINK_TITLE)
@@ -180,9 +182,11 @@ func async_show_external_link_modal(external_url: String) -> void:
 
 ## Shows a SCENE_TIMEOUT type modal
 func async_show_scene_timeout_modal() -> void:
-	if not current_modal:
+	if not is_instance_valid(current_modal):
 		if not await _async_create_modal():
 			print("NOT CREATED MODAL")
+			return
+		if not NodeGuard.is_alive(current_modal, "ModalManager.async_show_scene_timeout_modal"):
 			return
 
 	current_modal.set_title(SCENE_TIMEOUT_TITLE)
@@ -201,9 +205,11 @@ func async_show_scene_timeout_modal() -> void:
 ## Shows a CONNECTION_LOST type modal
 ## @param hide_buttons: If true, hides all buttons (used on iOS after retry fails)
 func async_show_connection_lost_modal(hide_buttons: bool = false) -> void:
-	if not current_modal:
+	if not is_instance_valid(current_modal):
 		if not await _async_create_modal():
 			print("NOT CREATED MODAL")
+			return
+		if not NodeGuard.is_alive(current_modal, "ModalManager.async_show_connection_lost_modal"):
 			return
 
 	current_modal.blocker = true
@@ -237,6 +243,8 @@ func async_show_teleport_modal(location: Vector2i, realm: String = "") -> void:
 	var destination_realm = realm if not realm.is_empty() else DclUrls.main_realm()
 
 	if not await _async_create_travel_modal():
+		return
+	if not NodeGuard.is_alive(current_travel_modal, "ModalManager.async_show_teleport_modal"):
 		return
 
 	current_travel_modal.closed.connect(close_travel_modal)
@@ -279,6 +287,8 @@ func async_show_world_modal(world_name: String) -> void:
 
 	if not await _async_create_travel_modal():
 		return
+	if not NodeGuard.is_alive(current_travel_modal, "ModalManager.async_show_world_modal"):
+		return
 
 	current_travel_modal.closed.connect(close_travel_modal)
 	current_travel_modal.jump_in_pressed.connect(_on_world_jump_in.bind(world_name))
@@ -303,6 +313,8 @@ func async_show_world_modal(world_name: String) -> void:
 func async_show_change_realm_modal(realm_name: String, _message: String = "") -> void:
 	if not await _async_create_travel_modal():
 		return
+	if not NodeGuard.is_alive(current_travel_modal, "ModalManager.async_show_change_realm_modal"):
+		return
 
 	current_travel_modal.closed.connect(close_travel_modal)
 	current_travel_modal.jump_in_pressed.connect(_on_change_realm_primary.bind(realm_name))
@@ -318,8 +330,10 @@ func async_show_change_realm_modal(realm_name: String, _message: String = "") ->
 ## Shows a SCENE_CRASH type modal
 ## @param entity_id: The entity ID of the crashed scene
 func async_show_scene_crash_modal(entity_id: String) -> void:
-	if not current_modal:
+	if not is_instance_valid(current_modal):
 		if not await _async_create_modal():
+			return
+		if not NodeGuard.is_alive(current_modal, "ModalManager.async_show_scene_crash_modal"):
 			return
 
 	current_modal.blocker = true
@@ -347,8 +361,12 @@ func async_show_scene_crash_modal(entity_id: String) -> void:
 func async_show_low_memory_warning_modal(
 	entity_id: String, footprint_mb: int = -1, available_mb: int = -1
 ) -> void:
-	if not current_modal:
+	if not is_instance_valid(current_modal):
 		if not await _async_create_modal():
+			return
+		if not NodeGuard.is_alive(
+			current_modal, "ModalManager.async_show_low_memory_warning_modal"
+		):
 			return
 
 	current_modal.blocker = true
@@ -386,8 +404,10 @@ func async_show_low_memory_warning_modal(
 func async_show_ban_pre_check_modal() -> void:
 	_force_hide_loading_screen()
 
-	if not current_modal:
+	if not is_instance_valid(current_modal):
 		if not await _async_create_modal():
+			return
+		if not NodeGuard.is_alive(current_modal, "ModalManager.async_show_ban_pre_check_modal"):
 			return
 
 	current_modal.blocker = true
@@ -409,8 +429,10 @@ func async_show_ban_pre_check_modal() -> void:
 func async_show_private_world_modal(world_name: String) -> void:
 	_force_hide_loading_screen()
 
-	if not current_modal:
+	if not is_instance_valid(current_modal):
 		if not await _async_create_modal():
+			return
+		if not NodeGuard.is_alive(current_modal, "ModalManager.async_show_private_world_modal"):
 			return
 
 	current_modal.blocker = true
@@ -432,8 +454,10 @@ func async_show_ban_kicked_modal() -> void:
 	if _suppress_ban_kicked:
 		_suppress_ban_kicked = false
 		return
-	if not current_modal:
+	if not is_instance_valid(current_modal):
 		if not await _async_create_modal():
+			return
+		if not NodeGuard.is_alive(current_modal, "ModalManager.async_show_ban_kicked_modal"):
 			return
 
 	current_modal.blocker = true
@@ -484,8 +508,10 @@ func async_show_disconnected_modal() -> void:
 func _async_show_disconnect_modal(
 	title: String, body: String, primary_label: String, primary_handler: Callable
 ) -> void:
-	if not current_modal:
+	if not is_instance_valid(current_modal):
 		if not await _async_create_modal():
+			return
+		if not NodeGuard.is_alive(current_modal, "ModalManager._async_show_disconnect_modal"):
 			return
 
 	current_modal.blocker = true
@@ -519,8 +545,10 @@ func _on_session_ended_secondary() -> void:
 
 ## Shows a low-spec iPhone warning modal (lobby popup)
 func async_show_low_spec_iphone_modal() -> void:
-	if not current_modal:
+	if not is_instance_valid(current_modal):
 		if not await _async_create_modal():
+			return
+		if not NodeGuard.is_alive(current_modal, "ModalManager.async_show_low_spec_iphone_modal"):
 			return
 
 	current_modal.set_title(LOW_SPEC_IPHONE_TITLE)
@@ -539,8 +567,10 @@ func async_show_low_spec_iphone_modal() -> void:
 
 ## Shows a purchase failed modal
 func async_show_purchase_failed_modal() -> void:
-	if not current_modal:
+	if not is_instance_valid(current_modal):
 		if not await _async_create_modal():
+			return
+		if not NodeGuard.is_alive(current_modal, "ModalManager.async_show_purchase_failed_modal"):
 			return
 
 	current_modal.set_title(PURCHASE_FAILED_TITLE)
@@ -557,8 +587,12 @@ func async_show_purchase_failed_modal() -> void:
 
 ## Shows a total credit limit reached modal
 func async_show_credit_limit_total_modal() -> void:
-	if not current_modal:
+	if not is_instance_valid(current_modal):
 		if not await _async_create_modal():
+			return
+		if not NodeGuard.is_alive(
+			current_modal, "ModalManager.async_show_credit_limit_total_modal"
+		):
 			return
 
 	current_modal.set_title(CREDIT_LIMIT_TITLE)
@@ -575,8 +609,12 @@ func async_show_credit_limit_total_modal() -> void:
 
 ## Shows a daily credit limit reached modal
 func async_show_credit_limit_daily_modal() -> void:
-	if not current_modal:
+	if not is_instance_valid(current_modal):
 		if not await _async_create_modal():
+			return
+		if not NodeGuard.is_alive(
+			current_modal, "ModalManager.async_show_credit_limit_daily_modal"
+		):
 			return
 
 	current_modal.set_title(CREDIT_LIMIT_TITLE)
@@ -593,8 +631,12 @@ func async_show_credit_limit_daily_modal() -> void:
 
 ## Shows a purchase-in-flight modal when the user tries to buy while another purchase is pending
 func async_show_purchase_in_flight_modal() -> void:
-	if not current_modal:
+	if not is_instance_valid(current_modal):
 		if not await _async_create_modal():
+			return
+		if not NodeGuard.is_alive(
+			current_modal, "ModalManager.async_show_purchase_in_flight_modal"
+		):
 			return
 
 	current_modal.set_title(PURCHASE_IN_FLIGHT_TITLE)
@@ -611,8 +653,12 @@ func async_show_purchase_in_flight_modal() -> void:
 
 ## Shows a modal when credit purchases are temporarily unavailable (server daily cap)
 func async_show_purchase_unavailable_modal() -> void:
-	if not current_modal:
+	if not is_instance_valid(current_modal):
 		if not await _async_create_modal():
+			return
+		if not NodeGuard.is_alive(
+			current_modal, "ModalManager.async_show_purchase_unavailable_modal"
+		):
 			return
 
 	current_modal.set_title(PURCHASE_UNAVAILABLE_TITLE)
@@ -629,8 +675,12 @@ func async_show_purchase_unavailable_modal() -> void:
 
 ## Shows a modal when a purchase succeeded but its credits are still being applied
 func async_show_purchase_processing_modal() -> void:
-	if not current_modal:
+	if not is_instance_valid(current_modal):
 		if not await _async_create_modal():
+			return
+		if not NodeGuard.is_alive(
+			current_modal, "ModalManager.async_show_purchase_processing_modal"
+		):
 			return
 
 	current_modal.set_title(PURCHASE_PROCESSING_TITLE)
@@ -647,8 +697,10 @@ func async_show_purchase_processing_modal() -> void:
 
 ## Shows IAP terms of use modal with a checkbox that must be accepted before confirming
 func async_show_iap_terms_modal() -> void:
-	if not current_modal:
+	if not is_instance_valid(current_modal):
 		if not await _async_create_modal():
+			return
+		if not NodeGuard.is_alive(current_modal, "ModalManager.async_show_iap_terms_modal"):
 			return
 
 	current_modal.set_title(IAP_TERMS_TITLE)
@@ -672,7 +724,7 @@ func async_show_iap_terms_modal() -> void:
 
 
 func _on_iap_terms_checkbox_toggled(checked: bool) -> void:
-	if current_modal:
+	if is_instance_valid(current_modal):
 		current_modal.button_primary.disabled = not checked
 
 
@@ -706,7 +758,7 @@ func async_show_input_modal(
 	validation: Callable,
 ) -> InputModal:
 	var modal = await _async_create_input_modal()
-	if not modal:
+	if not is_instance_valid(modal):
 		return null
 	modal.setup(title, subtitle, placeholder, confirm_text, cancel_text, validation)
 	modal.open()
@@ -715,28 +767,28 @@ func async_show_input_modal(
 
 ## Closes the current input modal if it exists
 func close_input_modal() -> void:
-	if current_input_modal:
+	if is_instance_valid(current_input_modal):
 		current_input_modal.close()
 		_remove_input_modal()
 
 
 ## Closes the current travel modal if it exists
 func close_travel_modal() -> void:
-	if current_travel_modal:
+	if is_instance_valid(current_travel_modal):
 		current_travel_modal.hide()
 		_remove_travel_modal()
 
 
 ## Closes the current modal if it exists
 func close_current_modal() -> void:
-	if current_modal:
+	if is_instance_valid(current_modal):
 		current_modal.hide()
 		_remove_modal()
 
 
 ## Disconnects all button signals from the current modal
 func _disconnect_button_signals() -> void:
-	if not current_modal:
+	if not is_instance_valid(current_modal):
 		return
 
 	# Disconnect all connections from primary button
@@ -767,7 +819,7 @@ func _dismiss_chat_input_for_modal() -> void:
 func _async_create_modal() -> Modal:
 	_dismiss_chat_input_for_modal()
 	# If there's already a modal open, close it first
-	if current_modal:
+	if is_instance_valid(current_modal):
 		close_current_modal()
 
 	if not modal_scene:
@@ -780,7 +832,7 @@ func _async_create_modal() -> Modal:
 		return null
 
 	# Wrap in a CanvasLayer with high layer to ensure modals render above all overlays
-	if _canvas_layer and is_instance_valid(_canvas_layer):
+	if is_instance_valid(_canvas_layer):
 		_canvas_layer.get_parent().remove_child(_canvas_layer)
 		_canvas_layer.queue_free()
 
@@ -808,12 +860,16 @@ func _async_create_modal() -> Modal:
 	await get_tree().process_frame
 	await get_tree().process_frame
 
+	# Those two frames are a window in which the modal can be freed — see NodeGuard.
+	if not NodeGuard.is_alive(modal, "ModalManager._async_create_modal"):
+		return null
+
 	return modal
 
 
 func _async_create_travel_modal() -> TravelModal:
 	_dismiss_chat_input_for_modal()
-	if current_travel_modal:
+	if is_instance_valid(current_travel_modal):
 		close_travel_modal()
 
 	if not travel_modal_scene:
@@ -825,7 +881,7 @@ func _async_create_travel_modal() -> TravelModal:
 		push_error("ModalManager: Could not instantiate travel modal")
 		return null
 
-	if _travel_canvas_layer and is_instance_valid(_travel_canvas_layer):
+	if is_instance_valid(_travel_canvas_layer):
 		_travel_canvas_layer.get_parent().remove_child(_travel_canvas_layer)
 		_travel_canvas_layer.queue_free()
 
@@ -845,6 +901,10 @@ func _async_create_travel_modal() -> TravelModal:
 
 	await get_tree().process_frame
 	await get_tree().process_frame
+
+	# Those two frames are a window in which the modal can be freed — see NodeGuard.
+	if not NodeGuard.is_alive(modal, "ModalManager._async_create_travel_modal"):
+		return null
 
 	return modal
 
@@ -1033,14 +1093,14 @@ func _on_ban_go_to_discover() -> void:
 
 
 func _on_modal_tree_exited() -> void:
-	# Modal was removed from tree, clear reference
-	if current_modal:
-		current_modal = null
+	# Modal left the tree. Drop the reference whether or not the instance is still alive:
+	# a freed-but-not-cleared member is exactly the dangling pointer we are removing.
+	current_modal = null
 
 
 func _on_travel_modal_tree_exited() -> void:
-	if current_travel_modal:
-		current_travel_modal = null
+	# Cleared unconditionally — see _on_modal_tree_exited.
+	current_travel_modal = null
 
 
 ## Instantly kills the loading screen and runs the normal post-loading cleanup
@@ -1080,19 +1140,19 @@ func _on_loading_finished_clear_suppress() -> void:
 
 
 func _remove_modal() -> void:
-	if current_modal:
+	if is_instance_valid(current_modal):
 		_disconnect_button_signals()
 		if current_modal.tree_exited.is_connected(_on_modal_tree_exited):
 			current_modal.tree_exited.disconnect(_on_modal_tree_exited)
 		current_modal.queue_free()
-		current_modal = null
-	if _canvas_layer and is_instance_valid(_canvas_layer):
+	current_modal = null
+	if is_instance_valid(_canvas_layer):
 		_canvas_layer.queue_free()
-		_canvas_layer = null
+	_canvas_layer = null
 
 
 func _disconnect_travel_signals() -> void:
-	if not current_travel_modal:
+	if not is_instance_valid(current_travel_modal):
 		return
 	for connection in current_travel_modal.closed.get_connections():
 		current_travel_modal.closed.disconnect(connection.callable)
@@ -1101,19 +1161,19 @@ func _disconnect_travel_signals() -> void:
 
 
 func _remove_travel_modal() -> void:
-	if current_travel_modal:
+	if is_instance_valid(current_travel_modal):
 		_disconnect_travel_signals()
 		if current_travel_modal.tree_exited.is_connected(_on_travel_modal_tree_exited):
 			current_travel_modal.tree_exited.disconnect(_on_travel_modal_tree_exited)
 		current_travel_modal.queue_free()
-		current_travel_modal = null
-	if _travel_canvas_layer and is_instance_valid(_travel_canvas_layer):
+	current_travel_modal = null
+	if is_instance_valid(_travel_canvas_layer):
 		_travel_canvas_layer.queue_free()
-		_travel_canvas_layer = null
+	_travel_canvas_layer = null
 
 
 func _async_create_input_modal() -> InputModal:
-	if current_input_modal:
+	if is_instance_valid(current_input_modal):
 		close_input_modal()
 
 	if not input_modal_scene:
@@ -1125,7 +1185,7 @@ func _async_create_input_modal() -> InputModal:
 		push_error("ModalManager: Could not instantiate input modal")
 		return null
 
-	if _input_canvas_layer and is_instance_valid(_input_canvas_layer):
+	if is_instance_valid(_input_canvas_layer):
 		_input_canvas_layer.get_parent().remove_child(_input_canvas_layer)
 		_input_canvas_layer.queue_free()
 
@@ -1146,41 +1206,45 @@ func _async_create_input_modal() -> InputModal:
 	await get_tree().process_frame
 	await get_tree().process_frame
 
+	# Those two frames are a window in which the modal can be freed — see NodeGuard.
+	if not NodeGuard.is_alive(modal, "ModalManager._async_create_input_modal"):
+		return null
+
 	return modal
 
 
 func _on_input_modal_tree_exited() -> void:
-	if current_input_modal:
-		current_input_modal = null
+	# Cleared unconditionally — see _on_modal_tree_exited.
+	current_input_modal = null
 
 
 func _remove_input_modal() -> void:
-	if current_input_modal:
+	if is_instance_valid(current_input_modal):
 		if current_input_modal.tree_exited.is_connected(_on_input_modal_tree_exited):
 			current_input_modal.tree_exited.disconnect(_on_input_modal_tree_exited)
 		current_input_modal.queue_free()
-		current_input_modal = null
-	if _input_canvas_layer and is_instance_valid(_input_canvas_layer):
+	current_input_modal = null
+	if is_instance_valid(_input_canvas_layer):
 		_input_canvas_layer.queue_free()
-		_input_canvas_layer = null
+	_input_canvas_layer = null
 
 
 func async_show_code_modal(email: String = "") -> CodeModal:
 	var modal = await _async_create_code_modal()
-	if not modal:
+	if not is_instance_valid(modal):
 		return null
 	modal.open(email)
 	return modal
 
 
 func close_code_modal() -> void:
-	if current_code_modal:
+	if is_instance_valid(current_code_modal):
 		current_code_modal.close()
 		_remove_code_modal()
 
 
 func _async_create_code_modal() -> CodeModal:
-	if current_code_modal:
+	if is_instance_valid(current_code_modal):
 		close_code_modal()
 
 	if not code_modal_scene:
@@ -1192,7 +1256,7 @@ func _async_create_code_modal() -> CodeModal:
 		push_error("ModalManager: Could not instantiate code modal")
 		return null
 
-	if _code_canvas_layer and is_instance_valid(_code_canvas_layer):
+	if is_instance_valid(_code_canvas_layer):
 		_code_canvas_layer.get_parent().remove_child(_code_canvas_layer)
 		_code_canvas_layer.queue_free()
 
@@ -1213,23 +1277,27 @@ func _async_create_code_modal() -> CodeModal:
 	await get_tree().process_frame
 	await get_tree().process_frame
 
+	# Those two frames are a window in which the modal can be freed — see NodeGuard.
+	if not NodeGuard.is_alive(modal, "ModalManager._async_create_code_modal"):
+		return null
+
 	return modal
 
 
 func _on_code_modal_tree_exited() -> void:
-	if current_code_modal:
-		current_code_modal = null
+	# Cleared unconditionally — see _on_modal_tree_exited.
+	current_code_modal = null
 
 
 func _remove_code_modal() -> void:
-	if current_code_modal:
+	if is_instance_valid(current_code_modal):
 		if current_code_modal.tree_exited.is_connected(_on_code_modal_tree_exited):
 			current_code_modal.tree_exited.disconnect(_on_code_modal_tree_exited)
 		current_code_modal.queue_free()
-		current_code_modal = null
-	if _code_canvas_layer and is_instance_valid(_code_canvas_layer):
+	current_code_modal = null
+	if is_instance_valid(_code_canvas_layer):
 		_code_canvas_layer.queue_free()
-		_code_canvas_layer = null
+	_code_canvas_layer = null
 
 
 ## Shows the reward modal for a claimable campaign.
@@ -1239,20 +1307,20 @@ func _remove_code_modal() -> void:
 ## gate analytics / cadence bookkeeping on a real appearance.
 func async_show_reward_modal(campaign: Dictionary) -> bool:
 	var modal = await _async_create_reward_modal()
-	if not modal:
+	if not is_instance_valid(modal):
 		return false
 	await modal.async_setup(campaign)
 	return true
 
 
 func close_reward_modal() -> void:
-	if current_reward_modal:
+	if is_instance_valid(current_reward_modal):
 		current_reward_modal.hide()
 		_remove_reward_modal()
 
 
 func _async_create_reward_modal() -> RewardModal:
-	if current_reward_modal:
+	if is_instance_valid(current_reward_modal):
 		close_reward_modal()
 
 	if not reward_modal_scene:
@@ -1264,7 +1332,7 @@ func _async_create_reward_modal() -> RewardModal:
 		push_error("ModalManager: Could not instantiate reward modal")
 		return null
 
-	if _reward_canvas_layer and is_instance_valid(_reward_canvas_layer):
+	if is_instance_valid(_reward_canvas_layer):
 		_reward_canvas_layer.get_parent().remove_child(_reward_canvas_layer)
 		_reward_canvas_layer.queue_free()
 
@@ -1285,43 +1353,47 @@ func _async_create_reward_modal() -> RewardModal:
 	await get_tree().process_frame
 	await get_tree().process_frame
 
+	# Those two frames are a window in which the modal can be freed — see NodeGuard.
+	if not NodeGuard.is_alive(modal, "ModalManager._async_create_reward_modal"):
+		return null
+
 	return modal
 
 
 func _on_reward_modal_tree_exited() -> void:
-	if current_reward_modal:
-		current_reward_modal = null
+	# Cleared unconditionally — see _on_modal_tree_exited.
+	current_reward_modal = null
 
 
 func _remove_reward_modal() -> void:
-	if current_reward_modal:
+	if is_instance_valid(current_reward_modal):
 		if current_reward_modal.tree_exited.is_connected(_on_reward_modal_tree_exited):
 			current_reward_modal.tree_exited.disconnect(_on_reward_modal_tree_exited)
 		current_reward_modal.queue_free()
-		current_reward_modal = null
-	if _reward_canvas_layer and is_instance_valid(_reward_canvas_layer):
+	current_reward_modal = null
+	if is_instance_valid(_reward_canvas_layer):
 		_reward_canvas_layer.queue_free()
-		_reward_canvas_layer = null
+	_reward_canvas_layer = null
 
 
 ## Shows the aspirational guest-upgrade nudge modal (issue #2372). Returns true only if the
 ## modal was actually created and opened, so the coordinator advances its cadence only then.
 func async_show_upgrade_modal() -> bool:
 	var modal = await _async_create_upgrade_modal()
-	if not modal:
+	if not is_instance_valid(modal):
 		return false
 	modal.open()
 	return true
 
 
 func close_upgrade_modal() -> void:
-	if current_upgrade_modal:
+	if is_instance_valid(current_upgrade_modal):
 		current_upgrade_modal.hide()
 		_remove_upgrade_modal()
 
 
 func _async_create_upgrade_modal() -> UpgradeModal:
-	if current_upgrade_modal:
+	if is_instance_valid(current_upgrade_modal):
 		close_upgrade_modal()
 
 	if not upgrade_modal_scene:
@@ -1333,7 +1405,7 @@ func _async_create_upgrade_modal() -> UpgradeModal:
 		push_error("ModalManager: Could not instantiate upgrade modal")
 		return null
 
-	if _upgrade_canvas_layer and is_instance_valid(_upgrade_canvas_layer):
+	if is_instance_valid(_upgrade_canvas_layer):
 		_upgrade_canvas_layer.get_parent().remove_child(_upgrade_canvas_layer)
 		_upgrade_canvas_layer.queue_free()
 
@@ -1354,23 +1426,27 @@ func _async_create_upgrade_modal() -> UpgradeModal:
 	await get_tree().process_frame
 	await get_tree().process_frame
 
+	# Those two frames are a window in which the modal can be freed — see NodeGuard.
+	if not NodeGuard.is_alive(modal, "ModalManager._async_create_upgrade_modal"):
+		return null
+
 	return modal
 
 
 func _on_upgrade_modal_tree_exited() -> void:
-	if current_upgrade_modal:
-		current_upgrade_modal = null
+	# Cleared unconditionally — see _on_modal_tree_exited.
+	current_upgrade_modal = null
 
 
 func _remove_upgrade_modal() -> void:
-	if current_upgrade_modal:
+	if is_instance_valid(current_upgrade_modal):
 		if current_upgrade_modal.tree_exited.is_connected(_on_upgrade_modal_tree_exited):
 			current_upgrade_modal.tree_exited.disconnect(_on_upgrade_modal_tree_exited)
 		current_upgrade_modal.queue_free()
-		current_upgrade_modal = null
-	if _upgrade_canvas_layer and is_instance_valid(_upgrade_canvas_layer):
+	current_upgrade_modal = null
+	if is_instance_valid(_upgrade_canvas_layer):
 		_upgrade_canvas_layer.queue_free()
-		_upgrade_canvas_layer = null
+	_upgrade_canvas_layer = null
 
 
 # --- Add Email (guest upgrade) OTP flow (issue #2377) --------------------------------------
@@ -1390,7 +1466,7 @@ func async_start_add_email_flow() -> void:
 	var modal = await async_show_input_modal(
 		"Add Email", "My email", "name@email.com", "ADD", "CANCEL", is_valid_email
 	)
-	if modal:
+	if is_instance_valid(modal):
 		# Add Email modal shown — the OTP upgrade funnel has started (issue #2377).
 		Global.metrics.track_screen_viewed("UPGRADE_OTP_START", "")
 		modal.dismissable = false
@@ -1427,7 +1503,7 @@ func _async_add_email_send_code(email: String) -> Dictionary:
 # gdlint:ignore = async-function-name
 func _async_add_email_code_sent(email: String) -> void:
 	var code_modal = await async_show_code_modal(email)
-	if code_modal:
+	if is_instance_valid(code_modal):
 		Global.metrics.track_screen_viewed("UPGRADE_OTP_ENTERCODE", "")
 		code_modal.set_verifier(_async_add_email_verify.bind(email))
 		code_modal.set_resend_handler(_async_add_email_resend.bind(email))
@@ -1527,7 +1603,7 @@ func _add_email_friendly_error(raw: String) -> String:
 
 func _async_add_email_error_modal(title: String, body: String) -> void:
 	var modal = await _async_create_modal()
-	if not modal:
+	if not is_instance_valid(modal):
 		return
 	modal.set_title(title)
 	modal.set_body(body)

--- a/godot/src/utils/node_guard.gd
+++ b/godot/src/utils/node_guard.gd
@@ -1,0 +1,69 @@
+class_name NodeGuard
+extends RefCounted
+
+## Validity guard for node references that outlive an `await` (issue #2714).
+##
+## Every `await` hands control back to the engine, so between suspending and resuming a
+## function another code path is free to destroy the node that function is about to touch:
+## the user closes the modal, a realm change tears the UI down, sign-out reaps the tree.
+## Reading a member of a freed instance afterwards is a use-after-free. Under the debug
+## export template GDScript validates each object access and turns it into an "Attempted to
+## access a freed object" error; the release template we ship to the stores compiles that
+## validation out and reads the freed memory instead, which is a SIGSEGV on the phone.
+##
+## Two rules follow, and this class exists to make both cheap:
+##
+## 1. Never test a node reference for truthiness (`if node:`). A freed instance is not
+##    null, so the test passes and the *next* line is the one that crashes. Ask
+##    `is_instance_valid()` instead — it resolves the object id rather than the pointer.
+## 2. Re-validate after every `await`, not only before it. A check that ran before
+##    suspending says nothing about the state on resume.
+##
+## `is_alive()` is rule 2 plus telemetry. Swallowing the stale reference silently would fix
+## the crash and hide how often the race actually fires, so every guarded site reports the
+## first hit of the session to Sentry and Segment — enough to size the problem per build and
+## per device, capped so a device that reopens a modal in a loop cannot flood either.
+
+## Hits reported per site per session. The counter in `_hits` keeps rising past this;
+## only the outbound event is capped.
+const REPORTS_PER_SITE := 1
+
+## site name -> times that site caught a freed node this session.
+static var _hits: Dictionary = {}
+
+
+## True when `node` is still a live instance. When it is not, records the site, reports it
+## once per session, and returns false so the caller can bail out instead of crashing.
+## `site` identifies the call site in the telemetry, e.g. "ModalManager.async_show_world_modal".
+static func is_alive(node: Object, site: String) -> bool:
+	if is_instance_valid(node):
+		return true
+	_report_stale(site)
+	return false
+
+
+## Times each guarded site has caught a freed node this session, keyed by site name.
+## Empty on a healthy session; read by tests and the debug hub.
+static func hit_counts() -> Dictionary:
+	return _hits.duplicate()
+
+
+static func _report_stale(site: String) -> void:
+	var hits: int = int(_hits.get(site, 0)) + 1
+	_hits[site] = hits
+	if hits > REPORTS_PER_SITE:
+		return
+
+	var message := "NodeGuard: %s resumed on a freed node — skipped" % site
+	push_warning(message)
+
+	# Telemetry is off in asset-server / CI builds, where SentrySDK was never initialized.
+	if not DclGlobal.is_telemetry_disabled():
+		SentrySDK.capture_message(message, SentrySDK.LEVEL_WARNING)
+
+	# Segment carries the same hit so the rate can be tracked per release alongside the
+	# store crash rate, which is the number this guard is meant to move.
+	if Global.metrics != null:
+		Global.metrics.track_screen_viewed(
+			"STALE_NODE_GUARD", JSON.stringify({"site": site, "platform": OS.get_name()})
+		)

--- a/godot/src/utils/node_guard.gd.uid
+++ b/godot/src/utils/node_guard.gd.uid
@@ -1,0 +1,1 @@
+uid://b7qkn2vxm4dwc

--- a/lib/Cargo.lock
+++ b/lib/Cargo.lock
@@ -861,7 +861,7 @@ dependencies = [
 
 [[package]]
 name = "dclgodot"
-version = "1.12.1"
+version = "1.12.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dclgodot"
-version = "1.12.1"
+version = "1.12.2"
 edition = "2021"
 publish = false
 


### PR DESCRIPTION
Hotfix RC on top of shipped 1.12.1 (`90050d7`) — 5 code commits plus the version bump, no engine bump and no new features. Two threads aimed at the same problem: we are over **10% crash rate** (#2714), and we could not read the crashes properly because Sentry was drowning in noise and burning its quota.

**Crashes.** GDScript's `if node:` is not a validity check — a freed instance isn't null, so the test passes and the *next* line faults. Cross that with `await`, which hands control back to the engine and gives anything a window to free the node the function is about to touch, and it is a use-after-free. The **release** export template we ship has none of the debug template's freed-object validation, so it lands as a SIGSEGV on the phone instead of an error in the log — which is why these never showed up in testing. Guarded in `ModalManager` (`_async_create_*` assigns `current_*` then awaits two frames, with 20 callers touching it on resume), in `DropdownList`, and in the emote loader, where `AvatarEmoteController` is `RefCounted` and so gets none of the engine's implicit safety nets for a freed owner.

**Sentry.** The `NOISE_PATTERNS` filter had been dead code: it read `event.message`, which is always empty for logger-captured events, so all 16 patterns never matched and ~78% of accepted production events were noise the filter was meant to drop. On top of that the logger's limiter was left at addon defaults (20 events/10s, same line re-reported every 1s), letting one device emit ~172k events/day — a few hundred concurrent users drained the monthly quota in hours. Both fixed, and reporting now defaults to **crash-only**, with a remote flag to turn error events back on for a debugging window.

- **Base:** `release` · **Head:** `release-1.12.2` (= `release` @ `90050d7` + 6 commits)
- **Version:** `1.12.2` in `lib/Cargo.toml`, `lib/Cargo.lock`, `export_presets.cfg`. Store build numbers come from the Cloudflare worker at build time and are untouched here.

## Changes

**Crash guards (#2714)**
- **`godot/src/utils/node_guard.gd`** *(new)* — `NodeGuard.is_alive(node, site)`: `is_instance_valid()` plus capped telemetry (first hit per site per session → Sentry + Segment `STALE_NODE_GUARD`), so we learn how often the race really fires instead of silently swallowing it. Documents the two rules: never truthiness-test a node reference, always re-validate after an `await`.
- **`modal_manager.gd`** — 57 truthiness tests become `is_instance_valid()`; the 6 `_async_create_*` refuse to return an instance freed across their awaited frames; the 20 call sites re-validate on resume; `_remove_*` and the `tree_exited` handlers clear their member unconditionally, so a freed-but-not-cleared reference can't survive a close.
- **`dropdown_list.gd`** — `_popup_panel` was read after an awaited frame, behind a truthiness test on `_shadow_rect`.
- **`avatar_emote_controller.gd`** — every remote-player emote spans a network fetch plus two loader awaits and then touched the avatar unchecked. A player leaving mid-download freed it, and `avatar.add_child()` on the freed avatar is a native crash — matching the SIGSEGVs Sentry groups under `Node::_update_children_cache` and `Node::set_name`.

**Sentry quota & signal**
- **`project_main_loop.gd`** — noise filter now reads `get_exception_value(0)` (falling back to `message`), so the 16 patterns actually match; logger limiter clamped to ~5 events/min per device (~7k/day) with a given source line re-reported at most once a minute; `_before_send` drops sub-fatal exception events unless the new flag is on. Explicit `capture_message` events (NodeGuard) and FATAL crashes always pass, and errors still attach to crashes as breadcrumbs.
- **`feature_flags.gd`** — new fail-closed `sentry-error-events` flag re-enables ERROR reporting remotely. With the firehose gated, `DEFAULT_SENTRY_SAMPLE_RATE` rises `0.1 → 1.0` so early-session crashes aren't randomly dropped; `sentry-sample-rate` stays the remote kill switch.

## Test plan

The guards are bail-outs on state that would otherwise have crashed, so the happy path should be identical — §1 checks that, §2 is the actual fix. The Sentry changes are telemetry-only and are **not** hand-testable on a device; they are verified in the Sentry dashboard after release. Run on Android and iOS, including one low-end Android (where the crashes concentrate).

**0. Version** — Launch the app → the lobby screen and **Settings → About** read **`v1.12.2.<build>`**.

**1. Nothing regressed** — each modal must show with the right title, body and buttons, and the buttons must do what they say:
- [x] `/goto 0,0` in chat → teleport modal with place name, creator and image; **JUMP IN** teleports.
- [x] `/world <a-real-world>.dcl.eth` in chat → world modal with name and image; **JUMP IN** enters it.
- [x] Tap a scene link that opens an external URL → **"Open external link?"**; **OPEN LINK** opens the browser, **CANCEL** closes.
- [x] Turn airplane mode on in-world → **"Connection lost"**; turn it off → recovers. (iOS shows **RETRY** only.)
- [x] **Settings → Gameplay → Camera Mode** dropdown → opens with its drop shadow drawn; picking an item closes it and applies.
- [x] As a guest: **Settings → Account → Add Email** → email modal, then code modal, then reward modal, in sequence.
- [x] Play three of your own emotes from the emote wheel → each plays fully, with its props and sound.

**2. The race itself** — each of these frees a node while an `await` is in flight, which is what used to crash:
- [x] Open a Settings dropdown and close it on the same frame (fast double-tap), 10× → no crash, and it still opens normally afterwards.
- [x] `/goto 0,0`, then tap the travel modal's **X** before its image finishes loading, 10× → no crash; the last one still teleports.
- [x] `/goto 0,0`, then **sign out** from the navbar while the modal is on screen → back to the lobby, no crash; sign in again → modals still work.
- [x] In a busy Genesis Plaza, with other players visibly emoting, teleport out and straight back 5× → no crash; other players' emotes still play after each return.

**3. Regression** — shared UI code, so:
- [x] Sign in with a wallet and as a guest → both reach the world.
- [x] Open and close **Backpack**, **Profile**, **Settings**, **Map**, **Emote wheel**, **Chat** → no crash, no stuck overlay.
- [x] Teleport between three places including Genesis Plaza and a World → each loads, the previous unloads.

---

**After release (not QA).** Three numbers decide whether this worked, and none of them are visible before it ships:
1. Sentry event volume should drop sharply — if it doesn't, the noise filter is still missing its targets.
2. Hits on `NodeGuard: … resumed on a freed node` mean the guards are catching real races. Each names its call site and is a follow-up bug, not a regression; a flood from one site means that path needs a real lifecycle fix rather than a bail-out.
3. Play Console / App Store Connect crash rate against 1.12.1 over 7 days — post it on #2714.

Crash-only reporting is the one thing to keep an eye on: if we lose visibility of a non-crash failure we care about, flip `sentry-error-events` on in the bff rather than shipping a build.
