### PR TITLE
fix(startup): app never opens again after updating to 1.13.0 (iOS)

### DIFF
--- a/godot/src/connection_quality_monitor.gd
+++ b/godot/src/connection_quality_monitor.gd
@@ -80,16 +80,17 @@ func _ready() -> void:
 	_poll_timer.wait_time = FAST_POLL_SECONDS
 	_poll_timer.timeout.connect(_on_poll_timeout)
 	add_child(_poll_timer)
-	# Timer is started in _connect_signals after Global is fully initialized.
+	# Timer is started in _async_connect_signals after Global is fully initialized.
 
-	_connect_signals.call_deferred()
+	_async_connect_signals()
 
 
-func _connect_signals() -> void:
-	if Global.modal_manager == null:
-		# modal_manager not ready yet; retry next frame
-		_connect_signals.call_deferred()
-		return
+## Global._ready() awaits the startup cache clear before creating modal_manager, so
+## it can still be null here. Must yield on a real frame: a call_deferred self-retry
+## is re-entered by the same MessageQueue flush and spins until the queue overflows.
+func _async_connect_signals() -> void:
+	while Global.modal_manager == null:
+		await get_tree().process_frame
 	Global.modal_manager.connection_lost_retry.connect(_on_retry)
 	Global.modal_manager.connection_lost_exit.connect(_on_exit)
 

--- a/godot/src/ui/components/atoms/buttons/calendar_button/calendar_button.gd
+++ b/godot/src/ui/components/atoms/buttons/calendar_button/calendar_button.gd
@@ -93,7 +93,10 @@ func _get_start_iso() -> String:
 
 func _update_labels() -> void:
 	if not is_node_ready():
-		call_deferred("_update_labels")
+		# Not call_deferred: a deferred self-retry is re-entered by the same flush
+		# and spins until the message queue overflows.
+		if not ready.is_connected(_update_labels):
+			ready.connect(_update_labels, CONNECT_ONE_SHOT)
 		return
 	if not label_day or not label_time or not h_box_container_text:
 		return


### PR DESCRIPTION
## What

Users who update to 1.13.0 can get a **permanent** startup crash: the app dies on the splash and crashes again on every relaunch. Sentry issue [`EXC_BAD_ACCESS: Object was deleted while awaiting a callback`](https://dcl-regenesis-labs.sentry.io/issues/7692524485/) — 42 events / 11 users, 100% iOS, 28 of them on the current App Store build `1.13.0+1834`.

Every event has the same stack and dies in the same ~500 ms window, right after `main._start` / `Running in regular mode`:

```
CallQueue::flush            message_queue.cpp:268
  GDScriptFunction::call    gdscript_vm.cpp:1960
    CallQueue::push_callablep   message_queue.cpp:98     <- queue full
      CallQueue::statistics     message_queue.cpp:370
        Callable::get_object    callable.cpp:164         <- crash
```

## Why

1. `ConnectionQualityMonitor._ready()` deferred `_connect_signals`, which retried itself with `call_deferred` while `Global.modal_manager` was null.
2. That is not "next frame". `flush()` loops `while (i < pages_used && offset < page_bytes[i])`, so it consumes the message the callback just appended, in the same flush. Nothing else in the frame can run, `modal_manager` stays null, and the loop never ends.
3. The queue grows to `memory/limits/message_queue/max_size_mb = 64`. `push_callablep` then prints *"Message queue out of memory"* and calls `statistics()`.
4. `statistics()` walks every page **from offset 0**, i.e. the messages `flush()` already destructed (`message->~Message()`). It prints `"Object was deleted while awaiting a callback."` for each one — that string is the issue title — until a freed `Callable` holds garbage instead of null: `EXC_BAD_ACCESS`.

The trigger is the update itself. `Global._ready()` suspends on `await _async_clear_cache_if_needed()` (global.gd:638) and only creates `modal_manager` afterwards (global.gd:706), so autoloads see a half-built `Global`. That await is taken when the asset cache version changed — and 1.13.0 bumped `LOCAL_ASSETS_CACHE_VERSION` 4 → 5 in #2647. Since `config.local_assets_cache_version` is written only after the clear resolves (global.gd:879), the crash leaves the marker untouched and every relaunch repeats it.

The self-retry has been there since #1874 (April). #2647 is what pulled the trigger, which matches the issue's first-seen: 25 Aug, one day after that commit landed on staging.

## Scope

Not observed on Android (355 users / 995 sessions on `1.13.0.1736`), and the Sentry group is 100% iOS. Unverified hypothesis for the asymmetry: iOS ships an `export_debug` build, so `OS.is_debug_build()` is true and the scene-inspector boot dial + early log capture shift the timing of the first flush.

On iOS the issue counts 11 crashing users against 17 with a successful `1.13.0+1834` session (`MARTS.EXPLORER_SESSIONS`). Sentry is crash-only and quota-limited, so 11 is a floor. The App Store rollout is still early.

## Changes

- `connection_quality_monitor.gd`: wait on `get_tree().process_frame` instead of re-deferring.
- `calendar_button.gd`: same antipattern on `is_node_ready()` — wait for the `ready` signal.

## Follow-ups (not here)

- `Global._ready()` should not await halfway through building its components; every autoload after `ConnectionQualityMonitor` is exposed to the same half-built `Global`.
- Writing `local_assets_cache_version` before the clear would stop any future crash in that window from being permanent.

## Test plan

The bug needs an app-data state where the cache version differs, so a plain relaunch won't reproduce it.

- [ ] **Repro on the current build** — iOS `1.13.0+1834` on a device whose `local_assets_cache_version` is 4 (or `--clear-cache-startup`): the app dies on the splash and keeps dying on every relaunch.
- [ ] **Fixed** — same state on this build: the app boots to the lobby, and `[Startup] global._async_clear_cache end:` appears in the log.
- [ ] **Connection monitor still works** — pull the network while in-world: the connection-lost modal appears, and reconnecting dismisses it.
- [ ] **Regression** — normal launch (no cache clear), enter a scene, play an emote: no crash.
