### PR TITLE
fix(mobile): charge swapped-out memory to the Android budget, and stop the stall detector firing while paused

### DIFF
--- a/lib/src/scene_runner/scene_manager.rs
+++ b/lib/src/scene_runner/scene_manager.rs
@@ -29,6 +29,7 @@ use crate::{
 use godot::{
     classes::{
         control::{LayoutPreset, MouseFilter},
+        notify::NodeNotification,
         PhysicsRayQueryParameters3D,
     },
     prelude::*,
@@ -2885,6 +2886,22 @@ impl INode for SceneManager {
             let viewport_size = viewport.get_visible_rect();
             self.viewport_center =
                 Vector2::new(viewport_size.size.x * 0.5, viewport_size.size.y * 0.5);
+        }
+    }
+
+    /// Tell the memory monitor when the OS pauses us. The main-thread heartbeat
+    /// stops on its own while the app is backgrounded (screen off, task switch),
+    /// which is not a freeze — without this the stall detector reports one
+    /// continuous "main thread UNRESPONSIVE" for as long as the screen is off.
+    fn on_notification(&mut self, what: NodeNotification) {
+        match what {
+            NodeNotification::APPLICATION_PAUSED => {
+                crate::tools::memory_monitor::APP_PAUSED.store(true, Ordering::Relaxed);
+            }
+            NodeNotification::APPLICATION_RESUMED => {
+                crate::tools::memory_monitor::APP_PAUSED.store(false, Ordering::Relaxed);
+            }
+            _ => {}
         }
     }
 

--- a/lib/src/tools/memory_monitor.rs
+++ b/lib/src/tools/memory_monitor.rs
@@ -20,11 +20,39 @@
 //!   - iOS: `os_proc_available_memory()` — bytes left before jetsam. Cheap,
 //!     off-thread-safe, and already reflects the *dynamic* per-device limit.
 //!   - Android: the smaller of the kernel's `MemAvailable` and a per-app budget
-//!     `budget(MemTotal) - RSS`, both from `/proc` (no precise per-app headroom
-//!     call exists, and JNI is not thread-safe to call here; `/proc` files are
-//!     readable from any thread). `MemAvailable` is the signal that tracks what
-//!     lowmemorykiller acts on — the budget alone cannot see a device that is
-//!     already full because of everything *else* running on it.
+//!     `budget(MemTotal) - (RSS + VmSwap)`, both from `/proc` (no precise per-app
+//!     headroom call exists, and JNI is not thread-safe to call here; `/proc`
+//!     files are readable from any thread). `MemAvailable` tracks how full the
+//!     device is because of everything *else* running on it, which the budget
+//!     alone cannot see; the budget counts swapped-out anonymous memory so a
+//!     device that pages our cold pages to zram does not read as a recovery.
+//!
+//! ### What Android does *not* let us see (measured, do not retry)
+//!
+//! Headroom in MB answers "how much is left", never "is reclaim still keeping
+//! up" — and that second question is the one that predicts a kill. On a Galaxy
+//! A54 (Android 16) lowmemorykiller killed the app while `MemAvailable` still
+//! read 510-570MB, i.e. LEVEL_OK by the bands below, because what ran out was
+//! the free-page watermark while reclaim fell behind. The signals that would
+//! have shown it coming are all denied to an unprivileged app by SELinux —
+//! verified from inside the sandbox with `run-as`:
+//!
+//! * `/proc/pressure/memory` (PSI, the signal lmkd itself acts on) — denied,
+//!   labelled `proc_pressure_mem`. The denial is `dontaudit`, so it does not
+//!   even show up as an avc line: the read just fails.
+//! * `/proc/vmstat` (direct-reclaim / allocstall counters) — denied.
+//! * `/proc/zoneinfo` (the kernel watermarks lmkd compares against) — denied.
+//!
+//! `ComponentCallbacks2.onTrimMemory`, the framework's own way of telling an app
+//! memory is tight, does reach the process (HWUI trims on it) but Godot 4.6.2
+//! does not forward it to `NOTIFICATION_OS_MEMORY_WARNING`, so it is not
+//! reachable from here either without an engine change.
+//!
+//! What is left to us is `/proc/meminfo` and our own `/proc/self/status`. That
+//! is enough to see *our own* growth honestly — the case this monitor exists for
+//! — but it cannot anticipate a kill driven by system-wide pressure from other
+//! apps. Do not add a signal here without checking it is readable under
+//! `run-as` first.
 //!
 //! * **Secondary hard-stop — `phys_footprint`** (iOS only, via
 //!   `proc_pid_rusage`). This is the value jetsam actually compares against and,
@@ -63,6 +91,14 @@ pub static MAIN_THREAD_HEARTBEAT: AtomicU32 = AtomicU32::new(0);
 /// so we capture the headroom trajectory at full resolution right up to a
 /// potential OOM crash — to learn how far a heavy scene gets before dying.
 pub static VERBOSE: AtomicBool = AtomicBool::new(false);
+
+/// True while the OS has the app paused (screen off, task switch). Set from the
+/// main thread in `SceneManager::on_notification`. The heartbeat legitimately
+/// stops while paused, so the stall detector has to hold instead of reporting:
+/// without this gate a locked screen reads as one continuous "main thread
+/// UNRESPONSIVE" for as long as the screen stays off (measured: ~321 s on a
+/// Galaxy A54, reported every 2 s).
+pub static APP_PAUSED: AtomicBool = AtomicBool::new(false);
 
 /// `phys_footprint` ceiling in MB above which we force CRITICAL, computed at
 /// [`start`] from device RAM so it scales across devices. 0 = disabled (unknown
@@ -139,11 +175,12 @@ pub fn start() {
             let total_ram_mb = read_meminfo_mb("MemTotal:");
             if total_ram_mb > 0 {
                 emit_log(&format!(
-                    "[MemMonitor] total_ram={}MB app_budget={}MB WARNING<={}MB CRITICAL<={}MB",
+                    "[MemMonitor] total_ram={}MB app_budget={}MB WARNING<={}MB CRITICAL<={}MB swap_total={}MB",
                     total_ram_mb,
                     (total_ram_mb as f32 * ANDROID_BUDGET_FRACTION) as i32,
                     WARNING_MB,
-                    CRITICAL_MB
+                    CRITICAL_MB,
+                    read_meminfo_mb("SwapTotal:")
                 ));
             }
         }
@@ -372,6 +409,9 @@ fn monitor_loop() {
         let footprint = read_footprint_mb();
         let level = level_for(available, footprint);
 
+        #[cfg(target_os = "android")]
+        SWAPPED_MB.store(read_self_status_mb("VmSwap:"), Ordering::Relaxed);
+
         AVAILABLE_MB.store(available, Ordering::Relaxed);
         FOOTPRINT_MB.store(footprint, Ordering::Relaxed);
         PRESSURE_LEVEL.store(level, Ordering::Relaxed);
@@ -380,9 +420,13 @@ fn monitor_loop() {
         // so we can watch the trajectory right up to (and through) a main-thread
         // freeze or an eventual OOM after "Continue anyway".
         if level > 0 || VERBOSE.load(Ordering::Relaxed) || tick % 8 == 0 {
+            #[cfg(target_os = "android")]
+            let swap_note = format!(" swap={}MB", SWAPPED_MB.load(Ordering::Relaxed));
+            #[cfg(not(target_os = "android"))]
+            let swap_note = "";
             emit_log(&format!(
-                "[MemMonitor] available={}MB footprint={}MB level={}",
-                available, footprint, level
+                "[MemMonitor] available={}MB footprint={}MB{} level={}",
+                available, footprint, swap_note, level
             ));
         }
 
@@ -390,7 +434,15 @@ fn monitor_loop() {
         // Plaza freeze happens with plenty of headroom (a CPU/GPU/lock stall, not
         // an OOM). This survives the freeze because it runs off the main thread.
         let hb = MAIN_THREAD_HEARTBEAT.load(Ordering::Relaxed);
-        if hb != last_hb {
+        if APP_PAUSED.load(Ordering::Relaxed) {
+            // Paused by the OS: the main loop is stopped on purpose, so a frozen
+            // heartbeat means nothing here. Hold the accounting rather than report
+            // a "freeze" that lasts as long as the screen is off.
+            last_hb = hb;
+            stall_ms = 0;
+            stall_reported = false;
+            last_report_ms = 0;
+        } else if hb != last_hb {
             if stall_reported {
                 emit_log(&format!(
                     "[MainThreadStall] RECOVERED after ~{}ms (available={}MB)",
@@ -471,8 +523,16 @@ fn read_available_mb() -> i32 {
     if total_mb <= 0 {
         return -1;
     }
+    // Charge the budget for what the app *owns*, not for what is resident.
+    // Android pushes cold anonymous pages to zram / RAM Plus, which drops RSS
+    // without the app freeing anything: measured on a Galaxy A54, 2816MB of
+    // allocations with ~800MB swapped out made this headroom "recover" from
+    // 533MB to 1076MB with nothing released — a WARNING that disarms itself
+    // while the app is still holding every byte. VmSwap puts them back on the
+    // bill; it is 0 on a device without swap, leaving the old behaviour.
+    let swap_mb = read_self_status_mb("VmSwap:").max(0);
     let budget = (total_mb as f32 * ANDROID_BUDGET_FRACTION) as i32;
-    let budget_headroom = (budget - rss_mb).max(0);
+    let budget_headroom = (budget - rss_mb - swap_mb).max(0);
 
     // MemAvailable is absent on pre-3.14 kernels; fall back to the budget alone.
     let system_headroom = read_meminfo_mb("MemAvailable:");
@@ -481,6 +541,12 @@ fn read_available_mb() -> i32 {
     }
     budget_headroom.min(system_headroom)
 }
+
+/// Anonymous memory of ours the kernel has pushed to zram / RAM Plus, in MB.
+/// Published so a log line stays self-explanatory: `footprint` is RSS (what lmkd
+/// reports when it kills us) while the budget headroom also charges this, so
+/// without it the two numbers cannot be reconciled from a capture. -1 elsewhere.
+pub static SWAPPED_MB: AtomicI32 = AtomicI32::new(-1);
 
 #[cfg(target_os = "android")]
 fn read_footprint_mb() -> i32 {
@@ -493,13 +559,27 @@ fn read_footprint_mb() -> i32 {
 }
 
 /// Read a `/proc/meminfo` field (`"MemTotal:"`, `"MemAvailable:"`, ...) in MB.
-/// -1 when the file or the key is unavailable. Values there are in kB.
+/// -1 when the file or the key is unavailable.
 #[cfg(target_os = "android")]
 fn read_meminfo_mb(key: &str) -> i32 {
-    let Ok(meminfo) = std::fs::read_to_string("/proc/meminfo") else {
+    read_kb_field_mb("/proc/meminfo", key)
+}
+
+/// Read a `/proc/self/status` field (`"VmSwap:"`, `"VmRSS:"`, ...) in MB.
+/// -1 when the file or the key is unavailable.
+#[cfg(target_os = "android")]
+fn read_self_status_mb(key: &str) -> i32 {
+    read_kb_field_mb("/proc/self/status", key)
+}
+
+/// Read a `<key> <value> kB` field out of a /proc file, in MB. -1 when the file
+/// or the key is unavailable. These files report kB.
+#[cfg(target_os = "android")]
+fn read_kb_field_mb(path: &str, key: &str) -> i32 {
+    let Ok(contents) = std::fs::read_to_string(path) else {
         return -1;
     };
-    for line in meminfo.lines() {
+    for line in contents.lines() {
         if let Some(rest) = line.strip_prefix(key) {
             if let Some(kb) = rest
                 .split_whitespace()


### PR DESCRIPTION
Stacked on #2721 — this targets its branch, so the diff here is only what came out of running that PR on a device.

Everything below was found on a Galaxy A54 (SM-A546E, 8GB RAM + 8GB swap, Android 16), driving the app's own memory from inside via the scene-inspector `eval`.

## What #2721 gets right, confirmed on device

Worth stating first, because two of the three changes here only matter *because* that PR works. On the A54 the corrected signal tracked reality to the MB — `available` equalled `MemAvailable` exactly when that was the binding limit, and `budget - RSS` when that was — and the whole chain fired end to end: `level=1` at 471MB, `level=2` at 192MB, then

```
[MemMonitor] CRITICAL available=197MB footprint=3892MB -> warn user (scene id=0)
```

with the "Low memory" modal on screen. The `[MemMonitor]` and `[MainThreadStall]` lines reaching logcat at all is what made all of this observable.

## Changes

### 1. The budget headroom charges swapped-out memory

`budget(MemTotal) - RSS` is not monotonic in what the app allocates. Android pushes cold anonymous pages to zram / RAM Plus, which drops RSS without the app releasing anything, so the headroom climbs back while the app still holds every byte. Measured: 2816MB of allocations with ~800MB swapped out made it "recover" from **533MB to 1076MB** with nothing freed — a WARNING that disarms itself.

Now it charges `RSS + VmSwap`. At the threshold crossing on the same device:

| | RSS | VmSwap | reported `available` | what `budget - RSS` would report |
|---|---|---|---|---|
| step 7 | 3013MB | 276MB | 810MB | 1076MB |
| step 8 | 3214MB | 333MB | 544MB | 875MB |
| step 9 | 3343MB | 431MB | **305MB → level=1** | 746MB → **level=0** |

`VmSwap` is 0 on a device without swap, so this changes nothing there.

### 2. The stall detector holds while the OS has the app paused

The heartbeat legitimately stops when Android pauses us — screen off, task switch — and the detector read that as one continuous freeze:

```
[MainThreadStall] main thread UNRESPONSIVE ~321000ms (available=2610MB footprint=1228MB level=0)
```

re-reported every 2s for as long as the screen stayed off. Those lines were invisible on Android before #2721, so without this gate that PR ships a permanent source of false freeze reports into logcat — diluting the real ones, which are accurate (a deliberate 5s main-thread block reported at 1000ms, again at 3000ms, and `RECOVERED after ~4750ms`).

`SceneManager::on_notification` publishes `APPLICATION_PAUSED`/`APPLICATION_RESUMED` into an atomic the monitor thread reads. There was no handling of those notifications anywhere in the repo before.

### 3. Documented what Android does not let us see

#2721's `read_available_mb` doc says `MemAvailable` "is the signal that tracks what lowmemorykiller acts on". On this device it is not: under external pressure lmkd killed the app with `MemAvailable` still at **510-570MB** — LEVEL_OK by the bands — giving `min2x watermark is breached even after kill` as its reason, with `MemFree` at 35-58MB. `MemAvailable` counts reclaimable page cache, and under a fast collapse the kernel cannot reclaim it in time, so it stays high right up to the kill.

The obvious fix is PSI, which is what lmkd itself watches. It is not available to us. Verified from inside the app sandbox with `run-as`:

```
DENIED  /proc/pressure/memory     (proc_pressure_mem)
DENIED  /proc/vmstat              (direct-reclaim / allocstall counters)
DENIED  /proc/zoneinfo            (the kernel watermarks lmkd compares against)
OK      /proc/meminfo
OK      /proc/self/status
```

The denials are `dontaudit`, so the read simply fails with no avc line to explain it. The framework route is closed too: `am send-trim-memory` does reach the process (HWUI trims on it), but Godot 4.6.2 never forwards it to `NOTIFICATION_OS_MEMORY_WARNING` — a handler attached to a live client saw nothing.

So the module doc now carries a section listing all of it, with the instruction to check readability under `run-as` before adding any new signal here. No behaviour change; it exists to stop the next person spending an afternoon on it.

### 4. `swap=` on the log line

`footprint` is RSS (what lmkd reports when it kills us) while the budget headroom also charges swap, so without it the two numbers on a line cannot be reconciled from a capture. The captures quoted above predate this field.

## What this still does not fix

- **A kill driven by system-wide pressure remains unforeseeable from inside the app.** The information needed is denied to us; what is left (`/proc/meminfo` plus our own `/proc/self/status`) sees our own growth honestly — which is the case this monitor exists for — but nothing else. Worth tempering the "makes the existing safety net actually work" claim: it works for the app's own footprint, not for the device being full because of everything else.
- **`WARNING_MB` / `CRITICAL_MB` are still absolute constants**, tuned for a ~4GB iPhone 13 and applied unchanged from a 4GB phone to a 12GB one.
- **The eviction branch is unreachable in practice.** The explorer never keeps more than one scene alive — `scenes` returned exactly one both in Genesis Plaza and on a road — and the handler skips the current scene, so `farthest` is always `None` and the only possible outcome is the modal. #2721 lists this under Known limits as a Genesis Plaza peculiarity; it is general.

## Test plan

Both fixes were verified on the device on a local debug build of this branch.

### Case 1 — Swapped-out memory keeps counting against us
**Setup:** an Android phone with swap enabled (Samsung RAM Plus, zram — check `SwapTotal` in `/proc/meminfo`).
**Steps:**
1. Open the app and enter any place.
2. Drive the app's own memory up until `[MemMonitor]` reports `level=1`.
3. Watch `VmSwap` in `/proc/<pid>/status` while it climbs.

- [ ] **Expected:** `available` falls monotonically as memory is allocated. It never climbs back while allocations are still held, even once `VmSwap` starts growing.
- [ ] **Expected:** `available` equals `app_budget - (VmRSS + VmSwap)` whenever that is below `MemAvailable`.

### Case 2 — No stall reports while the app is paused
**Platform:** Android.
**Steps:**
1. Open the app and let it reach the explorer.
2. Turn the screen off and leave it off for a minute.
3. Wake and unlock.

- [ ] **Expected:** no `[MainThreadStall]` lines at all for the whole time the screen was off, while `[MemMonitor]` samples keep flowing.
- [ ] **Regression:** a real freeze is still reported — the detector fires at ~1000ms and reports `RECOVERED` with the elapsed time.

### Case 3 — Regression: devices without swap
**Setup:** a phone with `SwapTotal: 0`.
**Steps:**
1. Open the app, enter Genesis Plaza, walk around for two minutes.

- [ ] **Expected:** behaviour identical to #2721 — `VmSwap` is 0, so the budget term is unchanged.
