### PR TITLE
fix(comms): let a preview of an authoritative scene join Pulse on its own, behind the lsd-pulse flag

### DIFF
--- a/godot/src/feature_flags.gd
+++ b/godot/src/feature_flags.gd
@@ -23,6 +23,9 @@ const TIMEOUT_SECONDS := 5.0
 const FLAG_ARCHIPELAGO := "archipielago"
 const FLAG_PULSE := "pulse"
 const FLAG_DUAL_CHANNEL := "dual-channel"
+# Kill switch (default true): a local preview of an `authoritativeMultiplayer` scene
+# joins Pulse on its own, without a deeplink/CLI opt-in.
+const FLAG_LSD_PULSE := "lsd-pulse"
 # Sentry error-event sampling, served as a number in [0, 1].
 const FLAG_SENTRY_SAMPLE_RATE := "sentry-sample-rate"
 # Report ERROR-level Sentry events (the engine/Rust error firehose). Fail-closed:
@@ -114,10 +117,17 @@ func _async_load() -> void:
 # only safe once the deployment's authoritative servers ingest Pulse as scene
 # listeners, which is a property of the deployment, not of this client. Local
 # `--livekit-movement` / `--no-livekit-movement` / `dual-channel=` still win.
+# `lsd-pulse` (default true, a kill switch) lets a local preview of an
+# `authoritativeMultiplayer` scene join Pulse without an explicit opt-in: that
+# scene's own server reads avatar state off Pulse, and neither the deeplink
+# sdk-commands launches nor the QR it prints carries `pulse-server=` /
+# `pulse-realm=`. Still needs `pulse`; `--no-pulse` / `pulse=false` still win —
+# see CommunicationManager::pulse_activation on the Rust side.
 func _apply_flags() -> void:
 	Global.comms.set_archipelago_enabled(is_enabled(FLAG_ARCHIPELAGO, true))
 	Global.comms.set_pulse_flag_enabled(is_enabled(FLAG_PULSE, false))
 	Global.comms.set_dual_channel_flag_enabled(is_enabled(FLAG_DUAL_CHANNEL, true))
+	Global.comms.set_lsd_pulse_flag_enabled(is_enabled(FLAG_LSD_PULSE, true))
 
 	# SentrySDK.init runs at process start (before this fetch resolves), so the
 	# remote rate is enforced through the _before_send gate, not the init option.

--- a/godot/src/ui/components/organisms/multiplayer_debug/multiplayer_debug_panel.gd
+++ b/godot/src/ui/components/organisms/multiplayer_debug/multiplayer_debug_panel.gd
@@ -160,14 +160,18 @@ func _build_pulse_line(info: Dictionary) -> String:
 	var pulse_realm: String = info.get("pulse_realm", "")
 	if pulse_realm.is_empty():
 		pulse_realm = "[color=gray]pending[/color]"
+	# Joined by the authoritative-preview rule (`lsd-pulse` flag), not by a deeplink/CLI
+	# opt-in — the difference between "the QR alone works" and "someone added a param".
+	var auto_label: String = " | auto-lsd" if info.get("pulse_auto_lsd", false) else ""
 	return (
-		"Pulse: %s @ %s | realm %s | fails %d | dual-ch %s"
+		"Pulse: %s @ %s | realm %s | fails %d | dual-ch %s%s"
 		% [
 			_colored_state(pulse_state),
 			pulse_endpoint,
 			pulse_realm,
 			pulse_failures,
-			dual_channel_label
+			dual_channel_label,
+			auto_label
 		]
 	)
 

--- a/lib/src/comms/communication_manager.rs
+++ b/lib/src/comms/communication_manager.rs
@@ -100,18 +100,26 @@ fn avatar_sync_over_livekit(dual_channel: bool, pulse_established: bool) -> bool
 /// endpoint (`--pulse-server` / PULSE_SERVER) or a realm (`--pulse-realm` / PULSE_REALM).
 /// Otherwise the deployment's `pulse` flag decides, fail-closed — except in `--preview`.
 ///
