### PR TITLE
chore(ci): tolerate Godot's headless exit crash in the Linux build

### DIFF
--- a/src/check_gdscript.rs
+++ b/src/check_gdscript.rs
@@ -1,4 +1,7 @@
-use anyhow::Result;
+use std::io::{self, BufRead, BufReader, Write};
+use std::process::ExitStatus;
+
+use anyhow::{Context, Result};
 use xtaskops::ops::cmd;
 
 use crate::{
@@ -6,6 +9,79 @@ use crate::{
     path::get_godot_path,
     ui::{print_message, print_section, MessageType},
 };
+
+/// Run headless Godot, streaming its output through to our own stdout while
+/// keeping a copy so the caller can look for a success marker in it.
+///
+/// stderr is folded into stdout so the copy holds everything the CI log shows,
+/// in the order it was written. `program` is a parameter rather than a call to
+/// [`get_godot_path`] so tests can drive this with a stand-in for Godot.
+fn run_headless(program: String, args: Vec<String>) -> Result<(String, ExitStatus)> {
+    let reader = cmd(program, args)
+        .stderr_to_stdout()
+        // Without this, the last `read` below fails instead of reporting EOF.
+        .unchecked()
+        .reader()?;
+
+    let mut child_output = BufReader::new(&reader);
+    let mut log = String::new();
+    let mut line = Vec::new();
+    let stdout = io::stdout();
+    let mut sink = stdout.lock();
+    loop {
+        line.clear();
+        if child_output.read_until(b'\n', &mut line)? == 0 {
+            break;
+        }
+        let text = String::from_utf8_lossy(&line);
+        write!(sink, "{text}")?;
+        sink.flush()?;
+        log.push_str(&text);
+    }
+
+    let status = reader
+        .try_wait()?
+        .context("headless Godot reached EOF without exiting")?
+        .status;
+    Ok((log, status))
+}
+
+/// Decide whether a headless run passed, working around a Godot 4.6.2 crash on
+/// the way out.
+///
+/// Every headless test here runs as a `SceneTree` script over the real project,
+/// so Godot boots all 15 autoloads (network, threads, `CanvasItem`s) and then
+/// races them during teardown: it leaks RIDs and ObjectDB instances and dies
+/// with SIGSEGV — sometimes surfacing as SIGABRT from its own crash handler —
+/// *after* the test has already printed its result. Between 2026-08-15 and
+/// 2026-09-10 that turned the Linux build red 36 times with nothing wrong in the
+/// commit; of 32 such crashes with logs still retained, 30 came after the
+/// success marker.
+///
+/// The real fix is to stop booting the autoload stack for these tests. Until
+/// then, trust the marker over the exit status — but only for a death by
+/// signal, since a genuinely failing test prints `[<name>] FAIL: n case(s)` and
+/// quits with code 1 without ever printing the marker.
+fn headless_result(label: &str, log: &str, status: ExitStatus, success_marker: &str) -> Result<()> {
+    if status.success() {
+        return Ok(());
+    }
+
+    // `code()` is `None` only when a signal killed the process, which cannot
+    // happen on Windows, so this stays false there.
+    if status.code().is_none() && log.contains(success_marker) {
+        print_message(
+            MessageType::Warning,
+            &format!(
+                "{label} passed but Godot crashed on the way out ({status}) — \
+                 treating as success (engine teardown crash, not a test failure)"
+            ),
+        );
+        return Ok(());
+    }
+
+    Err(anyhow::anyhow!("{label} failed ({status})"))
+}
 
 pub fn check_gdscript() -> Result<()> {
     print_section("GDScript Validation");
@@ -17,55 +93,72 @@ pub fn check_gdscript() -> Result<()> {
         "Running script validation on all .gd files...",
     );
 
-    let output = cmd!(
+    let (log, status) = run_headless(
         godot_bin,
-        "--headless",
-        "--path",
-        GODOT_PROJECT_FOLDER,
-        "res://src/test/validate_all_scripts.tscn",
-        "--quit"
-    )
-    .run()?;
+        vec![
+            "--headless".to_owned(),
+            "--path".to_owned(),
+            GODOT_PROJECT_FOLDER.to_owned(),
+            "res://src/test/validate_all_scripts.tscn".to_owned(),
+            "--quit".to_owned(),
+        ],
+    )?;
 
-    if output.status.success() {
-        print_message(
-            MessageType::Success,
-            "All GDScript files validated successfully!",
-        );
-        Ok(())
-    } else {
-        print_message(
-            MessageType::Error,
-            "GDScript validation failed. See errors above.",
-        );
-        Err(anyhow::anyhow!("GDScript validation failed"))
+    match headless_result(
+        "GDScript validation",
+        &log,
+        status,
+        "All scripts validated successfully!",
+    ) {
+        Ok(()) => {
+            print_message(
+                MessageType::Success,
+                "All GDScript files validated successfully!",
+            );
+            Ok(())
+        }
+        Err(err) => {
+            print_message(
+                MessageType::Error,
+                "GDScript validation failed. See errors above.",
+            );
+            Err(err)
+        }
     }
 }
 
 /// Runs a set of headless GDScript unit tests, each a `SceneTree` script that
 /// exits non-zero on failure. `scripts` are paths under `godot/`, given in full so
 /// tests are not confined to one directory.
+///
+/// Each script announces itself as `[<file stem>] PASS`; see [`headless_result`]
+/// for why that marker, rather than the exit status, decides the outcome.
 fn run_script_tests(section: &str, kind: &str, scripts: &[&str]) -> Result<()> {
     print_section(section);
 
     let godot_bin = get_godot_path();
     for script in scripts {
         let name = script.rsplit('/').next().unwrap_or(script);
+        let stem = name.strip_suffix(".gd").unwrap_or(name);
         print_message(MessageType::Info, &format!("Running {name}..."));
-        let output = cmd!(
+
+        let (log, status) = run_headless(
             godot_bin.clone(),
-            "--headless",
-            "--path",
-            GODOT_PROJECT_FOLDER,
-            "--script",
-            &format!("res://{script}")
-        )
-        .run()?;
-        if !output.status.success() {
+            vec![
+                "--headless".to_owned(),
+                "--path".to_owned(),
+                GODOT_PROJECT_FOLDER.to_owned(),
+                "--script".to_owned(),
+                format!("res://{script}"),
+            ],
+        )?;
+
+        if let Err(err) = headless_result(name, &log, status, &format!("[{stem}] PASS")) {
             print_message(MessageType::Error, &format!("{name} FAILED"));
-            return Err(anyhow::anyhow!("{kind} test failed: {name}"));
+            return Err(err.context(format!("{kind} test failed: {name}")));
         }
     }
+
     print_message(MessageType::Success, &format!("All {kind} tests passed!"));
     Ok(())
 }
@@ -89,4 +182,58 @@ pub fn test_i18n() -> Result<()> {
         "localization",
         &["src/test/i18n/test_translation_key.gd"],
     )
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+
+    /// Drives the real pipeline against a stand-in for Godot, covering the
+    /// decision table [`headless_result`] exists for. The interesting case is
+    /// the second: a test that reported success and *then* died from a signal
+    /// must stay green, while every other kind of red must stay red.
+    #[test]
+    fn exit_crash_after_the_marker_is_the_only_failure_forgiven() {
+        // (child shell, expected to pass, what it stands for)
+        let cases = [
+            (r#"echo "[t] PASS""#, true, "clean pass"),
+            (
+                r#"echo "[t] PASS"; kill -SEGV $$"#,
+                true,
+                "passed, then the engine crashed tearing down autoloads",
+            ),
+            (
+                r#"echo "[t] FAIL: 3 case(s)" >&2; exit 1"#,
+                false,
+                "real test failure",
+            ),
+            (
+                // A failing test crashes on the way out just as often as a
+                // passing one, so the signal alone must not excuse it.
+                r#"echo "[t] FAIL: 3 case(s)" >&2; kill -SEGV $$"#,
+                false,
+                "real test failure that also crashed on exit",
+            ),
+            (r#"kill -SEGV $$"#, false, "crashed before any verdict"),
+            (
+                r#"echo "Godot Engine v4.6.2"; exit 2"#,
+                false,
+                "branch missing the subcommand / bad invocation",
+            ),
+        ];
+
+        for (script, should_pass, what) in cases {
+            let (log, status) = run_headless(
+                "/bin/sh".to_owned(),
+                vec!["-c".to_owned(), script.to_owned()],
+            )
+            .expect("running the stand-in should not fail");
+            let verdict = headless_result("t", &log, status, "[t] PASS");
+            assert_eq!(
+                verdict.is_ok(),
+                should_pass,
+                "{what}: expected pass={should_pass}, got {verdict:?} (status {status}, log {log:?})"
+            );
+        }
+    }
 }


### PR DESCRIPTION
# What

Headless Godot runs in the Linux build (`test-avatar`, `test-i18n`, `check-gdscript`) are now judged by the success marker each script prints, not by the exit status alone — **but only when the process was killed by a signal**. Everything else fails exactly as before.

| outcome | verdict |
|---|---|
| exit 0 | green |
| **killed by a signal AND the log has the marker** | **green + warning** |
| killed by a signal, no marker | red |
| exit ≠ 0 (1, 2, …) | red |

Also in here: child output is streamed line by line so the CI log reads the same as today, and `.unchecked()` makes duct hand back the exit status instead of erroring out — which is why the existing `status.success()` branch never actually ran (you saw duct's `Failed: command [...] exited with code <signal 11>` instead of `<test> FAILED`).

One test drives the whole pipeline against a stand-in for Godot, covering all six cases including the one that matters: a **failing** test that also crashed on exit must stay red.

# Why

I pulled 90 days of CI (2026-06-12 → 09-10): 1053 `🔗 GHA` runs, 864 where the Linux job actually ran, 83 red jobs, with logs and annotations for each.

**Of the 83 reds, 69 (83%) were flaky and only 7 (8%) were a real defect in the commit.** And of 23 reds that someone re-ran, **21 went green with zero code changes (91%)**.

There is a clean inflection point. `Avatar regression tests` landed on 2026-08-14 (#2699 / #2702):

| | first-attempt green |
|---|---|
| Jun 12 – Aug 14 | **94.7%** (588/621) |
| Aug 15 – Sep 10 | **80.2%** (195/243) |
| last week | **72.7%** |

Per-step failure rate since it landed: `Avatar regression tests` **15.5%** (39/252), `Localization tests` **7.8%** (6/77, added 2026-09-02 by #2754), `Validate GDScript` 1.15%. Everything else is at or near 0%.

**Root cause.** These tests are `SceneTree` scripts run with `--script` against the real project, so Godot boots all 15 autoloads (`Global`, `SplashOverlay`, `ConnectionQualityMonitor`, `DebugWs`, `TouchFeedback`, …) — network, threads and viewport-attached `CanvasItem`s — and then races them on the way out. The test passes and *then* the process dies:

```
[test_avatar_locomotion_grounded] PASS          <- the test passed
[Startup] global._ready start: 98ms             <- autoloads only start booting here
SceneInspectorBridge: Dedicated WebSocket channel -> ws://127.0.0.1:9231
WARNING: 1 RID of type "CanvasItem" was leaked.
WARNING: ObjectDB instances leaked at exit
ERROR: 1 resources still in use at exit (core/io/resource.cpp:810)
Error: ... exited with code <signal 11>
```

GitHub only keeps logs ~15 days, so I have full logs for the 38 reds between 08-26 and 09-10. **31 of those 38 (82%) are this exact crash, and 30 of 32 crashes happened after the success marker.** The `<signal 6>` cases are the same bug — the header reads `Program crashed with signal 11` and then Godot's own crash handler aborts. Crashes are spread across scripts (`state_machine_graph` 11, `locomotion_grounded` 7, `anim_throttle` 7, `translation_key` 5, `validate_all_scripts` 1), which is why the marker check covers all three commands.

The signal alone is **not** a safe discriminator: the 3 genuine reds on `feat/graphic-profiles-budgets-2672` also died with `<signal 6>`, because `quit(1)` goes through the same broken teardown. Hence gating on the marker.

Cost so far: 13.4h of runner time burned on flaky reds, 24 branches hit, and `docker-build-test` (`needs: linux-build`) blocked each time. Worse, **72% of reds were never re-run** — people push over them, so the gate has lost its signal.

Without this class of failure the last four weeks would have been **95.1% green instead of 80.2%**.

# Next steps

This is a mitigation, not the fix. Follow-ups worth filing:

1. **The real fix — stop booting the autoload stack for these tests** (a minimal `project.godot` without `[autoload]`, or a separate test project). Kills the crash at the source and lets this workaround be reverted. Note `test_avatar_autoplay_stomp` has never crashed once — worth checking what it does differently on teardown.
2. **Say "rebase onto main" on exit code 2.** 5 of the 83 reds were branches cut before the step existed: the workflow comes from the merge base but the checkout uses `pull_request.head.sha`, so xtask reports a cryptic `The subcommand 'test-avatar' wasn't recognized`.
3. **Alert if this workaround starts firing a lot.** The warning it prints is the signal that the underlying engine crash is getting worse rather than being fixed.

## Verification

`cargo fmt --check` and `cargo clippy --all-targets` clean on the touched file; all 8 xtask tests pass.

Not verified against the real Godot binary — that needs a full install + asset import, and the worthwhile assertion (does the marker reach the pipe before the crash?) is already answered by the 30 CI logs above, which have the identical setup: stdout to a pipe, process killed by a signal, marker present. If the marker were ever lost to buffering the build goes red, never falsely green.
