### PR TITLE
fix(iap): point the production storefront links at the shop

### DIFF
--- a/lib/src/urls/mod.rs
+++ b/lib/src/urls/mod.rs
@@ -311,14 +311,12 @@ impl Storefront {
     }
 }
 
-/// Storefront serving an environment. Zone moved to the new shop; org stays on the
-/// classic marketplace, which is also the only one that fires the
-/// `decentraland://open?iap_enabled=true&urn=` return deep link the IAP tracker
-/// relies on. `today` points at a local dev server and keeps the classic routes.
+/// Storefront serving an environment. Both public envs are on the shop; `today` is a
+/// local dev server and keeps the classic routes.
 fn storefront(env: DclEnvironment) -> Storefront {
     match env {
-        DclEnvironment::Zone => Storefront::Shop,
-        _ => Storefront::Marketplace,
+        DclEnvironment::Org | DclEnvironment::Zone => Storefront::Shop,
+        DclEnvironment::Today => Storefront::Marketplace,
     }
 }
 
@@ -473,10 +471,9 @@ mod tests {
 
     #[test]
     fn test_storefront_routes_per_env() {
-        // Zone moved the storefront to /shop; org (and the localhost dev build,
-        // which ignores the path) stay on /marketplace.
+        // Only the localhost dev build stays on /marketplace.
         assert_eq!(storefront(DclEnvironment::Zone), Storefront::Shop);
-        assert_eq!(storefront(DclEnvironment::Org), Storefront::Marketplace);
+        assert_eq!(storefront(DclEnvironment::Org), Storefront::Shop);
         assert_eq!(storefront(DclEnvironment::Today), Storefront::Marketplace);
 
         // Every destination the client links to, in both route tables. The shop


### PR DESCRIPTION
## What

On production every storefront link now opens the shop (`decentraland.org/shop`) instead of the classic marketplace: the backpack's recommended-item cards, the "GO TO SHOP" CTAs in Backpack and Emotes, the empty-state link, the item link on a profile, and the claim-a-NAME link.

## Why

The shop replaced the classic marketplace on `.org`, but the client's environment → storefront table was only ever updated for `.zone`. Everything else fell through to the classic routes, so a button reading "GO TO SHOP" landed on `/marketplace`. The same build booted with `dclenv=…,zone` reached `/shop` correctly.

Three things ride along on production, because the two web apps filter differently. The recommendation cards inside the app are unaffected — those filter through the catalog API, not the web grid.

- The shop grid ignores the `genders` param we append, so items with no representation for the player's body shape can show up there.
- The shop grid has no price ceiling. In mobile-IAP mode the classic marketplace injects its own `maxPrice`, so items above what one credits pack buys can now show up.
- No "try it on in world" button after a purchase: that is the classic success page firing `decentraland://open?iap_enabled=true&urn=`, and the shop has no equivalent. The round-trip still closes (`MarketplaceTracker` uses the native `webview_closed` signal on iOS and app focus elsewhere), but the player dismisses the browser themselves. Fixing that belongs in the shop.

## Details

<details>
<summary>Expand</summary>

`storefront()` in `lib/src/urls/mod.rs`: `Org` now resolves to `Shop`, matched exhaustively so a new environment has to state which storefront serves it. Both route tables were already in the file:

| destination | `/marketplace` | `/shop` |
|---|---|---|
| browse | `/browse?section=wearables` | `/items?category=wearable` |
| item detail | `/contracts/{c}/items/{i}` | `/item/{c}/{i}` |
| claim NAME | `/names/claim` | `/items?category=names` |

The shop's `?category=names` is the NAME registration page, not a listing, so the claim link keeps working.

Ran locally: `cargo test --lib urls::` (7 passed), `cargo clippy --lib -- -D warnings`, `cargo fmt --all -- --check`.

Builds already installed from the stores keep going to `/marketplace`. A `view=mobile-iap` redirect in the classic marketplace app is being prepared separately for them.

</details>

## Test plan

Read the URL bar in the in-app browser to tell the apps apart: the shop serves `/shop/…`, the classic marketplace `/marketplace/…`.

**Storefront links land on the shop**

Setup: signed-in account with a credits balance above 0.

1. Open the app and sign in.
2. Open the menu and go to Backpack.
3. Scroll the wearables grid to the recommended row, tap a card, then tap **DETAIL**.
4. Back in the app, tap the **GO TO SHOP** card at the end of that row.
5. Back in the app, switch to the Emotes tab and tap its **GO TO SHOP** card.
6. Back in the app, open Profile and tap one of the equipped items.

- [ ] Step 3 opens `decentraland.org/shop/item/<contract>/<itemId>` and renders that item's page, not "Page not found"
- [ ] Step 4 opens `decentraland.org/shop/items?category=wearable` with items in the grid
- [ ] Step 5 opens `decentraland.org/shop/items?category=emote`
- [ ] Step 6 opens a `decentraland.org/shop/item/…` page
- [ ] No URL in any step contains `/marketplace/`

**Claim a NAME**

1. Open the app and sign in.
2. Open Profile and start changing the nickname.
3. Tap the claim-a-NAME link.

- [ ] Opens `decentraland.org/shop/items?category=names` showing the NAME registration page (name field + availability check), not an empty listing

**Purchase round-trip still delivers the item**

Setup: account with enough credits to buy one item from the recommended row.

1. Open the app, go to Backpack, tap a recommended card, tap **DETAIL**.
2. Complete the purchase in the shop.
3. Dismiss the browser by hand — swipe down on iOS, back button on Android. The shop shows no "try it on in world" button; that is expected.

- [ ] The item appears in the backpack within ~5 minutes, without restarting the app
- [ ] The credits balance in the app drops to reflect the purchase

**Regression**

- [ ] Enter a few scenes, chat, change a wearable, play an emote from the wheel: no crashes
