### PR TITLE
feat(scene-stats): VFX emitter and light source limit rows

### DIFF
--- a/godot/src/tool/debug_server/debug_collector.gd
+++ b/godot/src/tool/debug_server/debug_collector.gd
@@ -103,17 +103,19 @@ static func _walk_scene_resources(
 	elif node is CollisionShape3D:
 		acc["colliders"] += 1
 	elif node is GPUParticles3D:
-		# SDK particle systems live under scene entities; avatar particles are
-		# under the global AvatarScene and never reached by this scene-rooted walk.
+		# Authored, not playback state: every emitter counts (the runtime forces
+		# emitting off for scenes the player isn't standing in, and for paused /
+		# stopped / one-shot systems). The particle total reads the pre-clamp
+		# authored amount — ps.amount is already clamped by the runtime budgets
+		# and would saturate at the cap, never signalling an over-budget scene.
 		var ps: GPUParticles3D = node
-		if ps.emitting:
-			acc["emitters"] += 1
-			acc["live_particles"] += ps.amount
+		acc["emitters"] += 1
+		acc["live_particles"] += int(ps.get_meta("dcl_authored_amount", ps.amount))
 	elif node is DclLightSourceComponent:
 		# Authored counts, not budgeted — but skip lights authored off
-		# (active=false): they never emit, so they don't hit perf.
+		# (active=false) or torn down (no Light3D): they never emit.
 		var dcl_light := node as DclLightSourceComponent
-		if dcl_light.runtime_light_enabled:
+		if dcl_light.runtime_light_enabled and dcl_light.current_light != null:
 			acc["lights"] += 1
 			if dcl_light.runtime_shadows_enabled:
 				acc["shadow_casters"] += 1

--- a/godot/src/tool/debug_server/debug_collector.gd
+++ b/godot/src/tool/debug_server/debug_collector.gd
@@ -52,10 +52,19 @@ static func collect_scenes_summary() -> Array:
 ## entity count — the ONE scene-scoped resource walker (also feeds the preview
 ## SceneStatsPanel); extend it here instead of adding another subtree walk.
 ## Returns: { triangles, bodies, colliders, entities, geometries, materials,
-## textures }. `tri_cache` (mesh instance_id -> triangles) is caller-owned so
-## repeated refresh ticks stay cheap; pass {} to skip caching.
+## textures, emitters, live_particles, lights, shadow_casters }. `tri_cache`
+## (mesh instance_id -> triangles) is caller-owned so repeated refresh ticks
+## stay cheap; pass {} to skip caching.
 static func collect_scene_resources(scene_id: int, tri_cache: Dictionary) -> Dictionary:
-	var acc: Dictionary = {"triangles": 0, "bodies": 0, "colliders": 0}
+	var acc: Dictionary = {
+		"triangles": 0,
+		"bodies": 0,
+		"colliders": 0,
+		"emitters": 0,
+		"live_particles": 0,
+		"lights": 0,
+		"shadow_casters": 0,
+	}
 	var geos: Dictionary = {}
 	var mats: Dictionary = {}
 	var texs: Dictionary = {}
@@ -93,6 +102,21 @@ static func _walk_scene_resources(
 					_collect_material_textures(mat, texs)
 	elif node is CollisionShape3D:
 		acc["colliders"] += 1
+	elif node is GPUParticles3D:
+		# SDK particle systems live under scene entities; avatar particles are
+		# under the global AvatarScene and never reached by this scene-rooted walk.
+		var ps: GPUParticles3D = node
+		if ps.emitting:
+			acc["emitters"] += 1
+			acc["live_particles"] += ps.amount
+	elif node is DclLightSourceComponent:
+		# Authored counts, not budgeted — but skip lights authored off
+		# (active=false): they never emit, so they don't hit perf.
+		var dcl_light := node as DclLightSourceComponent
+		if dcl_light.runtime_light_enabled:
+			acc["lights"] += 1
+			if dcl_light.runtime_shadows_enabled:
+				acc["shadow_casters"] += 1
 	for c in node.get_children():
 		_walk_scene_resources(c, acc, geos, mats, texs, tri_cache)
 

--- a/godot/src/ui/components/utils/scene_limits.gd
+++ b/godot/src/ui/components/utils/scene_limits.gd
@@ -33,7 +33,16 @@ const FIXED: Dictionary = {
 	{"label": "Materials", "group": "scene", "unit": "count", "soft": 400, "hard": 500},
 	"textures": {"label": "Textures", "group": "scene", "unit": "count", "soft": 400, "hard": 500},
 	"colliders":
+	# Anchored to the Rust runtime budgets (lib/.../particle_system.rs:
+	# SCENE_PARTICLE_BUDGET 50k, MAX_AMOUNT_PER_EMITTER 5k) and the High graphic
 	{"label": "Colliders", "group": "scene", "unit": "count", "soft": 1200, "hard": 1500},
+	# profile's 8 active lights (#2633). Authored counts, not budgeted.
+	"emitters": {"label": "VFX emitters", "group": "scene", "unit": "count", "soft": 8, "hard": 10},
+	"live_particles":
+	{"label": "Live particles", "group": "scene", "unit": "count", "soft": 25000, "hard": 50000},
+	"lights": {"label": "Light sources", "group": "scene", "unit": "count", "soft": 8, "hard": 16},
+	"shadow_casters":
+	{"label": "Shadow lights", "group": "scene", "unit": "count", "soft": 2, "hard": 4},
 	"content_size":
 	{
 		"label": "Content size",
@@ -81,6 +90,10 @@ const ORDER: Array = [
 	"materials",
 	"textures",
 	"colliders",
+	"emitters",
+	"live_particles",
+	"lights",
+	"shadow_casters",
 	"content_size",
 	"external_size",
 	"static_mem",

--- a/godot/src/ui/components/utils/scene_limits.gd
+++ b/godot/src/ui/components/utils/scene_limits.gd
@@ -33,13 +33,15 @@ const FIXED: Dictionary = {
 	{"label": "Materials", "group": "scene", "unit": "count", "soft": 400, "hard": 500},
 	"textures": {"label": "Textures", "group": "scene", "unit": "count", "soft": 400, "hard": 500},
 	"colliders":
+	{"label": "Colliders", "group": "scene", "unit": "count", "soft": 1200, "hard": 1500},
+	"emitters":
 	# Anchored to the Rust runtime budgets (lib/.../particle_system.rs:
 	# SCENE_PARTICLE_BUDGET 50k, MAX_AMOUNT_PER_EMITTER 5k) and the High graphic
-	{"label": "Colliders", "group": "scene", "unit": "count", "soft": 1200, "hard": 1500},
-	# profile's 8 active lights (#2633). Authored counts, not budgeted.
-	"emitters": {"label": "VFX emitters", "group": "scene", "unit": "count", "soft": 8, "hard": 10},
+	# profile's 8 active lights (#2633). Authored counts, not budgeted. Applies
+	# to the 4 rows below.
+	{"label": "VFX emitters", "group": "scene", "unit": "count", "soft": 8, "hard": 10},
 	"live_particles":
-	{"label": "Live particles", "group": "scene", "unit": "count", "soft": 25000, "hard": 50000},
+	{"label": "Particles", "group": "scene", "unit": "count", "soft": 25000, "hard": 50000},
 	"lights": {"label": "Light sources", "group": "scene", "unit": "count", "soft": 8, "hard": 16},
 	"shadow_casters":
 	{"label": "Shadow lights", "group": "scene", "unit": "count", "soft": 2, "hard": 4},

--- a/lib/src/scene_runner/components/particle_system.rs
+++ b/lib/src/scene_runner/components/particle_system.rs
@@ -458,6 +458,10 @@ fn apply_particle_system(
     let upper_cap = (max_particles as i32).clamp(1, MAX_AMOUNT_PER_EMITTER);
     let continuous = ((rate * lifetime as f32).ceil() as i32).max(0);
     let mut amount = continuous.max(burst_capacity as i32).clamp(1, upper_cap);
+    // Authored per-emitter amount (post per-emitter caps, pre scene-budget clamp),
+    // exposed for the scene-stats overlay: `amount` saturates at the runtime
+    // budget, so it can never signal an over-budget scene.
+    let authored_amount = amount;
     let used_elsewhere: i32 = scene
         .particle_systems
         .iter()
@@ -476,6 +480,7 @@ fn apply_particle_system(
     }
 
     node.set_amount(amount);
+    node.set_meta("dcl_authored_amount", &authored_amount.to_variant());
     node.set_lifetime(lifetime);
 
     let looping = value.r#loop.unwrap_or(true);


### PR DESCRIPTION
Closes #2674

## What

Adds 4 per-scene rows to the scene stats overlay (signal only, no runtime enforcement):

| Row | Soft | Hard | Anchor |
|---|---|---|---|
| VFX emitters | 8 | 10 | 50k scene budget / 5k per-emitter cap |
| Particles | 25,000 | 50,000 | `SCENE_PARTICLE_BUDGET` (particle_system.rs) |
| Light sources | 8 | 16 | High profile = 8 active lights (#2633) |
| Shadow lights | 2 | 4 | Shadow cost >> light cost |

## How

- `debug_collector.gd`: the single scene-rooted subtree walker now also counts every `GPUParticles3D` (authored, not playback-gated) and every `DclLightSourceComponent` (**authored, not budgeted**; skips lights authored `active=false` or torn down; shadow count uses the authored SDK value before profile overrides — so the overlay never contradicts the per-profile budget from #2633)
- `particle_system.rs`: exposes the pre-scene-budget particle amount as a `dcl_authored_amount` node meta — the runtime-clamped `amount` would saturate at the cap and the row could never overpass
- `scene_limits.gd`: 4 entries in `FIXED` + `ORDER`. Panel and collector wrapper untouched (both iterate rows dynamically)

## Audit (live readings via scene-inspector bridge)

| Scene | Emitters | Particles | Lights | Shadow lights |
|---|---|---|---|---|
| Genesis Plaza | 42 🔴 420% | 443 🟢 | 59 🔴 369% | 48 🔴 1200% |
| doriangray.dcl.eth | 0 🟢 | 0 🟢 | 16 🟡 100% | 0 🟢 |
| rituals.dcl.eth | 0 🟢 | 0 🟢 | 20 🔴 125% | 0 🟢 |

All three read green on legacy rows while authoring lights well past the engine budget; Genesis Plaza also authors 42 emitters against a budget of 10. Exactly the overheat blind spot the issue describes.

## Follow-ups

- Docs: decentraland/docs#189 (mobile optimization page)

## Test plan

1. Launch the explorer with the scene-stats overlay enabled: `cargo run -- run -- --fake-deeplink "decentraland://open?location=0,0&scene-stats=true"`
2. Once Genesis Plaza loads, open **Scene Status** from the HUD toolbar.
3. Confirm the four new rows appear between Colliders and Content size, in this order: VFX emitters, Live particles, Light sources, Shadow lights.
4. Confirm Genesis Plaza reads red on VFX emitters (~42, >10), Light sources (~59, >16) and Shadow lights (~48, >4), and green on Particles (~443, <25k).
5. Regression: confirm the pre-existing rows (triangles, entities, materials, etc.) show the same values as on `main` for the same scene.


