### PR TITLE
chore(ci): disable the self-hosted iOS pipeline

### DIFF
--- a/.github/workflows/ios_self_hosted.yml
+++ b/.github/workflows/ios_self_hosted.yml
@@ -35,15 +35,22 @@ name: 🍏 iOS (self-hosted)
 # this workflow. The `if:` gates are correctness/convenience only. The runner/VM setup scripts are
 # kept LOCAL (outside this repo) and provision the `dcl-ios`-labelled runner this workflow targets.
 
+# ⛔ DISABLED: the self-hosted `dcl-ios` Mac has been shut down, so the automatic triggers are
+# commented out — otherwise every push/PR would queue a job against a runner that never comes
+# online. iOS builds are served entirely by mobile_distribute.yml (WarpBuild). `workflow_dispatch`
+# is kept so the workflow can still be run by hand if the Mac is ever brought back.
+# To re-enable: restore the triggers below AND flip IOS_SELF_HOSTED_ENABLED back to 'true' in
+# mobile_distribute.yml (its `ios-resolve` job otherwise skips waiting for this workflow's export).
 on:
-  push:
-    branches:
-      - main
-      - release
-  pull_request:
-    # `labeled` is included so adding the `build` label re-triggers this workflow; combined with
-    # the `if` skip + concurrency below, that cancels any per-push run already queued on the Mac.
-    types: [opened, synchronize, reopened, labeled]
+  workflow_dispatch:
+  # push:
+  #   branches:
+  #     - main
+  #     - release
+  # pull_request:
+  #   # `labeled` is included so adding the `build` label re-triggers this workflow; combined with
+  #   # the `if` skip + concurrency below, that cancels any per-push run already queued on the Mac.
+  #   types: [opened, synchronize, reopened, labeled]
 
 permissions:
   contents: read

--- a/.github/workflows/mobile_distribute.yml
+++ b/.github/workflows/mobile_distribute.yml
@@ -283,6 +283,10 @@ jobs:
       SHA:         ${{ needs.prepare.outputs.sha }}
       SAFE_BRANCH: ${{ needs.prepare.outputs.safe_branch }}
       GH_TOKEN:    ${{ secrets.GITHUB_TOKEN }}
+      # ios_self_hosted.yml is DISABLED (the `dcl-ios` Mac was shut down), so no self-hosted export
+      # will ever appear for a commit — don't burn 20 minutes polling for one. Flip back to 'true'
+      # together with that workflow's triggers if the runner comes back.
+      IOS_SELF_HOSTED_ENABLED: 'false'
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
@@ -307,6 +311,8 @@ jobs:
           if have_export; then
             echo "✅ Export already present."
             have=true
+          elif [ "$IOS_SELF_HOSTED_ENABLED" != "true" ]; then
+            echo "ℹ️  self-hosted iOS runner is disabled → building on CI."
           else
             # The self-hosted build for this commit may still be in flight (~12 min). Poll for it,
             # but stop the moment that run concludes without a usable export (→ build on CI).


### PR DESCRIPTION
The `dcl-ios` self-hosted Mac has been shut down, so ios_self_hosted.yml's push/pull_request triggers only queue jobs against a runner that never comes online: without RUNNERS_READ_TOKEN the gate bypasses and build-ios stays pending until a newer push cancels it or the 24h limit expires.

Comment the triggers out and keep `workflow_dispatch`, so the workflow (and its gate/queueing logic) survives intact for the day the Mac comes back.

mobile_distribute.yml's `ios-resolve` job also has to know: its poll waits up to 20 minutes for a self-hosted export to appear in R2 and only breaks early when a self-hosted run for that SHA has concluded. With the workflow disabled no such run exists, so every distribution would burn the full timeout before falling back to WarpBuild. An IOS_SELF_HOSTED_ENABLED flag short-circuits the wait; the initial head-object check is kept, so an export already in R2 for that commit is still reused.