### PR TITLE
chore: pr-description skill and PR description rules in REVIEW.md

### DIFF
--- a/.claude/skills/pr-description/SKILL.md
+++ b/.claude/skills/pr-description/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pr-description
-description: Use whenever writing, rewriting or reviewing the description of a pull request in this repo — a development PR (base `main`) or a Release Candidate PR (base `release`, head `release-X.Y.Z`). Encodes the team's AG (AI-generated) communication guideline as it applies to PRs — the author owns understanding and communicating the change — plus the exact description shape: a What/Why lead paragraph anyone can understand in a few sentences, an optional collapsed Details block, and a QA-executable Test plan per `REVIEW.md` §4. For RCs, the recipe to build the changelog from each promoted PR. Trigger on "open a PR", "write the PR description/body", "gh pr create", "release candidate", "RC", "promote main to release", "changelog for the release", or when a PR body reads like raw AI output.
+description: Use whenever writing, rewriting or reviewing the description of a pull request in this repo — a development PR (base `main`) or a Release Candidate PR (base `release`, head `release-X.Y.Z`). Encodes the team's AG (AI-generated) communication guideline as it applies to PRs — the author owns understanding and communicating the change — plus the exact description shape: `## What` and `## Why` sections anyone can understand in a few sentences, an optional `## Details` section (collapsed), and a QA-executable `## Test plan` per `REVIEW.md` §4. For RCs, the recipe to build the changelog from each promoted PR. Trigger on "open a PR", "write the PR description/body", "gh pr create", "release candidate", "RC", "promote main to release", "changelog for the release", or when a PR body reads like raw AI output.
 ---
 
 # Decentraland Godot Explorer — PR descriptions
@@ -23,7 +23,7 @@ it if asked. *AI can replace knowledge, but it can't replace our understanding.*
 
 For PRs this means:
 
-- **What and why come first, in plain language.** Whoever reads the first paragraph — a reviewer,
+- **What and why come first, in plain language.** Whoever reads `## What` and `## Why` — a reviewer,
   QA, someone on another team, someone reading the changelog in three months — understands what
   changed and why without reading anything else. If they still have to guess, the work was moved
   from the author to them.
@@ -53,16 +53,23 @@ describe a change you have not read the diff for.
 ### 2.1 Shape
 
 ```markdown
-<Lead paragraph — WHAT changed and WHY, 2–5 sentences. Plain language. No header.>
+## What
+<What is different after this merges — for the player, the creator, the reviewer or the
+ build. 1–3 sentences, plain language. Name at most one or two identifiers.>
+
+## Why
+<The bug, the request, the measurement, the parity gap. 1–3 sentences. Include what the
+ change deliberately does NOT do when a reader might assume otherwise.>
 
 Closes #<issue>
 
+## Details
 <details>
-<summary>Details</summary>
+<summary>Expand</summary>
 
-<Only what a reviewer needs beyond the lead: root cause, approach and trade-offs,
- what was deliberately left out, screenshots/video, per-file notes when non-obvious.
- Short paragraphs or a tight bullet list. Omit the whole block when the lead says it all.>
+<Only what a reviewer needs beyond What/Why: root cause, approach and trade-offs,
+ screenshots/video, per-file notes when non-obvious. Short paragraphs or a tight bullet
+ list. Omit the whole section when What/Why say it all.>
 
 </details>
 
@@ -71,15 +78,15 @@ Closes #<issue>
 <See 2.3. Either "No QA needed — no behavior change" or numbered cases.>
 ```
 
