### PR TITLE
fix: remove Settings 'Marketplace' link (Google Play payments policy)

### DIFF
--- a/godot/src/ui/pages/settings/settings.gd
+++ b/godot/src/ui/pages/settings/settings.gd
@@ -975,12 +975,6 @@ func _on_button_discord_pressed() -> void:
 	Global.open_url(DISCORD_URL)
 
 
-func _on_button_marketplace_pressed() -> void:
-	# SFSafariViewController on iOS (same webview as Apple Sign In) and
-	# Chrome Custom Tabs on Android. Desktop falls back to shell_open.
-	MarketplaceTracker.open_and_track(DclUrls.marketplace())
-
-
 func _on_button_storage_pressed() -> void:
 	show_control(container_storage)
 	_async_scroll_to_tab_button(%Button_Storage)

--- a/godot/src/ui/pages/settings/settings.tscn
+++ b/godot/src/ui/pages/settings/settings.tscn
@@ -1438,24 +1438,6 @@ flat = true
 alignment = 0
 icon_alignment = 2
 
-[node name="Button_Marketplace" type="Button" parent="VBoxContainer/MarginContainer_Content/ContentScrollContainer/VBoxContainer/MarginContainer_Upgrade/VBoxContainer_Sections/VBoxContainer_Account/SectionHelp/VBoxContainer/VBoxContainer2" unique_id=1384661529]
-custom_minimum_size = Vector2(0, 40)
-layout_mode = 2
-size_flags_horizontal = 0
-focus_mode = 0
-mouse_filter = 1
-theme_override_colors/font_color = Color(0.9882353, 0.9882353, 0.9882353, 1)
-theme_override_colors/icon_normal_color = Color(0.9882353, 0.9882353, 0.9882353, 1)
-theme_override_constants/h_separation = 16
-theme_override_constants/icon_max_width = 32
-theme_override_fonts/font = ExtResource("23_c03rv")
-theme_override_font_sizes/font_size = 30
-text = "Shop"
-icon = ExtResource("24_jf4mt")
-flat = true
-alignment = 0
-icon_alignment = 2
-
 [node name="MarginContainer" type="MarginContainer" parent="VBoxContainer/MarginContainer_Content/ContentScrollContainer/VBoxContainer/MarginContainer_Upgrade/VBoxContainer_Sections/VBoxContainer_Account" unique_id=1029705279]
 layout_mode = 2
 theme_override_constants/margin_left = 0
@@ -1520,6 +1502,5 @@ font = ExtResource("25_jf4mt")
 [connection signal="pressed" from="VBoxContainer/MarginContainer_Content/ContentScrollContainer/VBoxContainer/MarginContainer_Upgrade/VBoxContainer_Sections/VBoxContainer_Account/SectionHelp/VBoxContainer/VBoxContainer2/Button_ContentPolicy" to="." method="_on_button_content_policy_pressed"]
 [connection signal="pressed" from="VBoxContainer/MarginContainer_Content/ContentScrollContainer/VBoxContainer/MarginContainer_Upgrade/VBoxContainer_Sections/VBoxContainer_Account/SectionHelp/VBoxContainer/VBoxContainer2/Button_TermsOfService" to="." method="_on_button_terms_of_service_pressed"]
 [connection signal="pressed" from="VBoxContainer/MarginContainer_Content/ContentScrollContainer/VBoxContainer/MarginContainer_Upgrade/VBoxContainer_Sections/VBoxContainer_Account/SectionHelp/VBoxContainer/VBoxContainer2/Button_Discord" to="." method="_on_button_discord_pressed"]
-[connection signal="pressed" from="VBoxContainer/MarginContainer_Content/ContentScrollContainer/VBoxContainer/MarginContainer_Upgrade/VBoxContainer_Sections/VBoxContainer_Account/SectionHelp/VBoxContainer/VBoxContainer2/Button_Marketplace" to="." method="_on_button_marketplace_pressed"]
 [connection signal="pressed" from="VBoxContainer/MarginContainer_Content/ContentScrollContainer/VBoxContainer/MarginContainer_Upgrade/VBoxContainer_Sections/VBoxContainer_Account/MarginContainer/VBoxContainer/CustomButton_SignOut" to="." method="_on_custom_button_sign_out_pressed"]
 [connection signal="pressed" from="VBoxContainer/MarginContainer_Content/ContentScrollContainer/VBoxContainer/MarginContainer_Upgrade/VBoxContainer_Sections/VBoxContainer_Account/MarginContainer/VBoxContainer/UnderlinedButton_DeleteAccount" to="." method="_on_button_delete_account_pressed"]


### PR DESCRIPTION
Removes the `Button_Marketplace` entry from Settings > Account > Help and its pressed handler, on all platforms.

Google Play flagged the button as leading users to a payment method outside Play billing (deadline: 2026-09-15).

Targeted at `release` so it ships with the current build.

Closes #2808