### PR TITLE
fix(sdk): read AvatarLocomotionSettings from the PLAYER entity

### DIFF
--- a/lib/src/scene_runner/components/avatar_locomotion_settings.rs
+++ b/lib/src/scene_runner/components/avatar_locomotion_settings.rs
@@ -9,7 +9,14 @@ use crate::{
     scene_runner::scene::Scene,
 };
 
-/// Updates the locomotion settings for the scene.
+/// Updates the locomotion settings for the scene from the `PBAvatarLocomotionSettings`
+/// component on the PLAYER entity (id = 1), which is where scenes address it:
+/// `AvatarLocomotionSettings.createOrReplace(engine.PlayerEntity, { ... })`.
+///
+/// This mirrors the other player-targeted components (`InputModifier`,
+/// `PhysicsCombinedForce`) and the reference implementation. The component is
+/// ignored on any other entity.
+///
 /// Returns `true` if the settings were changed, `false` otherwise.
 pub fn update_avatar_locomotion_settings(
     scene: &mut Scene,
@@ -17,25 +24,25 @@ pub fn update_avatar_locomotion_settings(
 ) -> bool {
     let dirty_lww_components = &scene.current_dirty.lww_components;
 
-    if let Some(locomotion_dirty) =
-        dirty_lww_components.get(&SceneComponentId::AVATAR_LOCOMOTION_SETTINGS)
-    {
-        // Only process ROOT_ENTITY (id = 0)
-        if locomotion_dirty.contains(&SceneEntityId::ROOT) {
-            let locomotion_component =
-                SceneCrdtStateProtoComponents::get_avatar_locomotion_settings(crdt_state);
+    let is_dirty = dirty_lww_components
+        .get(&SceneComponentId::AVATAR_LOCOMOTION_SETTINGS)
+        .is_some_and(|dirty| dirty.contains(&SceneEntityId::PLAYER));
 
-            if let Some(value) = locomotion_component.get(&SceneEntityId::ROOT) {
-                if let Some(proto) = &value.value {
-                    scene.locomotion_settings.bind_mut().set_from_proto(proto);
-                } else {
-                    scene.locomotion_settings.bind_mut().reset_to_defaults();
-                }
-            } else {
-                scene.locomotion_settings.bind_mut().reset_to_defaults();
-            }
-            return true;
-        }
+    if !is_dirty {
+        return false;
     }
-    false
+
+    let locomotion_component =
+        SceneCrdtStateProtoComponents::get_avatar_locomotion_settings(crdt_state);
+    let player_settings = locomotion_component.get(&SceneEntityId::PLAYER);
+
+    // A missing entry or a cleared value means the scene removed the component:
+    // fall back to the engine defaults.
+    let mut settings = scene.locomotion_settings.bind_mut();
+    match player_settings.and_then(|entry| entry.value.as_ref()) {
+        Some(proto) => settings.set_from_proto(proto),
+        None => settings.reset_to_defaults(),
+    }
+
+    true
 }


### PR DESCRIPTION
Fixes #2727
Fixes #2682

`AvatarLocomotionSettings` was read from `SceneEntityId::ROOT` (id 0), but scenes set it on `engine.PlayerEntity` (id 1) as the protocol specifies. The dirty check never matched, so `locomotion_settings_changed` was never emitted and `player.gd` kept the engine defaults — `walkSpeed`/`jogSpeed`/`runSpeed` had no effect at all.

Read `SceneEntityId::PLAYER` instead. Every sibling component that targets the player (`input_modifier`, `physics_combined`, and the player transform the engine writes back) already does. Removal behaviour is unchanged: a missing entry or a cleared value resets to the engine defaults.

One file, no new API.

### Test plan

Any scene that sets the component on `engine.PlayerEntity` — e.g. https://github.com/iillee/mobile_test, or `afkj.dcl.eth` from #2682:

1. Enter the scene and confirm the avatar slows to the values the scene sets.
2. Leave the scene bounds and confirm the defaults come back.
3. Re-enter and confirm the settings are reapplied.

Worth checking on both desktop and mobile: on mobile the top speed is `jog_speed` (`run_speed` needs `ia_sprint`, which mobile has no input for), so a scene that only lowers `runSpeed` still won't change anything there. That is existing behaviour and out of scope here.