### PR TITLE
fix: remove Settings 'Marketplace' link (Google Play payments policy)

### DIFF
--- a/godot/src/ui/pages/settings/settings.gd
+++ b/godot/src/ui/pages/settings/settings.gd
@@ -975,12 +975,6 @@ func _on_button_discord_pressed() -> void:
 	Global.open_url(DISCORD_URL)
 
 
-func _on_button_marketplace_pressed() -> void:
-	# SFSafariViewController on iOS (same webview as Apple Sign In) and
-	# Chrome Custom Tabs on Android. Desktop falls back to shell_open.
-	MarketplaceTracker.open_and_track(DclUrls.marketplace())
-
-
 func _on_button_storage_pressed() -> void:
 	show_control(container_storage)
 	_async_scroll_to_tab_button(%Button_Storage)

--- a/godot/src/ui/pages/settings/settings.tscn
+++ b/godot/src/ui/pages/settings/settings.tscn
@@ -1438,24 +1438,6 @@ flat = true
 alignment = 0
 icon_alignment = 2
 
-[node name="Button_Marketplace" type="Button" parent="VBoxContainer/MarginContainer_Content/ContentScrollContainer/VBoxContainer/MarginContainer_Upgrade/VBoxContainer_Sections/VBoxContainer_Account/SectionHelp/VBoxContainer/VBoxContainer2" unique_id=1384661529]
-custom_minimum_size = Vector2(0, 40)
-layout_mode = 2
-size_flags_horizontal = 0
-focus_mode = 0
-mouse_filter = 1
-theme_override_colors/font_color = Color(0.9882353, 0.9882353, 0.9882353, 1)
-theme_override_colors/icon_normal_color = Color(0.9882353, 0.9882353, 0.9882353, 1)
-theme_override_constants/h_separation = 16
-theme_override_constants/icon_max_width = 32
-theme_override_fonts/font = ExtResource("23_c03rv")
-theme_override_font_sizes/font_size = 30
-text = "Shop"
-icon = ExtResource("24_jf4mt")
-flat = true
-alignment = 0
-icon_alignment = 2
-
 [node name="MarginContainer" type="MarginContainer" parent="VBoxContainer/MarginContainer_Content/ContentScrollContainer/VBoxContainer/MarginContainer_Upgrade/VBoxContainer_Sections/VBoxContainer_Account" unique_id=1029705279]
 layout_mode = 2
 theme_override_constants/margin_left = 0
@@ -1520,6 +1502,5 @@ font = ExtResource("25_jf4mt")
 [connection signal="pressed" from="VBoxContainer/MarginContainer_Content/ContentScrollContainer/VBoxContainer/MarginContainer_Upgrade/VBoxContainer_Sections/VBoxContainer_Account/SectionHelp/VBoxContainer/VBoxContainer2/Button_ContentPolicy" to="." method="_on_button_content_policy_pressed"]
 [connection signal="pressed" from="VBoxContainer/MarginContainer_Content/ContentScrollContainer/VBoxContainer/MarginContainer_Upgrade/VBoxContainer_Sections/VBoxContainer_Account/SectionHelp/VBoxContainer/VBoxContainer2/Button_TermsOfService" to="." method="_on_button_terms_of_service_pressed"]
 [connection signal="pressed" from="VBoxContainer/MarginContainer_Content/ContentScrollContainer/VBoxContainer/MarginContainer_Upgrade/VBoxContainer_Sections/VBoxContainer_Account/SectionHelp/VBoxContainer/VBoxContainer2/Button_Discord" to="." method="_on_button_discord_pressed"]
-[connection signal="pressed" from="VBoxContainer/MarginContainer_Content/ContentScrollContainer/VBoxContainer/MarginContainer_Upgrade/VBoxContainer_Sections/VBoxContainer_Account/SectionHelp/VBoxContainer/VBoxContainer2/Button_Marketplace" to="." method="_on_button_marketplace_pressed"]
 [connection signal="pressed" from="VBoxContainer/MarginContainer_Content/ContentScrollContainer/VBoxContainer/MarginContainer_Upgrade/VBoxContainer_Sections/VBoxContainer_Account/MarginContainer/VBoxContainer/CustomButton_SignOut" to="." method="_on_custom_button_sign_out_pressed"]
 [connection signal="pressed" from="VBoxContainer/MarginContainer_Content/ContentScrollContainer/VBoxContainer/MarginContainer_Upgrade/VBoxContainer_Sections/VBoxContainer_Account/MarginContainer/VBoxContainer/UnderlinedButton_DeleteAccount" to="." method="_on_button_delete_account_pressed"]


### PR DESCRIPTION
## Summary
Removes the **Marketplace** ("Shop") link from Settings › Account › Help, on all platforms (Android + iOS + desktop), per the Google Play Payments policy violation flagged on v1.13.0 (deadline **2026-09-15**).

Changes:
- `settings.tscn`: removed the `Button_Marketplace` node and its `pressed` signal connection.
- `settings.gd`: removed `_on_button_marketplace_pressed()` (which opened `DclUrls.marketplace()` in a webview/custom tab).

The button was originally added in #2099 as a way to reach the marketplace webview for testing before recommended-wearables existed; it was never removed afterwards.

## What could break
- No other code referenced `Button_Marketplace` / `_on_button_marketplace_pressed` (repo-wide grep).
- `MarketplaceTracker` and `DclUrls.marketplace()` are untouched — they are still used by the Rust URL helpers and by other flows.
- The `ExtResource("24_jf4mt")` icon is still used by `Button_Discord`, so no orphaned resource.
- Layout: the button was the last entry of the Help `VBoxContainer2` (after Privacy Policy / Content Policy / Terms / Discord), so the section just gets one row shorter.

## Not in scope (needs a decision)
Other in-app paths still reach the external marketplace and may fall under the same policy — flagging them rather than removing blindly, since some are part of the wearables/credits UX:
- `godot/src/ui/components/molecules/marketplace_cta_card/marketplace_cta_button.gd`
- `godot/src/ui/pages/backpack/no_items_message.gd` (empty-backpack CTA)
- `godot/src/ui/components/molecules/wearable_item/wearable_item.gd` (item → marketplace URL)

This matches Mateo's point about checking there is no other way to reach a place where something can be bought. Happy to follow up in a second PR once we decide how far the removal must go on Android vs iOS.

## How to test
1. Build for Android/iOS (or run in editor).
2. Open Settings → Account → scroll to the Help section.
3. Expect: Privacy Policy, Content Policy, Terms of Service, Discord — no "Shop"/Marketplace entry.
4. Verify the rest of Settings (Report section, Sign Out, Delete Account) still renders and works.

Closes #2808

Requested by Lean via Slack
