### PR TITLE
fix: filter zero-address chat messages from chat panel

### DIFF
--- a/godot/src/helpers_components/chat_handler.gd
+++ b/godot/src/helpers_components/chat_handler.gd
@@ -4,6 +4,11 @@ const EMOTE: String = "␐"
 const REQUEST_PING: String = "␑"
 const ACK: String = "␆"
 
+## Synthetic/non-player sender address (H160::zero() on the Rust side, formatted as
+## "0x000...000"). Room-level/relay participants can end up attached to this address;
+## such messages must never be rendered in chat as if a real user sent them (#2775).
+const ZERO_ADDRESS: String = "0x0000000000000000000000000000000000000000"
+
 
 func _ready():
 	Global.comms.chat_message.connect(self._on_chats_arrived)
@@ -14,6 +19,11 @@ func _on_chats_arrived(chats: Array):
 		var chat = chats[i]
 		var address: String = chat[0]
 		var timestamp: float = chat[1]
+
+		if address == ZERO_ADDRESS:
+			# Debug/relay message from a synthetic sender — drop it instead of showing it
+			# as a fake user message (#2775).
+			continue
 
 		var avatar: DclAvatar
 		if address == Global.player_identity.get_address_str():


### PR DESCRIPTION
## Summary

Fixes #2775 — a debug/relay message with sender address `0x0000...0000` (the synthetic `H160::zero()` address the Rust comms layer uses for room-level / non-player participants) was leaking into the NEARBY chat panel as if it were a real user message, e.g.:

```
0x0000...0000: Realm set to `https://peer.decentraland.org/content`
```

## Root cause

`chat_handler.gd` forwards every incoming chat entry from `Global.comms.chat_message` straight into `Global.on_chat_message` (rendered by the chat UI as a normal user bubble), with no check for a synthetic/zero sender address. Whenever such a message reaches the client, it gets rendered indistinguishably from a real player's message.

## Fix

Drop any incoming chat whose sender resolves to the zero address (`0x0000000000000000000000000000000000000000`, matching the `format!("{:#x}", H160::zero())` representation on the Rust side) in `chat_handler.gd`, before it ever reaches `Global.on_chat_message`. This mirrors the existing `"system"` sender special-case already handled in that file, but discards the message instead of rendering it, since it's not meant to be user-facing at all.

## How to test

1. Open the chat panel.
2. Trigger a realm change (`/reload`, `/changerealm <realm>`, teleport, etc.) while connected to a room that would otherwise relay a zero-address status/debug chat.
3. Confirm no `0x0000...0000` message bubble appears in NEARBY chat; legitimate `system` messages (teleport/realm-change confirmations, welcome message, `/pos`, etc.) still render normally, since only the exact zero address is filtered.

## Scope note

This addresses the client-side symptom (never render a zero-address message as a chat bubble) rather than the origin of the message itself, since I could not trace the exact upstream component that attaches this address to the relayed status text — it's out of scope for a GDScript-only client fix. Happy to take a follow-up if someone can point at the sending side.

Requested by Gon via Slack
