### PR TITLE
fix(ios): stop baking the dev scene-inspector endpoint into App Store builds

### DIFF
--- a/godot/addons/dcl-ios-devtools/export_plugin.gd
+++ b/godot/addons/dcl-ios-devtools/export_plugin.gd
@@ -56,10 +56,14 @@ class DclIosDevExportPlugin:
 		return platform is EditorExportPlatformIOS
 
 	func _export_begin(_features, is_debug, _path, flags):
-		# Only debug builds declare local networking / inject launch args. The relay
-		# and log-stream are themselves gated to OS.is_debug_build(), so release
-		# builds neither use nor declare it — which is what keeps App Review happy.
+		# `is_debug` alone is not a dev signal: CI exports the store build with
+		# --export-debug too, which shipped the local-network keys and a
+		# --scene-inspector pointed at the builder's LAN IP to every App Store user.
+		# Require an explicit dev signal on top — the xtask env or an editor deploy
+		# with remote debug. CI sets neither.
 		if not is_debug:
+			return
+		if _cmdline_env().is_empty() and (flags & REMOTE_DEBUG_FLAG) == 0:
 			return
 		var lines: Array = DEV_PLIST_LINES.duplicate()
 		lines.append_array(_godot_cmdline_lines(flags))
@@ -72,26 +76,19 @@ class DclIosDevExportPlugin:
 	## `--scene-inspector=ws://…` / `--log-stream=…` to a device build (an iOS app
 	## has no real CLI).
 	##
-	## Precedence: an explicit `DCL_IOS_GODOT_CMDLINE` env (set by the xtask for full
-	## control) wins. Otherwise the build is auto-pointed at the dev hub on this
-	## machine's LAN, so the app "phones home" however it was launched — including a
-	## plain Godot-editor deploy, which never sets the env. Harmless when no hub is
-	## up: the scene-inspector client just retries with backoff and (being
-	## connection-gated) captures nothing until a consumer subscribes.
+	## `DCL_IOS_GODOT_CMDLINE`: "none"/"-" injects nothing, "auto" (or an editor
+	## deploy, which sets no env) points at the dev hub on this machine's LAN,
+	## anything else is used verbatim.
 	func _godot_cmdline_lines(flags: int) -> Array:
 		var args: Array = []
-		var raw := OS.get_environment("DCL_IOS_GODOT_CMDLINE").strip_edges()
-		# Sentinel: an explicit "none"/"-" injects nothing (the xtask sets this for
-		# `run --target ios --no-hub` → plain `--console` log streaming, no hub).
+		var raw := _cmdline_env()
 		if raw.to_lower() == "none" or raw == "-":
 			return []
-		if raw.is_empty():
-			# Plain editor deploy: auto-point at the dev hub on this machine's LAN.
+		if raw.is_empty() or raw.to_lower() == "auto":
 			var host := _lan_ip()
 			if not host.is_empty():
 				args.append("--scene-inspector=ws://%s:%d" % [host, HUB_DEVICE_PORT])
 		else:
-			# Explicit override from the xtask — full control of the cmdline.
 			args.append_array(raw.split(" ", false))
 		# Remote debugger: an iOS app has no argv, so the ONLY way the editor's
 		# remote debugger can attach is to bake `--remote-debug <uri>` in here. The
@@ -142,6 +139,9 @@ class DclIosDevExportPlugin:
 		if host.is_empty():
 			return ""
 		return "tcp://%s:%d" % [host, port]
+
+	static func _cmdline_env() -> String:
+		return OS.get_environment("DCL_IOS_GODOT_CMDLINE").strip_edges()
 
 	## This machine's private-LAN IPv4 (the address a device on the same network
 	## can reach). Skips loopback, link-local and IPv6. Empty if none found.

--- a/src/main.rs
+++ b/src/main.rs
@@ -694,6 +694,12 @@ fn main() -> Result<(), anyhow::Error> {
                         HUB_CONSUMER_PORT,
                         log_server::HubOutput::Quiet,
                     );
+                    if platform == "ios" {
+                        // Opt the export plugin in to baking the connect-out arg.
+                        // Without it nothing is injected, so CI store builds (which
+                        // never set this) ship no dev endpoint.
+                        std::env::set_var("DCL_IOS_GODOT_CMDLINE", "auto");
+                    }
                     // Default (no --hub-viewer): on iOS attach a background log
                     // viewer so this terminal shows the GDScript/Rust logs os_log
                     // hides from `--console`; Android's logcat already shows


### PR DESCRIPTION
## What

Every shipped iOS build carries a debug endpoint pointed at whatever machine built it. Production crash reports from `1.13.0+1834` show:

```
godot_engine.command_line_arguments = ["--scene-inspector=ws://192.168.64.5:9231"]
godot_engine.debug_build = true      godot_engine.mode = "export_debug"
app.build_type = "app store"         environment = production
```

`192.168.64.5` is the CI runner's LAN address. Users dial it on every launch, forever, and it is what makes iOS ask for Local Network access. The build also ships `NSLocalNetworkUsageDescription` and `NSAllowsLocalNetworking`, which the plugin's own docstring says release builds must not declare ("Release / TestFlight / App Store exports stay clean, keeping the App-Review scrutinized local-network keys out of production").

## Why it happens

`_export_begin` gated the injection on `is_debug`. That is not a dev signal: CI runs `cargo run -- export --target ios` with no `--release`, and `src/export.rs:366` picks the export mode from that flag, so the store build is an `--export-debug` export. `is_debug` is therefore true in CI and the plugin injects the plist keys plus `_lan_ip()`. Present since #2342 (1 Jul), so 1.11.x onwards.

## Changes

- The plugin now needs an explicit developer signal on top of `is_debug`: either `DCL_IOS_GODOT_CMDLINE` is set, or the editor passed the remote-debug flag. CI sets neither, so store exports carry nothing — no plist keys, no `godot_cmdline`.
- `cargo run -- run --target ios` sets `DCL_IOS_GODOT_CMDLINE=auto`, which keeps the current LAN auto-dial for dev deploys. `--no-hub` still sets `none`. An editor deploy with remote debug still auto-dials.

Behaviour change for developers: a plain editor deploy **without** remote debug no longer auto-dials the hub. Use `cargo run -- run --target ios`, or set the env.

## Not fixed here

The root cause is that CI exports iOS with the debug template at all, so `OS.is_debug_build()` is true in production. That flips gates well beyond this plugin (debug chat commands, early log capture, the IAP StoreKit environment switch — see #2829). Passing `--release` there is the real fix, but it changes the templates, symbols and every one of those gates at once, so it does not belong in a hotfix.

## Test plan

- [ ] **Store export is clean** — export via CI (or `cargo run -- export --target ios`) and check the generated `Info.plist`: no `godot_cmdline`, no `NSLocalNetworkUsageDescription`, no `NSAppTransportSecurity`.
- [ ] **Dev deploy still works** — `cargo run -- run --target ios` with the hub up: the device connects to the hub and `scripts/unified.sh` shows its logs.
- [ ] **`--no-hub` still works** — `cargo run -- run --target ios --no-hub`: no connect-out arg, `--console` streams as before.
- [ ] **Shipped build no longer prompts** — on a build from this branch, a first launch on a production build raises no Local Network prompt, and the Sentry `command_line_arguments` context is empty.