-Optional extras, in this order, only when they add clarity: a **Heads-up** line right after the
-lead naming who was told and where (*"Heads-up posted in #ext-foundation — touches the shared
+Optional extras, in this order, only when they add clarity: a **Heads-up** line right after
+`## Why` naming who was told and where (*"Heads-up posted in #ext-foundation — touches the shared
 `ModalShell`"*); a **Changes** list (file → what it does) inside Details; a **Future plans** or
 **Known gaps** line at the end.
 
-### 2.2 Writing the lead
+### 2.2 Writing What and Why
 
-The lead is the deliverable. Everything else is optional. Write it so that reading *only* the
-lead answers three questions:
+`## What` and `## Why` are the deliverable. Everything else is optional. Write them so that
+reading *only* those two sections answers three questions:
 
 1. **What** is different for the player, the creator, the reviewer or the build after this merges.
 2. **Why** — the bug, the request, the measurement, the parity gap. One clause is usually enough
@@ -89,22 +96,25 @@ lead answers three questions:
 
 Rules of thumb:
 
-- 2–5 sentences. If it needs more, the PR probably needs splitting, or the extra belongs in Details.
+- 1–3 sentences each. If they need more, the PR probably needs splitting, or the extra belongs
+  in Details. Together they must fit on one screen with the Test plan headline visible.
 - Name at most one or two identifiers; describe the rest in words. Code goes in Details.
 - No narration of the work, no adjectives about the work ("comprehensive", "robust", "clean").
 - State behaviour changes that ride along outside the feature's scope — reviewers and QA need
   those most, and they are the easiest thing to lose in a long description.
 - If the change is a port from the Unity Foundation Client, say so and name the reference.
 
-Good lead (from #2779):
+Good What/Why (adapted from #2779):
 
-> Replaces the "Report a Bug" Google Form deep link in Settings with a native in-app bug report
-> flow that files Intercom tickets through the Decentraland `intercom-proxy`. The old flow
-> bounced the player out to an external browser and required a Google sign-in to attach an
-> image — so screenshots were almost never included. The new form is in-app, pre-fills a
-> screenshot of the game, and lands in the same Intercom buckets as the Unity Explorer client.
+> **What** — Replaces the "Report a Bug" Google Form deep link in Settings with a native in-app
+> bug report flow that files Intercom tickets through the Decentraland `intercom-proxy`. The
+> form pre-fills a screenshot of the game and lands in the same Intercom buckets as the Unity
+> Explorer client.
+>
+> **Why** — The old flow bounced the player out to an external browser and required a Google
+> sign-in to attach an image, so screenshots were almost never included.
 
-Not a lead (rewrite it): *"This PR introduces a comprehensive refactor of the bug reporting
+Not a What (rewrite it): *"This PR introduces a comprehensive refactor of the bug reporting
 system. Key changes include: a new `BugReportService` class…"* — the reader learns the shape of
 the diff and nothing about what a player gets or why anyone wanted it.
 
@@ -145,7 +155,7 @@ Follow `REVIEW.md` §4 exactly. In short:
 
 ### 2.5 Self-check before it goes out
 
-- [ ] Reading only the first paragraph, a teammate on another team knows what changed and why.
+- [ ] Reading only `## What` and `## Why`, a teammate on another team knows what changed and why.
 - [ ] Nothing in the description is a restatement of the diff or of the commit list.
 - [ ] Every claim is something you verified in the code or the issue — no guessed behaviour.
 - [ ] Ride-along behaviour changes outside the feature are stated, not buried.
@@ -158,7 +168,7 @@ Follow `REVIEW.md` §4 exactly. In short:
 An RC promotes `main` (or a cherry-picked subset) into `release`. Its description is the
 release's changelog and QA sheet — QA works from it directly, and it is what people read when
 asking "what shipped in 1.13.1?". It is built **from the promoted PRs' own descriptions**, which
-is why §2 matters: a bad dev PR lead makes a bad release line.
+is why §2 matters: a bad dev PR What/Why makes a bad release line.
 
 ### 3.1 Shape
 
@@ -219,7 +229,7 @@ paragraph under it instead of a single line — see #2797. Keep that for one or 
    ```bash
    gh pr view <N> -R decentraland/godot-explorer --json title,body,closingIssuesReferences
    ```
-   From each take: the *what/why* lead (→ one changelog line), the behaviour changes that ride
+   From each take: `## What` and `## Why` (→ one changelog line), the behaviour changes that ride
    along (→ often their own line, or a Known gap), and the one or two test-plan cases that prove
    the change on a phone (→ one Test plan line). Do not copy a PR's full test plan into the RC.
 3. **Classify** each PR: Feature (new capability a player or creator sees), Fix (a symptom went

--- a/.claude/skills/pr-description/SKILL.md
+++ b/.claude/skills/pr-description/SKILL.md
@@ -1,0 +1,259 @@
+---
+name: pr-description
+description: Use whenever writing, rewriting or reviewing the description of a pull request in this repo — a development PR (base `main`) or a Release Candidate PR (base `release`, head `release-X.Y.Z`). Encodes the team's AG (AI-generated) communication guideline as it applies to PRs — the author owns understanding and communicating the change — plus the exact description shape: a What/Why lead paragraph anyone can understand in a few sentences, an optional collapsed Details block, and a QA-executable Test plan per `REVIEW.md` §4. For RCs, the recipe to build the changelog from each promoted PR. Trigger on "open a PR", "write the PR description/body", "gh pr create", "release candidate", "RC", "promote main to release", "changelog for the release", or when a PR body reads like raw AI output.
+---
+
+# Decentraland Godot Explorer — PR descriptions
+
+There are two kinds of PR here and each has its own shape:
+
+| Kind | Base ← head | Title | Shape |
+|---|---|---|---|
+| **Development PR** | `main` ← feature branch | conventional commit (`feat:` / `fix:` / `chore:` / `refactor:`) | §2 |
+| **Release Candidate** | `release` ← `release-X.Y.Z` | `Release Candidate X.Y.Z` | §3 |
+
+Both follow the same principle (§1). Read it first; it decides what goes in and what stays out.
+
+## 1. The principle: the author owns the understanding
+
+The team's guideline for anything with your name on it — messages, PRs, docs, issues — is the
+**AG scale** (AG-0 raw AI output … AG-5 you wrote it, AI helped). The target is **AG-3 to AG-5**:
+the author has read every sentence, changed what didn't sound right, and can explain any part of
+it if asked. *AI can replace knowledge, but it can't replace our understanding.*
+
+For PRs this means:
+
+- **What and why come first, in plain language.** Whoever reads the first paragraph — a reviewer,
+  QA, someone on another team, someone reading the changelog in three months — understands what
+  changed and why without reading anything else. If they still have to guess, the work was moved
+  from the author to them.
+- **Short beats complete.** More text is not more clarity. Leave things out rather than pack
+  them in. Implementation detail goes in a collapsed block, or nowhere.
+- **No raw AI output.** Do not paste a model's summary of the diff. Reviewers read a description
+  to *validate the approach and decide what to trust*, not to re-derive the change from a wall of
+  bullets. Text that restates the diff file by file, narrates the work ("I've implemented…",
+  "This PR introduces a comprehensive…"), or hedges with filler is a rewrite request.
+- **Tell the people affected before merging, not after.** If the change touches something
+  another team, service, SDK or workflow depends on (shared UI components, the auth flow, the
+  comms protocol, the asset pipeline, the mobile-bff contract, the Unity-parity behaviours, CI
+  workflows), the PR is not the notification. Post a short message in the relevant shared channel
+  — `#ext-foundation` for cross-org — *before* investing in the full change when possible:
+  *"I'm planning to merge X, it changes Y and may affect Z. Any concerns?"* Say in the PR that
+  you did.
+- **QA runs the test plan by hand on a phone.** Every case must be executable cold by someone
+  who has never seen the code. The full rules are in `REVIEW.md` §4 → *Writing test steps QA can
+  execute*; the short form is in §2.3 below.
+
+You (Claude) are drafting on the author's behalf. A draft is AG-2 until the author has read it.
+**Always print the full body in your reply** so the author reads it before it goes out, and never
+describe a change you have not read the diff for.
+
+## 2. Development PR (base `main`)
+
+### 2.1 Shape
+
+```markdown
+<Lead paragraph — WHAT changed and WHY, 2–5 sentences. Plain language. No header.>
+
+Closes #<issue>
+
+<details>
+<summary>Details</summary>
+
+<Only what a reviewer needs beyond the lead: root cause, approach and trade-offs,
+ what was deliberately left out, screenshots/video, per-file notes when non-obvious.
+ Short paragraphs or a tight bullet list. Omit the whole block when the lead says it all.>
+
+</details>
+
+## Test plan
+
+<See 2.3. Either "No QA needed — no behavior change" or numbered cases.>
+```
+
+Optional extras, in this order, only when they add clarity: a **Heads-up** line right after the
+lead naming who was told and where (*"Heads-up posted in #ext-foundation — touches the shared
+`ModalShell`"*); a **Changes** list (file → what it does) inside Details; a **Future plans** or
+**Known gaps** line at the end.
+
+### 2.2 Writing the lead
+
+The lead is the deliverable. Everything else is optional. Write it so that reading *only* the
+lead answers three questions:
+
+1. **What** is different for the player, the creator, the reviewer or the build after this merges.
+2. **Why** — the bug, the request, the measurement, the parity gap. One clause is usually enough
+   (*"…so screenshots were almost never attached"*, *"…26.5% completion vs 92%"*).
+3. **What it does not do**, when a reader might reasonably assume otherwise (*"migrating the
+   five existing modals is left as a follow-up"*).
+
+Rules of thumb:
+
+- 2–5 sentences. If it needs more, the PR probably needs splitting, or the extra belongs in Details.
+- Name at most one or two identifiers; describe the rest in words. Code goes in Details.
+- No narration of the work, no adjectives about the work ("comprehensive", "robust", "clean").
+- State behaviour changes that ride along outside the feature's scope — reviewers and QA need
+  those most, and they are the easiest thing to lose in a long description.
+- If the change is a port from the Unity Foundation Client, say so and name the reference.
+
+Good lead (from #2779):
+
+> Replaces the "Report a Bug" Google Form deep link in Settings with a native in-app bug report
+> flow that files Intercom tickets through the Decentraland `intercom-proxy`. The old flow
+> bounced the player out to an external browser and required a Google sign-in to attach an
+> image — so screenshots were almost never included. The new form is in-app, pre-fills a
+> screenshot of the game, and lands in the same Intercom buckets as the Unity Explorer client.
+
+Not a lead (rewrite it): *"This PR introduces a comprehensive refactor of the bug reporting
+system. Key changes include: a new `BugReportService` class…"* — the reader learns the shape of
+the diff and nothing about what a player gets or why anyone wanted it.
+
+### 2.3 Test plan
+
+Follow `REVIEW.md` §4 exactly. In short:
+
+- **No behaviour change** (build tooling, CI, metadata, logging level, pure refactor, docs):
+  write `No QA needed — no behavior change` and, if useful, one optional verification line
+  (*"CI: Static checks + Clippy green"*). Do not invent cases.
+- **Behaviour change**: one block per case. **Setup** line only when the required state is
+  non-obvious (specific wearables, second account, guest vs signed-in, a deeplink or flag).
+  **Steps** numbered, one user action per line, **starting from opening the app**, with concrete
+  on-screen names and values. **Expected** result observable enough to mark pass/fail without
+  reading code. A **Regression** line whenever shared code was touched. Platform only when the
+  case is iOS- or Android-specific. Device, build download and TestFlight/Firebase install are
+  assumed — never spend steps on them.
+- Each Expected/Regression line is a `- [ ]` checkbox so QA can tick it.
+- What the author verified themselves (headless test, fmt/clippy, a device run) can go in
+  Details as ticked `- [x]` items. Keep the QA section for what QA still has to do.
+
+### 2.4 Procedure
+
+1. Read the actual diff: `git diff origin/main...HEAD --stat` then the files that matter. Do not
+   write from the branch name or the commit messages alone.
+2. Find the issue it closes (`gh issue view N`) so the *why* is the real one.
+3. Decide whether the change can affect another team/service/SDK/workflow. If yes, draft the
+   Slack heads-up message for the author alongside the PR body and add the Heads-up line.
+4. Write the body to the scratchpad and print it in full in your reply.
+5. Open it only when asked, always against `origin` (`decentraland/godot-explorer`), never `fork`:
+   ```bash
+   git push -u origin <branch>
+   gh pr create -R decentraland/godot-explorer --base main \
+     --title "<type>: <summary>" --body-file <scratchpad>/pr-body.md
+   ```
+   To rewrite an existing PR's body: `gh pr edit <N> -R decentraland/godot-explorer --body-file …`.
+6. Before handing over, run the checklist below on your own draft.
+
+### 2.5 Self-check before it goes out
+
+- [ ] Reading only the first paragraph, a teammate on another team knows what changed and why.
+- [ ] Nothing in the description is a restatement of the diff or of the commit list.
+- [ ] Every claim is something you verified in the code or the issue — no guessed behaviour.
+- [ ] Ride-along behaviour changes outside the feature are stated, not buried.
+- [ ] Test plan cases start from opening the app and end in an observable result.
+- [ ] Affected teams are named and were (or will be) told before merge.
+- [ ] Visible text outside `<details>` fits on one screen.
+
+## 3. Release Candidate PR (base `release`)
+
+An RC promotes `main` (or a cherry-picked subset) into `release`. Its description is the
+release's changelog and QA sheet — QA works from it directly, and it is what people read when
+asking "what shipped in 1.13.1?". It is built **from the promoted PRs' own descriptions**, which
+is why §2 matters: a bad dev PR lead makes a bad release line.
+
+### 3.1 Shape
+
+```markdown
+## Release Candidate X.Y.Z
+
+<Lead: what is promoted (main sha or the cherry-picked set), whether it is a clean
+ promotion or not, what was deliberately excluded, where the version bump lives.
+ Then one or two sentences on the theme of the release in player terms.>
+
+- **Base:** `release` · **Head:** `release-X.Y.Z`
+- <N> commits on top of `release`: <one clause each when cherry-picked; omit for clean promotions>
+
+## What's included
+
+**Features**
+- <one line, player/creator terms, ending in (#PR)>
+
+**Fixes**
+- <symptom that was fixed, with the number when it was measured, ending in (#PR)>
+
+**Technical** — no QA needed
+- <CI, tooling, back-merges, logging, dependency bumps (#PR)>
+
+## Test plan
+
+**Build:** `vX.Y.Z.<build>-<short sha>-prod` · one Android + one iPhone.
+
+<When stacked on a previous RC: "Everything QA'd for X.Y.0 (#prev) carries over unchanged —
+ the list below is only what this RC adds.">
+
+- [ ] **Version** — login screen and **Settings → About** read `vX.Y.Z.<build>-<sha>-prod`
+- [ ] **<Feature name>** — <the one action that proves it on a phone → what QA should see> `#PR`
+- [ ] …one line per QA-relevant PR, same order as What's included…
+- [ ] **Regression** — enter a few scenes, chat, change a wearable, play an emote from the wheel: no crashes
+
+**Known gap:** <anything shipped without device validation, with why>
+```
+
+When one promoted PR is large enough to need its own paragraph (an FTUE change, a Sentry
+overhaul), *What's included* may use a bold `**Name — #PR (closes #issue)**` heading with a short
+paragraph under it instead of a single line — see #2797. Keep that for one or two items, not all.
+
+### 3.2 Procedure
+
+1. **Establish the range.** From an up-to-date checkout:
+   ```bash
+   git fetch origin main release
+   git log --oneline origin/release..origin/main            # what main has that release doesn't
+   git log --oneline origin/release..origin/release-X.Y.Z   # what the RC branch actually carries
+   ```
+   If the two differ, the RC is a cherry-pick: list what is in and, in the lead, what was left
+   out and why. Commit subjects carry the PR number as `(#NNNN)`; extract them:
+   ```bash
+   git log --format=%s origin/release..origin/release-X.Y.Z | grep -o '#[0-9]\+' | sort -u
+   ```
+2. **Read every promoted PR**, not just its title:
+   ```bash
+   gh pr view <N> -R decentraland/godot-explorer --json title,body,closingIssuesReferences
+   ```
+   From each take: the *what/why* lead (→ one changelog line), the behaviour changes that ride
+   along (→ often their own line, or a Known gap), and the one or two test-plan cases that prove
+   the change on a phone (→ one Test plan line). Do not copy a PR's full test plan into the RC.
+3. **Classify** each PR: Feature (new capability a player or creator sees), Fix (a symptom went
+   away — quote the measurement when the PR has one), Technical (nothing QA can observe). A
+   `chore:` that changes runtime behaviour is not Technical.
+4. **Confirm the version.** `lib/Cargo.toml` and `godot/export_presets.cfg` carry it; say in the
+   lead which PR bumped it. The Test plan's **Version** line is not optional — it is how QA proves
+   they are on the right build.
+5. **Carry-over.** For a patch RC on top of a previous one (1.13.1 after 1.13.0), reference the
+   previous RC and list only the additions, both in *What's included* and in the Test plan.
+6. Write the body to the scratchpad, print it in full, then when asked:
+   ```bash
+   gh pr create -R decentraland/godot-explorer --base release --head release-X.Y.Z \
+     --title "Release Candidate X.Y.Z" --body-file <scratchpad>/rc-body.md
+   ```
+
+### 3.3 Writing the changelog lines
+
+- Player and creator terms first, the mechanism only when it is the news:
+  *"Nearby players rendered as discrete frames, and bounced after landing (#2778)"* — not
+  *"Interpolate remote avatar transforms and clamp ground snap (#2778)"*.
+- One line per PR. Two PRs that ship one feature share a line with both numbers.
+- Numbers only when they came from the PR and change what the reader thinks
+  (*"26.5% completion vs 92%, ~17 logins/day"*).
+- Under *Technical* the reader should be able to skip the block entirely; nothing there needs a
+  test case.
+- Test plan lines pair a **bold name** with one concrete action and the visible outcome, and end
+  with the PR number in backticks so QA can jump to the source when a case fails.
+
+### 3.4 Self-check
+
+- [ ] Every commit in `origin/release..head` is accounted for by a line or explicitly excluded.
+- [ ] Each line was written from the PR's body, not from its title alone.
+- [ ] Every Feature and Fix line has a Test plan line; every Technical line has none.
+- [ ] Version line present and matching `lib/Cargo.toml`.
+- [ ] Anything shipping without a device run is under **Known gap**, not silently omitted.
+- [ ] The lead says clean promotion or cherry-pick, and what was left behind.

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -18,7 +18,7 @@ These are blocking prerequisites. Resolve each one (or explicitly note its statu
    - If no iOS artifact exists, output exactly: *"No iOS build on this PR — a maintainer can add the `build` label to trigger one. I will not approve platform-sensitive iOS changes without a green iOS build."* and hold approval.
    - If the PR is purely backend / GDScript-with-no-platform-branch / docs, an iOS build is **not** required — call that out and proceed.
 3. **Submodule pointer drift.** If `git diff main...HEAD` shows changes under `plugins/dcl-godot-ios/godot` or any submodule and the PR description does not mention it, treat it as accidental and ask the author to confirm.
-4. **The description says what and why.** Read the first paragraph. If it does not tell you what changed and why in plain language, or it reads as raw AI output (see Section 4 → "PR description shape"), ask the author to rewrite it in their own words before a substantive review. The description is the author's statement of understanding; reverse-engineering it from the diff moves that work onto the reviewer.
+4. **The description says what and why.** Read `## What` and `## Why`. If they are missing or do not tell you what changed and why in plain language, or it reads as raw AI output (see Section 4 → "PR description shape"), ask the author to rewrite it in their own words before a substantive review. The description is the author's statement of understanding; reverse-engineering it from the diff moves that work onto the reviewer.
 
 If any of (1) or (2) fail and you proceed anyway, say so explicitly in the review header.
 
@@ -125,7 +125,7 @@ Apply this order. Everything below "Correctness" is negotiable; the top tier is 
 15. **Dev-only flags live in release builds.** Deep-link params like `fake-owned-wearables`, `disable-profile-deploy`, `dclenv=zone` parse unconditionally today. Acceptable but worth flagging for gating behind `#[cfg(debug_assertions)]` / a feature flag / a loud warning (#1849).
 16. **Dead code / orphan uniforms / unused imports.** Rust `clippy -D warnings` catches most of this, but `.tres` / `.tscn` / `.gdshader` don't — reviewers catch those manually. A shader uniform removed in `.gdshader` should also be removed from every `.tres`/`.tscn` that set it, and from every material that references a different-typed replacement (#1878 had a `Texture2D → samplerCube` mismatch that would render black silently).
 17. **Performance on the hot path.** The scene-runner update loop, pointer-event loop, and shaders are hot. Watch for per-pixel `acos`/`normalize`/`pow` that can be replaced by compares, per-frame `find_node` / `get_node` lookups, unbounded `for x in all_entities` scans inside scene systems, and JSON serialization on the scene thread.
-18. **Description and test plan quality.** PR descriptions in this repo open with a what/why lead paragraph, an optional collapsed Details block, and a `## Test plan` (see Section 4 → "PR description shape", including the AG rule on AI-generated text). A description that does not say what changed and why in its first paragraph, or reads as raw AI output, is a rewrite request before code review. A missing or vague test plan is a legitimate review comment, especially for UI changes. Mobile-visible changes should say *which* platform was tested on. **The QA team runs these by hand on a real phone** (builds auto-distribute via TestFlight / Firebase App Distribution) — a case a tester couldn't reproduce cold (steps that don't start from opening the app, no observable expected result, or non-obvious required state left unsaid) is worth holding on. See Section 4 → "Writing test steps QA can execute" for the required format and a worked example.
+18. **Description and test plan quality.** PR descriptions in this repo are `## What`, `## Why`, an optional collapsed `## Details`, and a `## Test plan` (see Section 4 → "PR description shape", including the AG rule on AI-generated text). A description with no What/Why, or whose What/Why read as raw AI output, is a rewrite request before code review. A missing or vague test plan is a legitimate review comment, especially for UI changes. Mobile-visible changes should say *which* platform was tested on. **The QA team runs these by hand on a real phone** (builds auto-distribute via TestFlight / Firebase App Distribution) — a case a tester couldn't reproduce cold (steps that don't start from opening the app, no observable expected result, or non-obvious required state left unsaid) is worth holding on. See Section 4 → "Writing test steps QA can execute" for the required format and a worked example.
 19. **Comments that explain "why", not "what".** Consistent with the CLAUDE.md guidance — reviewers flag comments that restate the code, and praise ones that cite a matching Unity file/line or explain a non-obvious Godot quirk.
 
 ---
@@ -137,28 +137,33 @@ Apply this order. Everything below "Correctness" is negotiable; the top tier is 
 The description is the author's statement of **what changed and why**, written for whoever reads it — reviewer, QA, another team, someone reading the changelog months later. It is not a summary of the diff. The `pr-description` skill (`.claude/skills/pr-description/`) is the authoring guide; this section is what a reviewer holds it to.
 
 ```
-<Lead paragraph — WHAT changed and WHY, 2–5 sentences, plain language, no header.
- Reading only this, a teammate on another team understands the change.>
+## What
+<What is different after this merges — player, creator, reviewer or build. 1–3 sentences,
+ plain language. Reading only What + Why, a teammate on another team understands the change.>
+
+## Why
+<The bug, the request, the measurement, the parity gap. 1–3 sentences, including what the
+ change deliberately does NOT do when a reader might assume otherwise.>
 
 Closes #<issue>
 
-<details>
-<summary>Details</summary>
-Root cause, approach and trade-offs, what was deliberately left out, screenshots/video,
-per-file notes when non-obvious. Omitted entirely when the lead says it all.
+## Details
+<details><summary>Expand</summary>
+Root cause, approach and trade-offs, screenshots/video, per-file notes when non-obvious.
+Section omitted entirely when What/Why say it all.
 </details>
 
 ## Test plan
 - [ ] <cases per "Writing test steps QA can execute" below — or "No QA needed — no behavior change">
 ```
 
-Optional, only when they add clarity: a **Heads-up** line after the lead naming which team was told and where; a **Changes** list (file → what it does) inside Details; **Future plans** / **Known gaps** at the end. Commit prefixes follow conventional commits: `feat:`, `fix:`, `chore:`, `refactor:`. Older PRs use `## Summary` bullets in place of the lead paragraph — accept that on existing PRs, ask for the lead on new ones.
+Optional, only when they add clarity: a **Heads-up** line after `## Why` naming which team was told and where; a **Changes** list (file → what it does) inside Details; **Future plans** / **Known gaps** at the end. Commit prefixes follow conventional commits: `feat:`, `fix:`, `chore:`, `refactor:`. Older PRs use `## Summary` bullets in place of What/Why — accept that on existing PRs, ask for the sections on new ones.
 
 **The AG rule — the author owns understanding the change.** The team's guideline for AI-assisted work (messages, PRs, docs, issues) is that anything with your name on it must be at **AG-3 to AG-5**: you read it, you changed what didn't sound right, and you can explain any part of it if asked. AI can help write code faster; it must not make *understanding* the change slower for everyone else. Concretely, a reviewer should hold the PR — before reading the code — when the description:
 
-- **does not say what and why in the first paragraph** (opens with a file list, a `## Changes` dump, or "This PR introduces a comprehensive…");
+- **has no `## What` / `## Why`, or they don't actually say it** (opens with a file list, a `## Changes` dump, or "This PR introduces a comprehensive…");
 - **reads as raw AI output** — restates the diff file by file, narrates the work, hedges with filler, or is far longer than the change warrants. Ask for a rewrite in the author's own words; do not reverse-engineer the intent from the diff on their behalf;
-- **hides ride-along behaviour changes** — anything outside the feature's stated scope that changes what a player, creator or build sees must be stated in the lead, not buried in Details;
+- **hides ride-along behaviour changes** — anything outside the feature's stated scope that changes what a player, creator or build sees must be stated in What/Why, not buried in Details;
 - **touches something another team, service, SDK or workflow depends on with no heads-up** (shared UI components, auth, comms protocol, asset pipeline, mobile-bff contract, CI workflows). The norm is a short message in the relevant shared channel — `#ext-foundation` for cross-org — *before* merging: "I'm planning to merge X, it changes Y and may affect Z. Any concerns?". Ask whether it was posted.
 
 The same rule applies to review comments and replies: keep them short, in your own words, and skip AI-generated explanations that add text without adding clarity.
@@ -355,7 +360,7 @@ Length:
 
 A reviewer should `grep` / eyeball the diff for these before reading logic:
 
-- The description's first paragraph does not say what changed and why, or reads as raw AI output (diff restated file by file, "This PR introduces a comprehensive…", far longer than the change) → ask for a rewrite in the author's words before reviewing code. See Section 4 → "PR description shape".
+- The description has no `## What` / `## Why`, or they don't say what changed and why, or read as raw AI output (diff restated file by file, "This PR introduces a comprehensive…", far longer than the change) → ask for a rewrite in the author's words before reviewing code. See Section 4 → "PR description shape".
 - `print(` / `prints(` / `print_verbose(` in non-tool GDScript → likely debug leftover.
 - New `tracing::error!` (Rust) or `push_error(` / `printerr(` (GDScript) in the diff → these ship to Sentry and cost quota. Confirm the condition is a genuine, actionable fault. If it's expected/recoverable or already has a fallback (missing texture/asset, optional absent, 404-then-default), ask to downgrade to `warn!`/`push_warning` or `debug!`/`print`. See Section 5.
 - New `tracing::error!` / `tracing::warn!` (or `push_error`/`printerr`) inside a loop, per-entity/per-frame scan, `_process`, or the scene-runner/pointer-event hot path → potential Sentry quota burst; flag even warnings here.

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -18,6 +18,7 @@ These are blocking prerequisites. Resolve each one (or explicitly note its statu
    - If no iOS artifact exists, output exactly: *"No iOS build on this PR — a maintainer can add the `build` label to trigger one. I will not approve platform-sensitive iOS changes without a green iOS build."* and hold approval.
    - If the PR is purely backend / GDScript-with-no-platform-branch / docs, an iOS build is **not** required — call that out and proceed.
 3. **Submodule pointer drift.** If `git diff main...HEAD` shows changes under `plugins/dcl-godot-ios/godot` or any submodule and the PR description does not mention it, treat it as accidental and ask the author to confirm.
+4. **The description says what and why.** Read the first paragraph. If it does not tell you what changed and why in plain language, or it reads as raw AI output (see Section 4 → "PR description shape"), ask the author to rewrite it in their own words before a substantive review. The description is the author's statement of understanding; reverse-engineering it from the diff moves that work onto the reviewer.
 
 If any of (1) or (2) fail and you proceed anyway, say so explicitly in the review header.
 
@@ -124,7 +125,7 @@ Apply this order. Everything below "Correctness" is negotiable; the top tier is 
 15. **Dev-only flags live in release builds.** Deep-link params like `fake-owned-wearables`, `disable-profile-deploy`, `dclenv=zone` parse unconditionally today. Acceptable but worth flagging for gating behind `#[cfg(debug_assertions)]` / a feature flag / a loud warning (#1849).
 16. **Dead code / orphan uniforms / unused imports.** Rust `clippy -D warnings` catches most of this, but `.tres` / `.tscn` / `.gdshader` don't — reviewers catch those manually. A shader uniform removed in `.gdshader` should also be removed from every `.tres`/`.tscn` that set it, and from every material that references a different-typed replacement (#1878 had a `Texture2D → samplerCube` mismatch that would render black silently).
 17. **Performance on the hot path.** The scene-runner update loop, pointer-event loop, and shaders are hot. Watch for per-pixel `acos`/`normalize`/`pow` that can be replaced by compares, per-frame `find_node` / `get_node` lookups, unbounded `for x in all_entities` scans inside scene systems, and JSON serialization on the scene thread.
-18. **Test plan quality.** PR descriptions in this repo follow `## Summary` + `## Test plan` (bulleted checklist). A missing or vague test plan is a legitimate review comment, especially for UI changes. Mobile-visible changes should say *which* platform was tested on. **The QA team runs these by hand on a real phone** (builds auto-distribute via TestFlight / Firebase App Distribution) — a case a tester couldn't reproduce cold (steps that don't start from opening the app, no observable expected result, or non-obvious required state left unsaid) is worth holding on. See Section 4 → "Writing test steps QA can execute" for the required format and a worked example.
+18. **Description and test plan quality.** PR descriptions in this repo open with a what/why lead paragraph, an optional collapsed Details block, and a `## Test plan` (see Section 4 → "PR description shape", including the AG rule on AI-generated text). A description that does not say what changed and why in its first paragraph, or reads as raw AI output, is a rewrite request before code review. A missing or vague test plan is a legitimate review comment, especially for UI changes. Mobile-visible changes should say *which* platform was tested on. **The QA team runs these by hand on a real phone** (builds auto-distribute via TestFlight / Firebase App Distribution) — a case a tester couldn't reproduce cold (steps that don't start from opening the app, no observable expected result, or non-obvious required state left unsaid) is worth holding on. See Section 4 → "Writing test steps QA can execute" for the required format and a worked example.
 19. **Comments that explain "why", not "what".** Consistent with the CLAUDE.md guidance — reviewers flag comments that restate the code, and praise ones that cite a matching Unity file/line or explain a non-obvious Godot quirk.
 
 ---
@@ -132,18 +133,35 @@ Apply this order. Everything below "Correctness" is negotiable; the top tier is 
 ## 4. Team conventions to uphold
 
 ### PR description shape
+
+The description is the author's statement of **what changed and why**, written for whoever reads it — reviewer, QA, another team, someone reading the changelog months later. It is not a summary of the diff. The `pr-description` skill (`.claude/skills/pr-description/`) is the authoring guide; this section is what a reviewer holds it to.
+
 ```
-## Summary
-- <bullet>
-- <bullet>
+<Lead paragraph — WHAT changed and WHY, 2–5 sentences, plain language, no header.
+ Reading only this, a teammate on another team understands the change.>
 
 Closes #<issue>
 
+<details>
+<summary>Details</summary>
+Root cause, approach and trade-offs, what was deliberately left out, screenshots/video,
+per-file notes when non-obvious. Omitted entirely when the lead says it all.
+</details>
+
 ## Test plan
-- [ ] <steps>
-- [ ] <steps>
+- [ ] <cases per "Writing test steps QA can execute" below — or "No QA needed — no behavior change">
 ```
-Larger PRs often add a "Root Cause" section before Summary, a Video/Images section after it, and a "Future plans" section at the end. Commit prefixes follow conventional commits: `feat:`, `fix:`, `chore:`, `refactor:`.
+
+Optional, only when they add clarity: a **Heads-up** line after the lead naming which team was told and where; a **Changes** list (file → what it does) inside Details; **Future plans** / **Known gaps** at the end. Commit prefixes follow conventional commits: `feat:`, `fix:`, `chore:`, `refactor:`. Older PRs use `## Summary` bullets in place of the lead paragraph — accept that on existing PRs, ask for the lead on new ones.
+
+**The AG rule — the author owns understanding the change.** The team's guideline for AI-assisted work (messages, PRs, docs, issues) is that anything with your name on it must be at **AG-3 to AG-5**: you read it, you changed what didn't sound right, and you can explain any part of it if asked. AI can help write code faster; it must not make *understanding* the change slower for everyone else. Concretely, a reviewer should hold the PR — before reading the code — when the description:
+
+- **does not say what and why in the first paragraph** (opens with a file list, a `## Changes` dump, or "This PR introduces a comprehensive…");
+- **reads as raw AI output** — restates the diff file by file, narrates the work, hedges with filler, or is far longer than the change warrants. Ask for a rewrite in the author's own words; do not reverse-engineer the intent from the diff on their behalf;
+- **hides ride-along behaviour changes** — anything outside the feature's stated scope that changes what a player, creator or build sees must be stated in the lead, not buried in Details;
+- **touches something another team, service, SDK or workflow depends on with no heads-up** (shared UI components, auth, comms protocol, asset pipeline, mobile-bff contract, CI workflows). The norm is a short message in the relevant shared channel — `#ext-foundation` for cross-org — *before* merging: "I'm planning to merge X, it changes Y and may affect Z. Any concerns?". Ask whether it was posted.
+
+The same rule applies to review comments and replies: keep them short, in your own words, and skip AI-generated explanations that add text without adding clarity.
 
 ### Writing test steps QA can execute
 
@@ -220,7 +238,33 @@ The PR-level workflows a reviewer should expect green before approving:
 - `🍏 iOS` is **opt-in** — gated on the `build` label (alias: `build-ios`), which also posts a Slack "Android build ready" notification with the R2 APK download link. See Section 0 pre-flight: for platform-sensitive changes the iOS build is *required* and the PR should be held until a maintainer adds the label. For pure-backend / docs PRs, an absent iOS build is fine — say so explicitly.
 
 ### Release flow
-`release` branch is used for production cuts. PRs titled `Release: merge release into main` / `Merge main into release` appear periodically and should usually be merge-only (no review nits on code that's already been reviewed upstream).
+`release` branch is used for production cuts. PRs titled `chore: sync release into main (vX.Y.Z)` / `chore: merge release back into main` appear periodically and should usually be merge-only (no review nits on code that's already been reviewed upstream).
+
+### Release Candidate PR shape
+A **Release Candidate** promotes `main` (or a cherry-picked subset) into `release`: base `release`, head `release-X.Y.Z`, title `Release Candidate X.Y.Z`. Its description is the release changelog and the QA sheet — it is built from the promoted PRs' own descriptions (which is why the lead-paragraph rule above matters). Review it as a document, not as code — the code was reviewed in the individual PRs:
+
+```
+## Release Candidate X.Y.Z
+
+<Lead: what is promoted (main sha or cherry-picked set), clean promotion or not,
+ what was deliberately excluded, which PR bumped the version; then the release theme in player terms.>
+
+- **Base:** `release` · **Head:** `release-X.Y.Z`
+
+## What's included
+**Features** — one line per PR in player/creator terms, ending in (#PR)
+**Fixes** — the symptom that went away, with the measurement when the PR had one (#PR)
+**Technical** — no QA needed (CI, tooling, back-merges, dependency bumps)
+
+## Test plan
+**Build:** `vX.Y.Z.<build>-<sha>-prod` · one Android + one iPhone.
+- [ ] **Version** — login screen and Settings → About read `vX.Y.Z.<build>-<sha>-prod`
+- [ ] **<Feature>** — one action that proves it on a phone → what QA should see `#PR`
+- [ ] **Regression** — enter a few scenes, chat, change a wearable, play an emote: no crashes
+**Known gap:** anything shipping without a device run, and why
+```
+
+What to check on an RC: every commit in `origin/release..head` is accounted for by a line or explicitly excluded; every Feature/Fix line has a Test plan line and no Technical line does; the **Version** line is present and matches `lib/Cargo.toml` / `godot/export_presets.cfg`; a patch RC stacked on a previous one says so and lists only the additions. Examples: #2787 (clean promotion), #2797 (cherry-picked, stacked on 1.13.0).
 
 ---
 
@@ -311,6 +355,7 @@ Length:
 
 A reviewer should `grep` / eyeball the diff for these before reading logic:
 
+- The description's first paragraph does not say what changed and why, or reads as raw AI output (diff restated file by file, "This PR introduces a comprehensive…", far longer than the change) → ask for a rewrite in the author's words before reviewing code. See Section 4 → "PR description shape".
 - `print(` / `prints(` / `print_verbose(` in non-tool GDScript → likely debug leftover.
 - New `tracing::error!` (Rust) or `push_error(` / `printerr(` (GDScript) in the diff → these ship to Sentry and cost quota. Confirm the condition is a genuine, actionable fault. If it's expected/recoverable or already has a fallback (missing texture/asset, optional absent, 404-then-default), ask to downgrade to `warn!`/`push_warning` or `debug!`/`print`. See Section 5.
 - New `tracing::error!` / `tracing::warn!` (or `push_error`/`printerr`) inside a loop, per-entity/per-frame scan, `_process`, or the scene-runner/pointer-event hot path → potential Sentry quota burst; flag even warnings here.


### PR DESCRIPTION
## What

Adds a `pr-description` Claude Code skill and the matching rules in `REVIEW.md`. Every PR description now has the same shape: `## What`, `## Why`, an optional collapsed `## Details`, and the existing `## Test plan`. Release Candidate PRs get their own shape and a recipe to build the changelog from each promoted PR. Reviewers are told to hold a PR whose description does not meet it.

## Why

This applies the AI-generated content guideline shared in Slack to PRs: the author owns understanding and communicating the change (AG-3 to AG-5). We are seeing PRs where the description is a raw AI dump of the diff, and the reviewer ends up doing the understanding work the author should have done. A fixed What/Why shape makes that visible at a glance and gives Claude one template to draft against.

## Details
<details>
<summary>Expand</summary>

- `.claude/skills/pr-description/SKILL.md` — new. §1 condenses the AG scale into PR terms, including the cross-team heads-up before merging. §2 is the development PR shape with a What/Why example adapted from #2779, an authoring procedure that starts from reading the diff, and a self-check. §3 is the Release Candidate shape modelled on #2787 and #2797, with the git/gh commands to establish the promoted range and build the changelog from each PR's own description.
- `REVIEW.md` — §0 gets a pre-flight item to read What/Why before the diff; §4 "PR description shape" is rewritten around the new sections and the AG rule, with the four concrete reasons a reviewer asks for a rewrite; §4 gains a "Release Candidate PR shape" subsection; Tier 3 item 18 and the §7 red-flag list point at the new rule. Sync-PR titles under Release flow updated to the current `chore: sync release into main` form.
- Older PRs using `## Summary` bullets are still accepted; the sections are asked for on new ones.

</details>

## Test plan

No QA needed — no behavior change (docs and a Claude Code skill only).

Optional: in a Claude Code session on this branch, ask it to draft a PR description and confirm the `pr-description` skill loads and produces the What / Why / Details / Test plan shape.
