### PR TITLE
fix(scene): report render frames in EngineInfo.frame_number

### DIFF
--- a/lib/src/scene_runner/scene_manager.rs
+++ b/lib/src/scene_runner/scene_manager.rs
@@ -1625,7 +1625,11 @@ impl SceneManager {
             }
         });
 
-        let frames_count = godot::classes::Engine::singleton().get_physics_frames();
+        // EngineInfo.frame_number must count rendered/main-loop frames (Unity
+        // reports Time.frameCount). Physics frames advance at a fixed 60 Hz in
+        // wall time even when rendering is slow, so they hide the real client
+        // frame rate from scenes that diff frame_number between ticks.
+        let frames_count = godot::classes::Engine::singleton().get_process_frames();
 
         let player_parcel_position = Vector2i::new(
             (player_global_transform.origin.x / 16.0).floor() as i32,


### PR DESCRIPTION
`EngineInfo.frame_number` was fed from Godot's **physics**-frame counter, which advances at a fixed 60 Hz in wall time no matter how slow rendering gets — so any SDK scene diffing `frameNumber` between ticks to estimate the client's frame rate always saw ~60 FPS, even on a phone rendering at 25. This switches the source to `Engine.get_process_frames()` (one increment per rendered/main-loop frame — the equivalent of Unity explorer's `Time.frameCount`, which is what unity-explorer reports in this field), so scenes now see the real render frame rate. `tick_number` and `total_runtime` are untouched, and nothing in the client reads `frame_number` internally — it only flows to scenes through the CRDT.

Closes #2729

## Test plan

The field is only observable from SDK scene code, so verification is dev-side:

**Dev verification:** run a local scene with a system that reads `EngineInfo` from the root entity and logs `(frameNumber₂ − frameNumber₁) / (totalRuntime₂ − totalRuntime₁)` once per second. On a device rendering below 60 FPS (or with the FPS limiter set to 30), the logged value now matches the on-screen FPS counter instead of pinning at ~60.

### Regression — scenes still run normally
**Steps:**
1. Open the app.
2. Enter Genesis Plaza and wait for it to load.
3. Walk around, interact with a couple of scene items (e.g. open an interactive prop), and let a video/billboard scene render for a minute.

- [ ] **Expected:** scenes load and animate normally, interactions respond, and no scene freezes or restarts (no behavior besides the reported frame counter changed).