-/// **A local preview never joins Pulse on the strength of the flag alone.** Its realm key is
-/// `lsd:` + the preview scene's entity id, which is reversible base64 of the developer's
-/// absolute project path and hostname; letting a fleet-wide flag push that to the default
-/// (production) Pulse from every `dcl start` would be a surprise. `sdk-commands` gates its own
-/// `--pulse-realm` off by default for the same reason, so Local Scene Development opts in
-/// explicitly — which is exactly what the orchestrator and `DCL_SERVER_PULSE_REALM=1` do.
+/// **A local preview never joins Pulse on the strength of the `pulse` flag alone.** Its realm
+/// key is `lsd:` + the preview scene's entity id, which is reversible base64 of the
+/// developer's absolute project path and hostname; letting a fleet-wide flag push that to the
+/// default (production) Pulse from every `dcl start` would be a surprise. `sdk-commands` gates
+/// its own `--pulse-realm` off by default for the same reason.
+///
+/// The one preview that does join without an opt-in is `authoritative_preview`: the scene
+/// under the player declares `authoritativeMultiplayer` and the `lsd-pulse` flag is on. That
+/// scene's own server already announces the identical key on the same Pulse and, once it
+/// reads avatar state from Pulse alone, a client that never joins is simply invisible to it.
+/// Neither the deeplink sdk-commands launches nor the QR it prints carries a Pulse opt-in, so
+/// this is the only way a stock `npm start` reaches its server. `lsd-pulse` is a kill switch
+/// for that rule (defaults on), and still needs the `pulse` flag.
 #[cfg(feature = "use_pulse")]
 fn pulse_activation(
     locally_enabled: bool,
     explicit_opt_in: bool,
     preview_mode: bool,
     flag_enabled: Option<bool>,
+    authoritative_preview: bool,
 ) -> bool {
     if !locally_enabled {
         return false;
@@ -119,7 +127,10 @@ fn pulse_activation(
     if explicit_opt_in {
         return true;
     }
-    !preview_mode && flag_enabled == Some(true)
+    if flag_enabled != Some(true) {
+        return false;
+    }
+    !preview_mode || authoritative_preview
 }
 
 /// Effective dual-channel setting. An explicit local choice (CLI `--livekit-movement` /
@@ -343,6 +354,11 @@ pub struct CommunicationManager {
     /// runtime/CLI opt-in overrides it — see `pulse_enabled`.
     #[cfg(feature = "use_pulse")]
     pulse_flag_enabled: Option<bool>,
+    /// Server `lsd-pulse` feature flag: lets a local preview of an `authoritativeMultiplayer`
+    /// scene join Pulse without an explicit opt-in (see `pulse_activation`). A kill switch,
+    /// so it defaults on and a failed flags fetch cannot break Local Scene Development.
+    #[cfg(feature = "use_pulse")]
+    lsd_pulse_flag: bool,
     /// Runtime endpoint override (deeplink `pulse-server=host:port`, shareable so a group can
     /// join the same server). Wins over --pulse-server / PULSE_SERVER / the default endpoint.
     #[cfg(feature = "use_pulse")]
@@ -455,6 +471,8 @@ impl INode for CommunicationManager {
             pulse_runtime_enabled: None,
             #[cfg(feature = "use_pulse")]
             pulse_flag_enabled: None,
+            #[cfg(feature = "use_pulse")]
+            lsd_pulse_flag: true,
             #[cfg(feature = "use_pulse")]
             pulse_endpoint_override: None,
             #[cfg(feature = "use_pulse")]
@@ -880,8 +898,33 @@ impl CommunicationManager {
                 cli.pulse_explicit,
                 cli.preview_mode || self.local_scene_development,
                 self.pulse_flag_enabled,
+                self.authoritative_preview(),
             )
         })
+    }
+
+    /// The `authoritative_preview` input of [`pulse_activation`]: the `lsd-pulse` flag is on
+    /// and the scene under the player declares `authoritativeMultiplayer`. `false` while no
+    /// scene is under the player yet — `on_scene_changed` re-evaluates once one is.
+    #[cfg(feature = "use_pulse")]
+    fn authoritative_preview(&self) -> bool {
+        if !self.lsd_pulse_flag {
+            return false;
+        }
+        let scene_runner = DclGlobal::singleton().bind().get_scene_runner();
+        let scene_runner = scene_runner.bind();
+        let scene_id = scene_runner.get_current_parcel_scene_id();
+        scene_runner.get_scene_is_authoritative(scene_id)
+    }
+
+    /// Whether Pulse is on *because of* the authoritative-preview rule rather than an explicit
+    /// opt-in — surfaced on the debug panel so QA can tell the two apart.
+    #[cfg(feature = "use_pulse")]
+    fn pulse_auto_lsd(&self, cli: &crate::godot_classes::dcl_cli::DclCli) -> bool {
+        self.pulse_runtime_enabled.is_none()
+            && !cli.pulse_explicit
+            && (cli.preview_mode || self.local_scene_development)
+            && self.pulse_enabled(cli)
     }
 
     /// Create the Pulse room if activation is on and it doesn't exist yet.
@@ -1588,6 +1631,32 @@ impl CommunicationManager {
             if effective {
                 self.ensure_pulse_room();
             } else if let Some(mut pulse_room) = self.pulse_room.take() {
+                pulse_room.clean();
+                self.pulse_teleport_pending = false;
+                self.pending_pulse_emote_urn = None;
+            }
+        }
+        #[cfg(not(feature = "use_pulse"))]
+        let _ = enabled;
+    }
+
+    /// Server `lsd-pulse` feature-flag verdict (feature_flags.gd, once the mobile-bff fetch
+    /// settles; `true` on fetch failure or an absent flag — a kill switch, not an opt-in).
+    /// Lets a local preview of an `authoritativeMultiplayer` scene join Pulse without an
+    /// explicit opt-in; see `pulse_activation`. Re-evaluates activation like the `pulse` flag.
+    #[func]
+    pub fn set_lsd_pulse_flag_enabled(&mut self, enabled: bool) {
+        #[cfg(feature = "use_pulse")]
+        {
+            self.lsd_pulse_flag = enabled;
+            tracing::info!("pulse: lsd-pulse flag = {enabled}");
+            let global = DclGlobal::singleton();
+            let cli = global.bind().cli.clone();
+            let effective = self.pulse_enabled(&cli.bind());
+            if effective {
+                self.ensure_pulse_room();
+            } else if let Some(mut pulse_room) = self.pulse_room.take() {
+                tracing::info!("pulse: leaving — lsd-pulse flag off for this preview");
                 pulse_room.clean();
                 self.pulse_teleport_pending = false;
                 self.pending_pulse_emote_urn = None;
@@ -2785,6 +2854,12 @@ impl CommunicationManager {
         self.scene_room_connect_in_flight = None;
         self.current_scene_id = Some(scene_entity_id.clone());
 
+        // A preview realm switches before its scene is loaded, so the authoritative-preview
+        // rule (see `pulse_activation`) can only be answered now that a scene is under the
+        // player. Cheap: returns at once when the room exists or activation is off.
+        #[cfg(feature = "use_pulse")]
+        self.ensure_pulse_room();
+
         // If loading is in progress, defer scene room creation until release
         if self.comms_on_hold {
             tracing::debug!(
@@ -3065,6 +3140,10 @@ impl CommunicationManager {
             };
             dict.set("pulse_available".to_variant(), true.to_variant());
             dict.set("pulse_enabled".to_variant(), pulse_enabled.to_variant());
+            dict.set(
+                "pulse_auto_lsd".to_variant(),
+                self.pulse_auto_lsd(&cli).to_variant(),
+            );
             dict.set("pulse_state".to_variant(), pulse_state.to_variant());
             dict.set("pulse_endpoint".to_variant(), pulse_endpoint.to_variant());
             dict.set(
@@ -3613,9 +3692,9 @@ mod tests {
         /// Outside preview the deployment flag decides, fail-closed on absent/unfetched.
         #[test]
         fn flag_decides_outside_preview() {
-            assert!(pulse_activation(true, false, false, Some(true)));
-            assert!(!pulse_activation(true, false, false, Some(false)));
-            assert!(!pulse_activation(true, false, false, None));
+            assert!(pulse_activation(true, false, false, Some(true), false));
+            assert!(!pulse_activation(true, false, false, Some(false), false));
+            assert!(!pulse_activation(true, false, false, None, false));
         }
 
         /// The point of the preview carve-out: a plain `dcl start` preview must not be pushed
@@ -3623,7 +3702,7 @@ mod tests {
         /// developer's project path and hostname.
         #[test]
         fn preview_ignores_the_flag_without_an_explicit_opt_in() {
-            assert!(!pulse_activation(true, false, true, Some(true)));
+            assert!(!pulse_activation(true, false, true, Some(true), false));
         }
 
         /// ...but an explicit opt-in (--pulse-realm / --pulse-server / --pulse) still works,
@@ -3631,15 +3710,33 @@ mod tests {
         /// Development.
         #[test]
         fn preview_joins_on_an_explicit_opt_in() {
-            assert!(pulse_activation(true, true, true, Some(true)));
-            assert!(pulse_activation(true, true, true, None));
+            assert!(pulse_activation(true, true, true, Some(true), false));
+            assert!(pulse_activation(true, true, true, None, false));
         }
 
-        /// --no-pulse always wins, everywhere.
+        /// A preview of an `authoritativeMultiplayer` scene joins on its own (the stock
+        /// `npm start` deeplink and QR carry no opt-in), but only with the `pulse` flag on:
+        /// `lsd-pulse` is a kill switch for the rule, not a way to force Pulse on.
+        #[test]
+        fn authoritative_preview_joins_without_an_opt_in() {
+            assert!(pulse_activation(true, false, true, Some(true), true));
+            assert!(!pulse_activation(true, false, true, Some(false), true));
+            assert!(!pulse_activation(true, false, true, None, true));
+        }
+
+        /// The authoritative-preview input is irrelevant outside preview.
+        #[test]
+        fn authoritative_input_changes_nothing_outside_preview() {
+            assert!(pulse_activation(true, false, false, Some(true), true));
+            assert!(!pulse_activation(true, false, false, Some(false), true));
+        }
+
+        /// --no-pulse always wins, everywhere — the authoritative rule included.
         #[test]
         fn local_opt_out_always_wins() {
-            assert!(!pulse_activation(false, true, false, Some(true)));
-            assert!(!pulse_activation(false, true, true, Some(true)));
+            assert!(!pulse_activation(false, true, false, Some(true), false));
+            assert!(!pulse_activation(false, true, true, Some(true), false));
+            assert!(!pulse_activation(false, false, true, Some(true), true));
         }
     }
 

--- a/lib/src/scene_runner/scene_manager.rs
+++ b/lib/src/scene_runner/scene_manager.rs
@@ -1265,6 +1265,21 @@ impl SceneManager {
         GString::default()
     }
 
+    /// Whether the scene declares `authoritativeMultiplayer` in its `scene.json` — i.e. an
+    /// authoritative server owns its state. `false` for an unknown scene id.
+    #[func]
+    pub fn get_scene_is_authoritative(&self, scene_id: i32) -> bool {
+        self.scenes
+            .get(&SceneId(scene_id))
+            .and_then(|scene| {
+                scene
+                    .scene_entity_definition
+                    .scene_meta_scene
+                    .authoritative_multiplayer
+            })
+            .unwrap_or(false)
+    }
+
     /// Resolve a scene-emote URN (`urn:decentraland:off-chain:scene-emote:{scene_id}-{glb_hash}-{loop}`)
     /// against the currently loaded scenes. The URN payload cannot be dash-split:
     /// preview ids/hashes look like `b64-<base64>` and contain `-` themselves. Matching


### PR DESCRIPTION
A local preview joined Pulse only on an explicit opt-in, but neither the deeplink `sdk-commands` launches nor the QR it prints carries one. Once the authoritative server reads avatar state from Pulse alone, every stock `npm start` of an `authoritativeMultiplayer` scene would leave the client invisible to its own server, with no error. This makes such a preview join Pulse on its own, with the derived `lsd:` realm, behind a new `lsd-pulse` feature flag. The flag is a kill switch (defaults on, already `true` in org, still needs `pulse`), `--no-pulse` and `pulse=false` still win, and a plain scene without a server still never joins. The debug panel marks the join as `auto-lsd`.

## Changes

- `lib/src/comms/communication_manager.rs`: `pulse_activation` gains an `authoritative_preview` input; `set_lsd_pulse_flag_enabled`; activation re-evaluated on scene change; `pulse_auto_lsd` in the debug dict; tests.
- `lib/src/scene_runner/scene_manager.rs`: `get_scene_is_authoritative(scene_id)`.
- `godot/src/feature_flags.gd`: reads `lsd-pulse` (default true).
- `multiplayer_debug_panel.gd`: `| auto-lsd` suffix on the Pulse row.

## Test plan

**Setup.** Run [`robtfm/lsd-zone-scene`](https://github.com/robtfm/lsd-zone-scene) with `npm start -- --no-client --port 8022` (Node ≥ 24.16). It targets zone Pulse, so the client must too: on desktop pass `--dclenv comms::zone,org`; on a phone add `&dclenv=comms::zone,org` to the deeplink. Do **not** pass `pulse-server=`, `pulse-realm=` or `pulse=`.

- [ ] **Stock preview joins Pulse.** Open the app with `decentraland://open?preview=http://<mac-ip>:8022&position=0,0&dclenv=comms::zone,org&multiplayer_debug=true` and walk a few steps. Expected: the Multiplayer Debug panel's Pulse row reads `established`, `realm lsd:b64-…` and ends with `auto-lsd`; the scene's top panel lists your address **with a position** that changes as you walk.
- [ ] **Plain scene stays off.** Open the app with the QR of any non-authoritative scene (`npm start -- --mobile` on the SDK7 template). Expected: Pulse row reads `OFF`; the scene loads and hot reload still works.
- [ ] **Kill switch.** Set `lsd-pulse` to `false` in the mobile-bff payload and repeat the first case. Expected: Pulse row reads `OFF`.
- [ ] **Opt-out still wins.** Repeat the first case adding `&pulse=false`. Expected: Pulse row reads `OFF`.

Verified on desktop against zone Pulse: with no Pulse flags the client joined on `lsd:b64-…` and the server roster reported its position. Regression: Genesis City and worlds are untouched (the new input only matters in a preview), but a quick walk next to another player in Genesis City is worth one pass.
