### PR TITLE
feat(iap): instrument the credits flow

### DIFF
--- a/godot/src/global.gd
+++ b/godot/src/global.gd
@@ -19,7 +19,9 @@ signal open_settings
 signal open_settings_panel
 signal open_backpack(on_emotes: bool)
 signal open_discover
-signal open_credits
+## Opens the credits shop. Carries the entry point that asked for it, so the one
+## place that instantiates the page can report it (see Menu.async_show_credits).
+signal open_credits(source: String)
 signal open_own_profile
 signal open_profile_editor
 signal open_navbar_silently

--- a/godot/src/global.gd
+++ b/godot/src/global.gd
@@ -19,8 +19,7 @@ signal open_settings
 signal open_settings_panel
 signal open_backpack(on_emotes: bool)
 signal open_discover
-## Opens the credits shop. Carries the entry point that asked for it, so the one
-## place that instantiates the page can report it (see Menu.async_show_credits).
+## Carries the entry point, reported by Menu.async_show_credits.
 signal open_credits(source: String)
 signal open_own_profile
 signal open_profile_editor

--- a/godot/src/iap/iap_manager.gd
+++ b/godot/src/iap/iap_manager.gd
@@ -408,7 +408,13 @@ func _track_request(
 func _on_purchase_outcome(
 	outcome: String, product_id: String, reason: String, credits: int
 ) -> void:
-	var extra := {"product_id": product_id, "outcome": outcome}
+	# purchase_completed also fires for transactions StoreKit redelivers at launch, which
+	# never went through purchase(); flag them so they aren't counted as presses.
+	var extra := {
+		"product_id": product_id,
+		"outcome": outcome,
+		"user_initiated": _purchase_started_ms > 0,
+	}
 	if credits >= 0:
 		extra["credits_granted"] = credits
 	# 0 when the press never reached purchase(); report the outcome anyway.
@@ -949,7 +955,11 @@ func _async_signed_iap(path: String, method: int, body: String, context: String 
 		# after a purchase would emit that many identical error events. The retry loop
 		# already recovers from it.
 		print("[IAP] ", path, " transport/auth error: ", response.get_error())
-		_track_request(context, endpoint, method_name, false, -1, "transport", started)
+		# The promise is rejected for ANY non-2xx, so this is not only transport
+		# failures: the reason carries the server body, or the canonical status text
+		# when it was empty. Truncated like the unparseable-body log below.
+		var reason := str(response.get_error()).substr(0, _ERROR_BODY_EXCERPT_CHARS)
+		_track_request(context, endpoint, method_name, false, -1, reason, started)
 		return null
 	var status: int = response.status_code()
 	var json = response.get_string_response_as_json()

--- a/godot/src/iap/iap_manager.gd
+++ b/godot/src/iap/iap_manager.gd
@@ -76,8 +76,7 @@ const _CREDITS_BY_PRODUCT := {
 	"credits_tier_b3": 260,
 }
 
-# HTTP verb names for the Request Result event. Godot has no built-in mapping and
-# only these two are used by the IAP endpoints.
+# Godot has no built-in verb mapping; only these two are used here.
 const _METHOD_NAMES := {
 	HTTPClient.METHOD_GET: "GET",
 	HTTPClient.METHOD_POST: "POST",
@@ -185,16 +184,11 @@ var _transaction_history: Array = []
 var _overlay_token: int = 0
 var _overlay: CanvasLayer = null
 var _purchase_in_flight: bool = false
-# Authoritative StoreKit environment and how it was determined, retained after
-# _on_environment_resolved so analytics_context() can report which backend this
-# device is actually pointed at.
+# Retained from _on_environment_resolved for analytics_context().
 var _env_authoritative: String = ""
 var _env_source: String = ""
 var _can_make_payments: bool = false
-# Whether _apply_storekit_env switched to Option D, and — when it did not — which
-# gate stopped it. A sandbox device that never switched is talking to the
-# production credits-server and cannot complete a purchase; nothing else we emit
-# records that.
+# Whether _apply_storekit_env switched, and which gate stopped it if not.
 var _option_d_applied: bool = false
 var _option_d_skip_reason: String = ""
 # Time.get_ticks_msec() at the last purchase() press, for the outcome's duration.
@@ -240,7 +234,6 @@ func report_environment_to_analytics() -> void:
 func _on_environment_resolved(environment: String, source: String, resolve_ms: float) -> void:
 	var env_at_ms := Time.get_ticks_msec() - Global._startup_time
 	var matched := environment == _env_sync_value
-	# Retained for analytics_context().
 	_env_authoritative = environment
 	_env_source = source
 	_can_make_payments = _store_kit.can_make_payments()
@@ -298,9 +291,7 @@ func _on_environment_resolved(environment: String, source: String, resolve_ms: f
 # before this has applied.
 #
 # Gated on two conditions so it never overrides a developer/QA choice:
-#  - PRODUCTION builds only (release export template). A debug/dev build run on a
-#    device with a sandbox Apple ID also reports `sandbox`, but there the dev's
-#    chosen env (default org or --dclenv) must be respected.
+#  - Not on `-dev` builds: there the dev's chosen env (default org or --dclenv) wins.
 #  - Only an EXPLICIT `dclenv=org` exempts from the switch. Passing
 #    `decentraland://open?dclenv=org` (or `--dclenv org`) means "really use the prod
 #    .org backend" and wins. Any OTHER explicit env is not special-cased here — it
@@ -310,15 +301,13 @@ func _on_environment_resolved(environment: String, source: String, resolve_ms: f
 # environment on every launch.
 func _apply_storekit_env(environment: String) -> void:
 	if environment != "sandbox":
-		# The correct no-op: a real App Store install belongs on .org.
 		_option_d_skip_reason = "not_sandbox"
 		return
-	# Only production (release export template) builds auto-switch. A debug/dev build
-	# run on a device with a sandbox Apple ID also reports "sandbox", but there we must
-	# respect the dev's chosen env (org by default or --dclenv).
-	if OS.is_debug_build():
-		print("[IAP] StoreKit sandbox on a debug build — not forcing the Option D env")
-		_option_d_skip_reason = "debug_build"
+	# NOT OS.is_debug_build(): the iOS export always uses the debug template, so that
+	# check disabled this switch on every shipped build, review included.
+	if Global.is_dev():
+		print("[IAP] StoreKit sandbox on a dev build — not forcing the Option D env")
+		_option_d_skip_reason = "dev_build"
 		return
 	var current := str(DclGlobal.get_dcl_environment())
 	# The only explicit override that exempts from the switch is dclenv=org
@@ -363,13 +352,8 @@ func async_await_env_resolved(timeout_sec: float = 5.0) -> void:
 		)
 
 
-## The backend-selection snapshot, as a JSON string for an analytics event's
-## `extra_properties`. Attached to every credits click and to every IAP request
-## result, because the question those events exist to answer is which backend the
-## device was talking to — and `option_d_applied` is the field that answers it.
-##
-## Safe to call before the StoreKit environment has resolved: the storekit_* fields
-## are simply empty until then.
+## Which backend this device is pointed at, as JSON for an event's `extra_properties`.
+## Safe before the StoreKit env resolves — the storekit_* fields are empty until then.
 func analytics_context() -> String:
 	return (
 		JSON
@@ -402,8 +386,7 @@ func _track_request(
 	started_ms: int,
 	extra: Dictionary = {}
 ) -> void:
-	# Opt-in: a call site that passes no context reports nothing. Keeps the event a
-	# set of deliberately-watched calls rather than a traffic log.
+	# Opt-in: no context, no event.
 	if context.is_empty() or Global.metrics == null:
 		return
 	var payload := JSON.parse_string(analytics_context()) as Dictionary
@@ -420,20 +403,15 @@ func _track_request(
 	)
 
 
-# The StoreKit purchase round-trip reported through the same generic event as the
-# backend calls: it is a request with a wait and an outcome, and keeping it here
-# means one query answers "what happened after the user pressed buy".
-#
-# Wired to our own outcome signals rather than to each of the eight emit sites, so
-# a new exit path reports itself for free.
+# Wired to our own outcome signals rather than to each of the eight emit sites, so a
+# new exit path reports itself for free.
 func _on_purchase_outcome(
 	outcome: String, product_id: String, reason: String, credits: int
 ) -> void:
 	var extra := {"product_id": product_id, "outcome": outcome}
 	if credits >= 0:
 		extra["credits_granted"] = credits
-	# _purchase_started_ms is 0 when the press never reached purchase() (it bailed on
-	# a missing wallet); report the outcome anyway rather than inventing a duration.
+	# 0 when the press never reached purchase(); report the outcome anyway.
 	var started: int = _purchase_started_ms if _purchase_started_ms > 0 else Time.get_ticks_msec()
 	_track_request(
 		"iap_purchase",
@@ -986,10 +964,8 @@ func _async_signed_iap(path: String, method: int, body: String, context: String 
 		)
 		_track_request(context, endpoint, method_name, false, status, "unparseable", started)
 		return null
-	# A business refusal is HTTP 200 with ok:false + a `code`. From the caller's side
-	# that is the same outcome as a transport failure, so it reports as not-ok with the
-	# server's own code as the error — which is what makes `cap_exceeded` and
-	# `service_daily_limit` groupable next to the transport failures.
+	# A business refusal (HTTP 200 + ok:false) is the same outcome as a transport
+	# failure for the caller, so it reports as not-ok with the server's code.
 	var ok := true
 	var error := ""
 	if json.has("ok") and not json.get("ok", false):
@@ -999,8 +975,7 @@ func _async_signed_iap(path: String, method: int, body: String, context: String 
 	return json
 
 
-# Wallet-scoped paths must not become high-cardinality event values, and an address
-# has no business being in analytics as a path segment.
+# Keeps wallet-scoped paths from becoming high-cardinality event values.
 func _normalize_endpoint(path: String) -> String:
 	var wallet := _wallet_address()
 	if wallet.is_empty():

--- a/godot/src/iap/iap_manager.gd
+++ b/godot/src/iap/iap_manager.gd
@@ -76,6 +76,13 @@ const _CREDITS_BY_PRODUCT := {
 	"credits_tier_b3": 260,
 }
 
+# HTTP verb names for the Request Result event. Godot has no built-in mapping and
+# only these two are used by the IAP endpoints.
+const _METHOD_NAMES := {
+	HTTPClient.METHOD_GET: "GET",
+	HTTPClient.METHOD_POST: "POST",
+}
+
 # Bound how long the purchase overlay stays up. StoreKit prompt + validation
 # should land well inside this; past it we assume something stuck (network
 # drop, redelivery loop, missing signal) and let the user retry.
@@ -178,6 +185,20 @@ var _transaction_history: Array = []
 var _overlay_token: int = 0
 var _overlay: CanvasLayer = null
 var _purchase_in_flight: bool = false
+# Authoritative StoreKit environment and how it was determined, retained after
+# _on_environment_resolved so analytics_context() can report which backend this
+# device is actually pointed at.
+var _env_authoritative: String = ""
+var _env_source: String = ""
+var _can_make_payments: bool = false
+# Whether _apply_storekit_env switched to Option D, and — when it did not — which
+# gate stopped it. A sandbox device that never switched is talking to the
+# production credits-server and cannot complete a purchase; nothing else we emit
+# records that.
+var _option_d_applied: bool = false
+var _option_d_skip_reason: String = ""
+# Time.get_ticks_msec() at the last purchase() press, for the outcome's duration.
+var _purchase_started_ms: int = 0
 
 
 func _ready() -> void:
@@ -219,6 +240,10 @@ func report_environment_to_analytics() -> void:
 func _on_environment_resolved(environment: String, source: String, resolve_ms: float) -> void:
 	var env_at_ms := Time.get_ticks_msec() - Global._startup_time
 	var matched := environment == _env_sync_value
+	# Retained for analytics_context().
+	_env_authoritative = environment
+	_env_source = source
+	_can_make_payments = _store_kit.can_make_payments()
 	print(
 		(
 			"[IAP] StoreKit env: authoritative=%s (%s) sync=%s match=%s resolve=%dms sync@%dms env@%dms"
@@ -285,12 +310,15 @@ func _on_environment_resolved(environment: String, source: String, resolve_ms: f
 # environment on every launch.
 func _apply_storekit_env(environment: String) -> void:
 	if environment != "sandbox":
+		# The correct no-op: a real App Store install belongs on .org.
+		_option_d_skip_reason = "not_sandbox"
 		return
 	# Only production (release export template) builds auto-switch. A debug/dev build
 	# run on a device with a sandbox Apple ID also reports "sandbox", but there we must
 	# respect the dev's chosen env (org by default or --dclenv).
 	if OS.is_debug_build():
 		print("[IAP] StoreKit sandbox on a debug build — not forcing the Option D env")
+		_option_d_skip_reason = "debug_build"
 		return
 	var current := str(DclGlobal.get_dcl_environment())
 	# The only explicit override that exempts from the switch is dclenv=org
@@ -299,12 +327,16 @@ func _apply_storekit_env(environment: String) -> void:
 	# check below.
 	if Global.dcl_env_explicit and current == "org":
 		print("[IAP] StoreKit sandbox, but explicit dclenv=org — staying on .org")
+		_option_d_skip_reason = "explicit_org"
 		return
 	if current != "org":
 		print("[IAP] StoreKit sandbox, but dclenv already '", current, "' — leaving as-is")
+		_option_d_skip_reason = "already_overridden"
 		return
 	print("[IAP] StoreKit sandbox → switching to Option D hybrid env: ", _SANDBOX_DCLENV)
 	DclGlobal.set_dcl_environment(_SANDBOX_DCLENV)
+	_option_d_applied = true
+	_option_d_skip_reason = ""
 
 
 # Blocks the caller until the AUTHORITATIVE StoreKit environment has resolved and
@@ -329,6 +361,91 @@ func async_await_env_resolved(timeout_sec: float = 5.0) -> void:
 		printerr(
 			"[IAP] env resolve timed out after ", timeout_sec, "s; proceeding with current env"
 		)
+
+
+## The backend-selection snapshot, as a JSON string for an analytics event's
+## `extra_properties`. Attached to every credits click and to every IAP request
+## result, because the question those events exist to answer is which backend the
+## device was talking to — and `option_d_applied` is the field that answers it.
+##
+## Safe to call before the StoreKit environment has resolved: the storekit_* fields
+## are simply empty until then.
+func analytics_context() -> String:
+	return (
+		JSON
+		. stringify(
+			{
+				"dcl_environment": str(DclGlobal.get_dcl_environment()),
+				"option_d_applied": _option_d_applied,
+				"option_d_skip_reason": _option_d_skip_reason,
+				"storekit_environment": _env_authoritative,
+				"storekit_environment_sync": _env_sync_value,
+				"storekit_source": _env_source,
+				"can_make_payments": _can_make_payments,
+				"credits_server": DclUrls.credits_server(),
+				"balance": _balance,
+				# 0 means an empty storefront — the user saw no packs at all, which is a
+				# different failure from a refused charge.
+				"products_loaded": _products.size(),
+			}
+		)
+	)
+
+
+func _track_request(
+	context: String,
+	endpoint: String,
+	method: String,
+	ok: bool,
+	status: int,
+	error: String,
+	started_ms: int,
+	extra: Dictionary = {}
+) -> void:
+	# Opt-in: a call site that passes no context reports nothing. Keeps the event a
+	# set of deliberately-watched calls rather than a traffic log.
+	if context.is_empty() or Global.metrics == null:
+		return
+	var payload := JSON.parse_string(analytics_context()) as Dictionary
+	payload.merge(extra, true)
+	Global.metrics.track_request_result(
+		context,
+		endpoint,
+		method,
+		ok,
+		status,
+		error,
+		Time.get_ticks_msec() - started_ms,
+		JSON.stringify(payload)
+	)
+
+
+# The StoreKit purchase round-trip reported through the same generic event as the
+# backend calls: it is a request with a wait and an outcome, and keeping it here
+# means one query answers "what happened after the user pressed buy".
+#
+# Wired to our own outcome signals rather than to each of the eight emit sites, so
+# a new exit path reports itself for free.
+func _on_purchase_outcome(
+	outcome: String, product_id: String, reason: String, credits: int
+) -> void:
+	var extra := {"product_id": product_id, "outcome": outcome}
+	if credits >= 0:
+		extra["credits_granted"] = credits
+	# _purchase_started_ms is 0 when the press never reached purchase() (it bailed on
+	# a missing wallet); report the outcome anyway rather than inventing a duration.
+	var started: int = _purchase_started_ms if _purchase_started_ms > 0 else Time.get_ticks_msec()
+	_track_request(
+		"iap_purchase",
+		"storekit/purchase",
+		"STOREKIT",
+		outcome == "completed",
+		-1,
+		"" if outcome == "completed" else reason if not reason.is_empty() else outcome,
+		started,
+		extra
+	)
+	_purchase_started_ms = 0
 
 
 # Idempotent. Called from _ready on iOS. Performs the StoreKit wiring (signal
@@ -359,6 +476,15 @@ func enable() -> void:
 	print("[IAP] starting StoreKit listener; can_make_payments=", _store_kit.can_make_payments())
 	_store_kit.start_listening()
 	_store_kit.load_products(PRODUCT_IDS)
+
+	purchase_completed.connect(
+		func(pid: String, credits: int): _on_purchase_outcome("completed", pid, "", credits)
+	)
+	purchase_failed.connect(
+		func(pid: String, reason: String): _on_purchase_outcome("failed", pid, reason, -1)
+	)
+	purchase_cancelled.connect(func(pid: String): _on_purchase_outcome("cancelled", pid, "", -1))
+	purchase_pending.connect(func(pid: String): _on_purchase_outcome("pending", pid, "", -1))
 
 	# Global.player_identity is created during Global._ready (earlier in the
 	# autoload chain) but added to the tree via call_deferred — defer so the
@@ -420,6 +546,7 @@ func purchase(product_id: String) -> void:
 	# authoritative pre-purchase gate; only on `allowed` do we hand off to
 	# StoreKit. _async_begin_purchase owns the flow from here.
 	_purchase_in_flight = true
+	_purchase_started_ms = Time.get_ticks_msec()
 	_show_overlay()
 	_async_begin_purchase(product_id, wallet)
 
@@ -431,7 +558,9 @@ func _async_begin_purchase(product_id: String, wallet: String) -> void:
 	# On `allowed` the server also registers this wallet's appAccountToken so the
 	# webhook can resolve who to credit.
 	var body := JSON.stringify({"productId": product_id})
-	var envelope = await _async_signed_iap("/credits/iap/quote", HTTPClient.METHOD_POST, body)
+	var envelope = await _async_signed_iap(
+		"/credits/iap/quote", HTTPClient.METHOD_POST, body, "iap_quote"
+	)
 	# null == transport/auth failure (non-2xx, timeout). Fail closed: do NOT charge.
 	if envelope == null:
 		_finish_purchase_flow()
@@ -631,7 +760,9 @@ func _async_credit_with_backend(tx: Dictionary) -> int:
 		printerr("[IAP] missing JWS; cannot credit")
 		return _OUTCOME_REJECTED
 	var body := JSON.stringify({"jwsRepresentation": jws})
-	var envelope = await _async_signed_iap("/credits/iap/verify", HTTPClient.METHOD_POST, body)
+	var envelope = await _async_signed_iap(
+		"/credits/iap/verify", HTTPClient.METHOD_POST, body, "iap_verify"
+	)
 	# null == transport error (non-2xx / HTTP 500 / timeout) -> transient -> RETRY.
 	if envelope == null:
 		printerr("[IAP] verify transport error; will retry on next launch")
@@ -695,7 +826,7 @@ func _async_register_token() -> void:
 	# later launch that never went through a fresh quote. Idempotent server-side.
 	if _wallet_address().is_empty():
 		return
-	await _async_signed_iap("/credits/iap/register", HTTPClient.METHOD_POST, "{}")
+	await _async_signed_iap("/credits/iap/register", HTTPClient.METHOD_POST, "{}", "iap_register")
 
 
 # gdlint:ignore = async-function-name
@@ -818,7 +949,7 @@ func _async_poll_balance_after_purchase() -> void:
 
 
 # gdlint:ignore = async-function-name
-func _async_signed_iap(path: String, method: int, body: String) -> Variant:
+func _async_signed_iap(path: String, method: int, body: String, context: String = "") -> Variant:
 	# DCL signed-fetch (ADR-44) call to the IAP backend. Returns the parsed JSON
 	# response on any HTTP 2xx, or null on a transport error (non-2xx, timeout,
 	# unparseable). Some endpoints wrap their result in {ok, data, ...} and others
@@ -830,6 +961,9 @@ func _async_signed_iap(path: String, method: int, body: String) -> Variant:
 	# folded header. Safe here and nowhere else on this client — credits-server reads
 	# `productId` off the body and never touches `authMetadata`.
 	var url := DclUrls.credits_server() + path
+	var endpoint := _normalize_endpoint(path)
+	var method_name := _METHOD_NAMES.get(method, "OTHER") as String
+	var started := Time.get_ticks_msec()
 	var response = await Global.async_signed_fetch(url, method, body, true)
 	if response is PromiseError:
 		# `print`, not `printerr`: `_async_poll_balance_after_purchase` calls this
@@ -837,7 +971,9 @@ func _async_signed_iap(path: String, method: int, body: String) -> Variant:
 		# after a purchase would emit that many identical error events. The retry loop
 		# already recovers from it.
 		print("[IAP] ", path, " transport/auth error: ", response.get_error())
+		_track_request(context, endpoint, method_name, false, -1, "transport", started)
 		return null
+	var status: int = response.status_code()
 	var json = response.get_string_response_as_json()
 	if not (json is Dictionary):
 		# Truncated on purpose: this body is wallet-scoped purchase data, and when the
@@ -848,8 +984,28 @@ func _async_signed_iap(path: String, method: int, body: String) -> Variant:
 			" unparseable response: ",
 			response.get_string_response().substr(0, _ERROR_BODY_EXCERPT_CHARS)
 		)
+		_track_request(context, endpoint, method_name, false, status, "unparseable", started)
 		return null
+	# A business refusal is HTTP 200 with ok:false + a `code`. From the caller's side
+	# that is the same outcome as a transport failure, so it reports as not-ok with the
+	# server's own code as the error — which is what makes `cap_exceeded` and
+	# `service_daily_limit` groupable next to the transport failures.
+	var ok := true
+	var error := ""
+	if json.has("ok") and not json.get("ok", false):
+		ok = false
+		error = str(json.get("code", "denied"))
+	_track_request(context, endpoint, method_name, ok, status, error, started)
 	return json
+
+
+# Wallet-scoped paths must not become high-cardinality event values, and an address
+# has no business being in analytics as a path segment.
+func _normalize_endpoint(path: String) -> String:
+	var wallet := _wallet_address()
+	if wallet.is_empty():
+		return path
+	return path.replace(wallet, ":address")
 
 
 func _wallet_address() -> String:

--- a/godot/src/ui/components/molecules/credit_option_item/credit_option_item.gd
+++ b/godot/src/ui/components/molecules/credit_option_item/credit_option_item.gd
@@ -71,6 +71,14 @@ func _find_product(pid: String) -> Dictionary:
 func _on_button_price_pressed() -> void:
 	if product_id.is_empty():
 		return
+	# The press itself, before the terms gate and before StoreKit. A press with no
+	# matching "Request Result" for context iap_purchase is the signal that the flow
+	# died on the way — which is exactly what we could not see during App Review.
+	if Global.metrics != null:
+		var extra := JSON.parse_string(Iap.analytics_context()) as Dictionary
+		extra["product_id"] = product_id
+		extra["terms_accepted"] = Iap.are_terms_accepted()
+		Global.metrics.track_click_button("BUY_PACK", "CREDITS_SHOP", JSON.stringify(extra))
 	if not Iap.are_terms_accepted():
 		_async_show_terms_then_purchase()
 		return

--- a/godot/src/ui/components/molecules/credit_option_item/credit_option_item.gd
+++ b/godot/src/ui/components/molecules/credit_option_item/credit_option_item.gd
@@ -71,9 +71,8 @@ func _find_product(pid: String) -> Dictionary:
 func _on_button_price_pressed() -> void:
 	if product_id.is_empty():
 		return
-	# The press itself, before the terms gate and before StoreKit. A press with no
-	# matching "Request Result" for context iap_purchase is the signal that the flow
-	# died on the way — which is exactly what we could not see during App Review.
+	# The press itself, before the terms gate and before StoreKit: a press with no
+	# matching iap_purchase result means the flow died on the way.
 	if Global.metrics != null:
 		var extra := JSON.parse_string(Iap.analytics_context()) as Dictionary
 		extra["product_id"] = product_id

--- a/godot/src/ui/components/molecules/credits_balance_button/credits_balance_button.gd
+++ b/godot/src/ui/components/molecules/credits_balance_button/credits_balance_button.gd
@@ -50,4 +50,4 @@ func _on_balance_changed(new_balance: int) -> void:
 
 func _on_pressed() -> void:
 	Global.metrics.track_click_button("BUTTON_CREDITS", "CREDITS_BALANCE_BUTTON", "")
-	Global.open_credits.emit()
+	Global.open_credits.emit("balance_button")

--- a/godot/src/ui/components/molecules/credits_balance_button/credits_balance_button.gd
+++ b/godot/src/ui/components/molecules/credits_balance_button/credits_balance_button.gd
@@ -49,5 +49,8 @@ func _on_balance_changed(new_balance: int) -> void:
 
 
 func _on_pressed() -> void:
+	# Kept for continuity with the pre-OPEN_CREDITS series. This press therefore emits
+	# two Click Buttons; count shop opens on OPEN_CREDITS, which covers all three
+	# entry points, not on an unfiltered Click Button.
 	Global.metrics.track_click_button("BUTTON_CREDITS", "CREDITS_BALANCE_BUTTON", "")
-	Global.open_credits.emit("balance_button")
+	Global.open_credits.emit("BALANCE_BUTTON")

--- a/godot/src/ui/components/molecules/marketplace_cta_card/marketplace_cta_button.gd
+++ b/godot/src/ui/components/molecules/marketplace_cta_card/marketplace_cta_button.gd
@@ -45,4 +45,4 @@ func _on_pressed():
 	if can_afford:
 		MarketplaceTracker.open_and_track(DclUrls.marketplace_browse(marketplace_section))
 	else:
-		Global.open_credits.emit()
+		Global.open_credits.emit("marketplace_cta")

--- a/godot/src/ui/components/molecules/marketplace_cta_card/marketplace_cta_button.gd
+++ b/godot/src/ui/components/molecules/marketplace_cta_card/marketplace_cta_button.gd
@@ -45,4 +45,4 @@ func _on_pressed():
 	if can_afford:
 		MarketplaceTracker.open_and_track(DclUrls.marketplace_browse(marketplace_section))
 	else:
-		Global.open_credits.emit("marketplace_cta")
+		Global.open_credits.emit("MARKETPLACE_CTA")

--- a/godot/src/ui/components/molecules/wearable_item/wearable_item.gd
+++ b/godot/src/ui/components/molecules/wearable_item/wearable_item.gd
@@ -167,7 +167,7 @@ func _on_action_pressed():
 	if Iap.get_balance() >= marketplace_price and not marketplace_url.is_empty():
 		MarketplaceTracker.open_and_track(marketplace_url)
 	else:
-		Global.open_credits.emit("wearable_item")
+		Global.open_credits.emit("WEARABLE_ITEM")
 
 
 func _update_category_icon(wearable: DclItemEntityDefinition):

--- a/godot/src/ui/components/molecules/wearable_item/wearable_item.gd
+++ b/godot/src/ui/components/molecules/wearable_item/wearable_item.gd
@@ -167,7 +167,7 @@ func _on_action_pressed():
 	if Iap.get_balance() >= marketplace_price and not marketplace_url.is_empty():
 		MarketplaceTracker.open_and_track(marketplace_url)
 	else:
-		Global.open_credits.emit()
+		Global.open_credits.emit("wearable_item")
 
 
 func _update_category_icon(wearable: DclItemEntityDefinition):

--- a/godot/src/ui/components/organisms/menu/menu.gd
+++ b/godot/src/ui/components/organisms/menu/menu.gd
@@ -158,10 +158,8 @@ func async_show_discover(open_menu := true):
 func async_show_credits(source: String = "unknown"):
 	if is_instance_valid(_credits_page):
 		return
-	# Tracked here rather than on each button: this is the one place the page is
-	# instantiated, so a new entry point reports itself for free. Two of the three
-	# existing ones had no telemetry at all, which is why a reviewer opening the shop
-	# and finding nothing to buy left no trace.
+	# Tracked here, not per button: the one place the page is instantiated, so a new
+	# entry point reports itself for free.
 	if Global.metrics != null:
 		Global.metrics.track_click_button("OPEN_CREDITS", source, Iap.analytics_context())
 	_open()

--- a/godot/src/ui/components/organisms/menu/menu.gd
+++ b/godot/src/ui/components/organisms/menu/menu.gd
@@ -155,9 +155,15 @@ func async_show_discover(open_menu := true):
 		_open()
 
 
-func async_show_credits():
+func async_show_credits(source: String = "unknown"):
 	if is_instance_valid(_credits_page):
 		return
+	# Tracked here rather than on each button: this is the one place the page is
+	# instantiated, so a new entry point reports itself for free. Two of the three
+	# existing ones had no telemetry at all, which is why a reviewer opening the shop
+	# and finding nothing to buy left no trace.
+	if Global.metrics != null:
+		Global.metrics.track_click_button("OPEN_CREDITS", source, Iap.analytics_context())
 	_open()
 	_credits_was_portrait = Global.is_orientation_portrait()
 	Global.set_orientation_portrait()

--- a/godot/src/ui/components/organisms/menu/menu.gd
+++ b/godot/src/ui/components/organisms/menu/menu.gd
@@ -155,7 +155,7 @@ func async_show_discover(open_menu := true):
 		_open()
 
 
-func async_show_credits(source: String = "unknown"):
+func async_show_credits(source: String = "UNKNOWN"):
 	if is_instance_valid(_credits_page):
 		return
 	# Tracked here, not per button: the one place the page is instantiated, so a new

--- a/lib/src/analytics/data_definition.rs
+++ b/lib/src/analytics/data_definition.rs
@@ -79,6 +79,7 @@ pub enum SegmentEvent {
     // (see SegmentEventLoading). Boxed: it is the largest variant by far.
     Loading(Box<SegmentEventLoading>),
     GuestWalletCreation(SegmentEventGuestWalletCreation),
+    RequestResult(SegmentEventRequestResult),
 }
 
 /// Cross-system correlation anchor. The ONLY Segment event that carries the Firebase Analytics
@@ -658,6 +659,48 @@ pub struct SegmentEventGuestWalletCreation {
     pub duration_ms: u32,
 }
 
+// Outcome of one watched request. Deliberately generic and OPT-IN: a call site
+// passes a `context` tag and gets one event per call. It is not wired into the
+// HTTP layer wholesale — the point is a handful of deliberately-watched calls,
+// not a traffic log, and Segment volume is not free.
+//
+// "Request" is read broadly: anything with a call, a wait and an outcome. The
+// StoreKit purchase round-trip reports through here too (`endpoint` =
+// "storekit/purchase"), so a flow's UI clicks and its outcomes stay in two tables
+// instead of one bespoke table per feature.
+//
+// Anything feature-specific belongs in `extra_properties`, exactly like
+// SegmentEventClickButton — that is what keeps this event from growing a column
+// per caller.
+#[derive(Serialize, Clone)]
+pub struct SegmentEventRequestResult {
+    // What was being attempted: "iap_quote" | "iap_verify" | "iap_balance" |
+    // "iap_purchase" | ... . Group by this first.
+    pub context: String,
+    // Normalised path, never a full URL: no wallet addresses, no ids. The host is
+    // implied by the environment and belongs in `extra_properties` when it matters
+    // (for IAP it does — it is the whole question).
+    pub endpoint: String,
+    // "GET" | "POST" | ... . "STOREKIT" for the native purchase round-trip.
+    pub method: String,
+    // Whether the caller got what it asked for. False covers a transport failure, a
+    // non-2xx, an unparseable body AND a business-level refusal (HTTP 200 + ok:false),
+    // because from the caller's side those are the same outcome.
+    pub ok: bool,
+    // HTTP status when there was one. None on a transport failure or a non-HTTP call.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status: Option<u32>,
+    // Short failure bucket or server error code ("transport", "unparseable",
+    // "cap_exceeded", "user_cancelled", ...). None when ok.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+    // Wall-clock duration of the attempt in milliseconds.
+    pub duration_ms: u32,
+    // JSON with extra payload, in case we need to track additional metadata.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub extra_properties: Option<String>,
+}
+
 pub fn build_segment_event_batch_item(
     user_id: String,
     common: &SegmentEventCommonExplorerFields,
@@ -763,6 +806,11 @@ pub fn build_segment_event_batch_item(
         ),
         SegmentEvent::GuestWalletCreation(event) => (
             "Guest Wallet Creation".to_string(),
+            serde_json::to_value(event).unwrap(),
+            None,
+        ),
+        SegmentEvent::RequestResult(event) => (
+            "Request Result".to_string(),
             serde_json::to_value(event).unwrap(),
             None,
         ),

--- a/lib/src/analytics/data_definition.rs
+++ b/lib/src/analytics/data_definition.rs
@@ -674,7 +674,9 @@ pub struct SegmentEventRequestResult {
     // False covers transport failure, non-2xx, unparseable body, and a business
     // refusal (HTTP 200 + ok:false) — the same outcome from the caller's side.
     pub ok: bool,
-    // HTTP status when there was one. None on a transport failure or a non-HTTP call.
+    // HTTP status when the caller could recover one. None for a non-HTTP call and for
+    // any failure surfaced as a rejected promise, which is every non-2xx — those carry
+    // the server's reason in `error` instead.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub status: Option<u32>,
     // Failure bucket or server code ("transport", "unparseable", "cap_exceeded", ...).

--- a/lib/src/analytics/data_definition.rs
+++ b/lib/src/analytics/data_definition.rs
@@ -659,39 +659,25 @@ pub struct SegmentEventGuestWalletCreation {
     pub duration_ms: u32,
 }
 
-// Outcome of one watched request. Deliberately generic and OPT-IN: a call site
-// passes a `context` tag and gets one event per call. It is not wired into the
-// HTTP layer wholesale — the point is a handful of deliberately-watched calls,
-// not a traffic log, and Segment volume is not free.
-//
-// "Request" is read broadly: anything with a call, a wait and an outcome. The
-// StoreKit purchase round-trip reports through here too (`endpoint` =
-// "storekit/purchase"), so a flow's UI clicks and its outcomes stay in two tables
-// instead of one bespoke table per feature.
-//
-// Anything feature-specific belongs in `extra_properties`, exactly like
-// SegmentEventClickButton — that is what keeps this event from growing a column
-// per caller.
+// Outcome of one watched request. Opt-in: a call site passes a `context` and gets one
+// event per call — this is not wired into the HTTP layer wholesale. "Request" is read
+// broadly; the StoreKit purchase round-trip reports through here too. Feature-specific
+// fields belong in `extra_properties`, like SegmentEventClickButton.
 #[derive(Serialize, Clone)]
 pub struct SegmentEventRequestResult {
-    // What was being attempted: "iap_quote" | "iap_verify" | "iap_balance" |
-    // "iap_purchase" | ... . Group by this first.
+    // What was attempted: "iap_quote" | "iap_verify" | "iap_purchase" | ... .
     pub context: String,
-    // Normalised path, never a full URL: no wallet addresses, no ids. The host is
-    // implied by the environment and belongs in `extra_properties` when it matters
-    // (for IAP it does — it is the whole question).
+    // Normalised path, never a full URL: no wallet addresses, no ids.
     pub endpoint: String,
     // "GET" | "POST" | ... . "STOREKIT" for the native purchase round-trip.
     pub method: String,
-    // Whether the caller got what it asked for. False covers a transport failure, a
-    // non-2xx, an unparseable body AND a business-level refusal (HTTP 200 + ok:false),
-    // because from the caller's side those are the same outcome.
+    // False covers transport failure, non-2xx, unparseable body, and a business
+    // refusal (HTTP 200 + ok:false) — the same outcome from the caller's side.
     pub ok: bool,
     // HTTP status when there was one. None on a transport failure or a non-HTTP call.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub status: Option<u32>,
-    // Short failure bucket or server error code ("transport", "unparseable",
-    // "cap_exceeded", "user_cancelled", ...). None when ok.
+    // Failure bucket or server code ("transport", "unparseable", "cap_exceeded", ...).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
     // Wall-clock duration of the attempt in milliseconds.

--- a/lib/src/analytics/metrics.rs
+++ b/lib/src/analytics/metrics.rs
@@ -565,13 +565,9 @@ impl Metrics {
         self.queue_event("Guest Wallet Creation", event);
     }
 
-    /// One watched request outcome. See data_definition::SegmentEventRequestResult —
-    /// it is opt-in by `context`, and anything feature-specific rides in
-    /// `extra_properties` rather than becoming a new column.
+    /// One watched request outcome. See data_definition::SegmentEventRequestResult.
     ///
-    /// GDScript-friendly sentinels (gdext doesn't surface Option<T> across FFI):
-    ///   - `status`: -1 == None (transport failure, or a non-HTTP call).
-    ///   - `error` / `extra_properties`: empty string == None.
+    /// GDScript-friendly sentinels: `status` -1 == None, empty string == None.
     #[func]
     #[allow(clippy::too_many_arguments)]
     pub fn track_request_result(

--- a/lib/src/analytics/metrics.rs
+++ b/lib/src/analytics/metrics.rs
@@ -28,7 +28,7 @@ use super::{
         SegmentEventCommonExplorerFields, SegmentEventExplorerMoveToParcel,
         SegmentEventFirebaseInit, SegmentEventGuestWalletCreation,
         SegmentEventIosStoreKitEnvironment, SegmentEventLoading, SegmentEventRequestFriend,
-        SegmentEventScreenViewed, SegmentEventUnfriend,
+        SegmentEventRequestResult, SegmentEventScreenViewed, SegmentEventUnfriend,
     },
     frame::Frame,
     install_referrer::InstallReferrer,
@@ -563,6 +563,44 @@ impl Metrics {
             duration_ms: duration_ms.max(0) as u32,
         });
         self.queue_event("Guest Wallet Creation", event);
+    }
+
+    /// One watched request outcome. See data_definition::SegmentEventRequestResult —
+    /// it is opt-in by `context`, and anything feature-specific rides in
+    /// `extra_properties` rather than becoming a new column.
+    ///
+    /// GDScript-friendly sentinels (gdext doesn't surface Option<T> across FFI):
+    ///   - `status`: -1 == None (transport failure, or a non-HTTP call).
+    ///   - `error` / `extra_properties`: empty string == None.
+    #[func]
+    #[allow(clippy::too_many_arguments)]
+    pub fn track_request_result(
+        &mut self,
+        context: String,
+        endpoint: String,
+        method: String,
+        ok: bool,
+        status: i64,
+        error: String,
+        duration_ms: i64,
+        extra_properties: String,
+    ) {
+        let opt_str = |s: String| if s.is_empty() { None } else { Some(s) };
+        let event = SegmentEvent::RequestResult(SegmentEventRequestResult {
+            context,
+            endpoint,
+            method,
+            ok,
+            status: if status < 0 {
+                None
+            } else {
+                Some(status as u32)
+            },
+            error: opt_str(error),
+            duration_ms: duration_ms.max(0) as u32,
+            extra_properties: opt_str(extra_properties),
+        });
+        self.queue_event("Request Result", event);
     }
 
     /// Boot-time cache probe event. `remaining_s` is -1 (becomes None) for any


### PR DESCRIPTION
Two things: a generic `Request Result` Segment event wired through the credits flow, and the Option D gate fix that instrumentation exposed.

**Instrumentation.** `Request Result` (opt-in by `context`) is used by `iap_quote`, `iap_verify`, `iap_register` and the StoreKit purchase round-trip. A business refusal (HTTP 200 + `ok:false`) reports as not-ok with the server code; a rejected promise — which is every non-2xx — carries the server reason. Endpoints are normalised so no wallet reaches analytics. `Click Button` gains `OPEN_CREDITS`, tracked where the page is instantiated so all three shop entry points are covered (two had none), and `BUY_PACK`. All of them carry `Iap.analytics_context()`: resolved dclenv, whether the Option D switch ran and which gate stopped it, StoreKit environment/source, credits-server in use, balance and `products_loaded`.

**Gate fix.** `_apply_storekit_env` gated on `OS.is_debug_build()`, which reflects the Godot export template — and the iOS export runs without `--release`, so it was true on every shipped build and the sandbox env switch never ran on TestFlight or App Review. Now gated on `Global.is_dev()`, so `-prod` and `-staging` switch while dev builds keep the developer chosen env.

**Why it matters.** Left on `.org`, `POST /credits/iap/quote` answers `unknown_product` for the `credits_tier_b*` packs the storefront sells — the org catalog does not have them, zone does. That is the failure App Review hit: the shop opens, the pack does nothing, and no telemetry recorded any of it.

## Test plan

1. **Gate fires (needs a `-prod`/`-staging` artifact — cannot be done locally, release requires distribution provisioning).** Install from TestFlight on a device signed into a sandbox Apple ID. Open the credits shop. Expect the packs to load and the balance to render, and in Segment an `OPEN_CREDITS` whose `extra_properties` shows `option_d_applied: true` with `credits_server` on `.zone`.
2. **Purchase completes.** Press a pack. Expect `BUY_PACK` -> `iap_quote ok` -> `iap_verify ok` -> `iap_purchase ok`, and the balance to increase by the pack amount.
3. **Failure is legible.** Press a second pack past the daily cap. Expect `iap_quote` `ok:false` `error: cap_exceeded` and a matching `iap_purchase` failure, not a silent no-op.
4. **Regression, production users.** On a build installed from the App Store, `option_d_skip_reason` must read `not_sandbox` and `credits_server` must stay on `.org`.

Segment debugger tip: its search is plain substring matching, so `option_d_skip_reason` filters to exactly these events.

## Verification so far

Device-verified on a `-dev` build: both shop entry clicks, `iap_register`, a denied quote propagating into a failed purchase, a full successful purchase (`iap_quote` -> `iap_verify` -> `iap_purchase`) once forced onto the Option D env by a baked deeplink, and the `cap_exceeded` path.

Not exercised: the gate itself letting a `-prod`/`-staging` build through, the `cancelled`/`pending` outcomes, and the `marketplace_cta` / `wearable_item` entry points.