### PR TITLE
bump marketing version to v1.14.0

### DIFF
--- a/godot/export_presets.cfg
+++ b/godot/export_presets.cfg
@@ -42,7 +42,7 @@ architectures/x86=false
 architectures/x86_64=true
 ; placeholder — the real store versionCode is stamped at export time from DCL_BUILD_NUMBER (Cloudflare Worker allocator); this committed value never ships
 version/code=1
-version/name="1.13.0"
+version/name="1.14.0"
 package/unique_name="org.decentraland.godotexplorer"
 package/name="Decentraland"
 package/signed=true
@@ -295,7 +295,7 @@ application/provisioning_profile_specifier_release=""
 application/export_method_release=1
 application/bundle_identifier="org.decentraland.godotexplorer"
 application/signature=""
-application/short_version="1.13.0"
+application/short_version="1.14.0"
 ; placeholder — the real CFBundleVersion is stamped at export time from DCL_BUILD_NUMBER (Cloudflare Worker allocator); this committed value never ships
 application/version="1"
 application/additional_plist_content="	<key>CFBundleURLTypes</key>

--- a/lib/Cargo.lock
+++ b/lib/Cargo.lock
@@ -861,7 +861,7 @@ dependencies = [
 
 [[package]]
 name = "dclgodot"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dclgodot"
-version = "1.13.0"
+version = "1.14.0"
 edition = "2021"
 publish = false
 


### PR DESCRIPTION
Marketing version bump (minor): v1.13.0 -> v1.14.0.

Store build numbers (Android versionCode / iOS CFBundleVersion) are allocated from the Cloudflare Worker and stamped at build time — not changed here.

Same diff the `🔢 Bump Marketing Version` workflow produces, committed and signed locally (the workflow's bot commit is unsigned). Supersedes #2817.

## Test plan
- [ ] No QA needed — version strings only, no behavior change.

https://claude.ai/code/session_01GnQBgn1y33mfhpzibX36Cq