### PR TITLE
fix(version-gate): render the force-update overlay above the startup splash

### DIFF
--- a/godot/src/ui/pages/auth/lobby.gd
+++ b/godot/src/ui/pages/auth/lobby.gd
@@ -501,7 +501,7 @@ func _ready():
 	if Global.is_mobile():
 		var gate_decision := await _async_run_version_gate()
 		if gate_decision == "hard":
-			# Overlay blocks interaction; loading screen stays behind it.
+			# The overlay replaces the startup splash and blocks all interaction.
 			return
 
 	# Track startup metric for analytics

--- a/godot/src/version_gate.gd
+++ b/godot/src/version_gate.gd
@@ -5,7 +5,8 @@ const SNOOZE_SECONDS := 86400  # 24h
 const OVERLAY_SCENE := preload(
 	"res://src/ui/components/organisms/update_available/update_available.tscn"
 )
-const OVERLAY_CANVAS_LAYER := 99  # modal_manager uses 100, so this sits just below
+# Must sit ABOVE the SplashOverlay autoload and modal_manager, which both use 100.
+const OVERLAY_CANVAS_LAYER := 101
 
 const RESULT_PROCEED := "proceed"
 const RESULT_SOFT := "soft"
@@ -74,6 +75,12 @@ func async_check() -> String:
 
 
 func show_overlay(allow_later: bool) -> void:
+	# The startup splash is an opaque full-screen CanvasLayer (SplashOverlay autoload,
+	# layer 100) and on the hard path nothing else ever dismisses it: lobby._ready()
+	# returns right after this call, so show_panel() -- the only fade_out() caller during
+	# startup -- is never reached. Drop it here, and render above it while it fades.
+	SplashOverlay.fade_out()
+
 	var layer := CanvasLayer.new()
 	layer.layer = OVERLAY_CANVAS_LAYER
 	var overlay := OVERLAY_SCENE.instantiate()

--- a/lib/src/urls/mod.rs
+++ b/lib/src/urls/mod.rs
@@ -236,9 +236,13 @@ pub fn account_deletion() -> String {
         suffix(ServiceGroup::MobileBff)
     )
 }
+/// Force-update gate. Pinned to the `v2` track: the bare `/app-versions` route serves the
+/// frozen legacy row, whose minimum can never be raised again because clients 1.12.0 to
+/// 1.13.1 render the update overlay below the startup splash and hang on the spinner
+/// instead of showing it. Only builds carrying that fix may read a movable track.
 pub fn app_versions() -> String {
     format!(
-        "https://mobile-bff.decentraland.{}/app-versions",
+        "https://mobile-bff.decentraland.{}/app-versions/v2",
         suffix(ServiceGroup::MobileBff)
     )
 }


### PR DESCRIPTION
## Problem

Triggering a hard force-update (setting `minimalRequiredVersionNumber` above the client's version) leaves the app on the purple startup screen with the spinner turning forever. The update dialog never appears and there is no way out of the screen.

## Root cause

Two independent regressions from the same change, #2561 (`95bd46d8`, 2026-07-22):

1. **The overlay renders underneath the splash.** `version_gate.show_overlay()` puts the dialog on a `CanvasLayer` at **99** — a number chosen when `modal_manager` (100) was the topmost layer. #2561 moved the startup splash into the `SplashOverlay` autoload: an opaque, full-screen `CanvasLayer` at **100** that persists across scene changes. Since then the dialog has been instantiated and added to the tree, but painted below the splash.

2. **Nothing dismisses the splash on the hard path.** `lobby._ready()` returns as soon as the gate answers `hard`, and the only startup caller of `SplashOverlay.fade_out()` is `show_panel()` (`lobby.gd:138`), which that early return never reaches.

Before #2561 the splash was `Main/DclSplash`, a plain `Control` inside `lobby.tscn` (layer 0), so the gate's layer-99 overlay covered it correctly.

## Fix

- `OVERLAY_CANVAS_LAYER` 99 → **101**, above both `SplashOverlay` and `modal_manager`.
- `show_overlay()` calls `SplashOverlay.fade_out()`, so the splash stops being the screen the moment the update dialog takes over.

The soft path benefits too: the "Later" dialog used to be hidden behind the splash until `show_panel()` faded it out, so it appeared late.

## Second commit: read the `v2` track

The thresholds at `GET /app-versions` are now frozen for good — raising the minimum there would strand every 1.12.0–1.13.1 install on the spinner rather than prompting it. decentraland/mobile-bff#89 splits that row into per-track rows, and this branch points the gate at `/app-versions/v2`, the track whose numbers can still move.

It has to ship in the same release as the fix above: a build that renders the dialog but still reads the frozen row leaves the gate unusable. It fails open on a 404 like any other non-200, so it does not depend on the mobile-bff deploy landing first.

Since this lands on `release` without a marketing version bump, the fixed build reports the same `101301` as a broken one — the track, not the version number, is what separates them.

## Affected versions

| Release | Hard gate |
|---|---|
| 0.66.0 (gate shipped, #1887) → 1.11.1 | works |
| **1.12.0 → 1.13.1** | infinite spinner |

`release-1.11.1` (2026-07-20) predates the regression; `release-1.12.0` (2026-08-06) is the first cut carrying it.

This went unnoticed because production has kept `minimalRequiredVersionNumber` at `6300` (0.63.0), so no live client has ever taken the hard path. It only surfaces now that we actually want to use the gate.

## Testing

Ran on desktop with `--force-mobile` against a local mobile-bff serving the `v2` track, with `v2.minimal = 101400` against this build's `101301`, so the gate answers `hard`. Screenshots taken from the client's own framebuffer:

- **Before the fix** (same commit with `version_gate.gd`/`lobby.gd` reverted): purple splash, isotype, spinner. No dialog. Reproduces the report exactly.
- **After**: the "Update available" dialog with a single UPDATE button, no LATER — correct for a hard gate.

Also checked the **soft** path on the pre-fix code, since that is the only lever left for the broken range: the dialog does appear there (UPDATE + LATER, visible ~6s in, once `show_panel()` fades the splash). So `recommendedVersionNumber` stays usable on those builds.

Not yet run on a physical iOS or Android device — the layering is platform-independent, but a device pass before release is worth it.