### PR TITLE
Release Candidate 1.13.2

### DIFF
--- a/godot/addons/dcl-ios-devtools/export_plugin.gd
+++ b/godot/addons/dcl-ios-devtools/export_plugin.gd
@@ -56,10 +56,14 @@ class DclIosDevExportPlugin:
 		return platform is EditorExportPlatformIOS
 
 	func _export_begin(_features, is_debug, _path, flags):
-		# Only debug builds declare local networking / inject launch args. The relay
-		# and log-stream are themselves gated to OS.is_debug_build(), so release
-		# builds neither use nor declare it — which is what keeps App Review happy.
+		# `is_debug` alone is not a dev signal: CI exports the store build with
+		# --export-debug too, which shipped the local-network keys and a
+		# --scene-inspector pointed at the builder's LAN IP to every App Store user.
+		# Require an explicit dev signal on top — the xtask env or an editor deploy
+		# with remote debug. CI sets neither.
 		if not is_debug:
+			return
+		if _cmdline_env().is_empty() and (flags & REMOTE_DEBUG_FLAG) == 0:
 			return
 		var lines: Array = DEV_PLIST_LINES.duplicate()
 		lines.append_array(_godot_cmdline_lines(flags))
@@ -72,26 +76,19 @@ class DclIosDevExportPlugin:
 	## `--scene-inspector=ws://…` / `--log-stream=…` to a device build (an iOS app
 	## has no real CLI).
 	##
-	## Precedence: an explicit `DCL_IOS_GODOT_CMDLINE` env (set by the xtask for full
-	## control) wins. Otherwise the build is auto-pointed at the dev hub on this
-	## machine's LAN, so the app "phones home" however it was launched — including a
-	## plain Godot-editor deploy, which never sets the env. Harmless when no hub is
-	## up: the scene-inspector client just retries with backoff and (being
-	## connection-gated) captures nothing until a consumer subscribes.
+	## `DCL_IOS_GODOT_CMDLINE`: "none"/"-" injects nothing, "auto" (or an editor
+	## deploy, which sets no env) points at the dev hub on this machine's LAN,
+	## anything else is used verbatim.
 	func _godot_cmdline_lines(flags: int) -> Array:
 		var args: Array = []
-		var raw := OS.get_environment("DCL_IOS_GODOT_CMDLINE").strip_edges()
-		# Sentinel: an explicit "none"/"-" injects nothing (the xtask sets this for
-		# `run --target ios --no-hub` → plain `--console` log streaming, no hub).
+		var raw := _cmdline_env()
 		if raw.to_lower() == "none" or raw == "-":
 			return []
-		if raw.is_empty():
-			# Plain editor deploy: auto-point at the dev hub on this machine's LAN.
+		if raw.is_empty() or raw.to_lower() == "auto":
 			var host := _lan_ip()
 			if not host.is_empty():
 				args.append("--scene-inspector=ws://%s:%d" % [host, HUB_DEVICE_PORT])
 		else:
-			# Explicit override from the xtask — full control of the cmdline.
 			args.append_array(raw.split(" ", false))
 		# Remote debugger: an iOS app has no argv, so the ONLY way the editor's
 		# remote debugger can attach is to bake `--remote-debug <uri>` in here. The
@@ -142,6 +139,9 @@ class DclIosDevExportPlugin:
 		if host.is_empty():
 			return ""
 		return "tcp://%s:%d" % [host, port]
+
+	static func _cmdline_env() -> String:
+		return OS.get_environment("DCL_IOS_GODOT_CMDLINE").strip_edges()
 
 	## This machine's private-LAN IPv4 (the address a device on the same network
 	## can reach). Skips loopback, link-local and IPv6. Empty if none found.

--- a/godot/export_presets.cfg
+++ b/godot/export_presets.cfg
@@ -42,7 +42,7 @@ architectures/x86=false
 architectures/x86_64=true
 ; placeholder — the real store versionCode is stamped at export time from DCL_BUILD_NUMBER (Cloudflare Worker allocator); this committed value never ships
 version/code=1
-version/name="1.13.1"
+version/name="1.13.2"
 package/unique_name="org.decentraland.godotexplorer"
 package/name="Decentraland"
 package/signed=true
@@ -295,7 +295,7 @@ application/provisioning_profile_specifier_release=""
 application/export_method_release=1
 application/bundle_identifier="org.decentraland.godotexplorer"
 application/signature=""
-application/short_version="1.13.1"
+application/short_version="1.13.2"
 ; placeholder — the real CFBundleVersion is stamped at export time from DCL_BUILD_NUMBER (Cloudflare Worker allocator); this committed value never ships
 application/version="1"
 application/additional_plist_content="	<key>CFBundleURLTypes</key>

--- a/godot/src/connection_quality_monitor.gd
+++ b/godot/src/connection_quality_monitor.gd
@@ -80,16 +80,17 @@ func _ready() -> void:
 	_poll_timer.wait_time = FAST_POLL_SECONDS
 	_poll_timer.timeout.connect(_on_poll_timeout)
 	add_child(_poll_timer)
-	# Timer is started in _connect_signals after Global is fully initialized.
+	# Timer is started in _async_connect_signals after Global is fully initialized.
 
-	_connect_signals.call_deferred()
+	_async_connect_signals()
 
 
-func _connect_signals() -> void:
-	if Global.modal_manager == null:
-		# modal_manager not ready yet; retry next frame
-		_connect_signals.call_deferred()
-		return
+## Global._ready() awaits the startup cache clear before creating modal_manager, so
+## it can still be null here. Must yield on a real frame: a call_deferred self-retry
+## is re-entered by the same MessageQueue flush and spins until the queue overflows.
+func _async_connect_signals() -> void:
+	while Global.modal_manager == null:
+		await get_tree().process_frame
 	Global.modal_manager.connection_lost_retry.connect(_on_retry)
 	Global.modal_manager.connection_lost_exit.connect(_on_exit)
 

--- a/godot/src/ui/components/atoms/buttons/calendar_button/calendar_button.gd
+++ b/godot/src/ui/components/atoms/buttons/calendar_button/calendar_button.gd
@@ -93,7 +93,10 @@ func _get_start_iso() -> String:
 
 func _update_labels() -> void:
 	if not is_node_ready():
-		call_deferred("_update_labels")
+		# Not call_deferred: a deferred self-retry is re-entered by the same flush
+		# and spins until the message queue overflows.
+		if not ready.is_connected(_update_labels):
+			ready.connect(_update_labels, CONNECT_ONE_SHOT)
 		return
 	if not label_day or not label_time or not h_box_container_text:
 		return

--- a/lib/Cargo.lock
+++ b/lib/Cargo.lock
@@ -861,7 +861,7 @@ dependencies = [
 
 [[package]]
 name = "dclgodot"
-version = "1.13.1"
+version = "1.13.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dclgodot"
-version = "1.13.1"
+version = "1.13.2"
 edition = "2021"
 publish = false
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -694,6 +694,12 @@ fn main() -> Result<(), anyhow::Error> {
                         HUB_CONSUMER_PORT,
                         log_server::HubOutput::Quiet,
                     );
+                    if platform == "ios" {
+                        // Opt the export plugin in to baking the connect-out arg.
+                        // Without it nothing is injected, so CI store builds (which
+                        // never set this) ship no dev endpoint.
+                        std::env::set_var("DCL_IOS_GODOT_CMDLINE", "auto");
+                    }
                     // Default (no --hub-viewer): on iOS attach a background log
                     // viewer so this terminal shows the GDScript/Rust logs os_log
                     // hides from `--console`; Android's logcat already shows


### PR DESCRIPTION
## Release Candidate 1.13.2

Two fixes on top of `release`, both about what 1.13.0 shipped to iOS. Three commits: the startup crash, the dev endpoint baked into store builds, and the version bump to `1.13.2`.

**Ship this.** Users who updated to 1.13.0 and got the crash cannot recover on their own — the app crashes before it can do anything, and it crashes again on every relaunch. Updating is the only way out, so the fix has to reach the store.

## What's included

### The app never opens again after updating — startup crash

Sentry issue [`EXC_BAD_ACCESS: Object was deleted while awaiting a callback`](https://dcl-regenesis-labs.sentry.io/issues/7692524485/): 42 events / 11 users, 100% iOS, 28 of them on the current App Store build `1.13.0+1834`. Every event has the same stack and dies in the same ~500 ms window, right after `main._start`:

```
CallQueue::flush            message_queue.cpp:268
  GDScriptFunction::call    gdscript_vm.cpp:1960
    CallQueue::push_callablep   message_queue.cpp:98     <- queue full
      CallQueue::statistics     message_queue.cpp:370
        Callable::get_object    callable.cpp:164         <- crash
```

`ConnectionQualityMonitor` retried its signal wiring with `call_deferred` while `Global.modal_manager` was null. That is not "next frame": `flush()` loops `while (i < pages_used && offset < page_bytes[i])`, so it consumes the message the callback just appended, in the same drain. Nothing else in the frame can run, so the condition provably cannot change — it spins until the queue hits `max_size_mb = 64`. `push_callablep` then calls `statistics()`, which walks every page from offset 0 including the messages `flush()` already destructed (`message->~Message()`), printing `"Object was deleted while awaiting a callback."` for each until a freed `Callable` holds garbage instead of null.

The update is the trigger. `Global._ready()` suspends on `await _async_clear_cache_if_needed()` (global.gd:638) and creates `modal_manager` only afterwards (global.gd:706), so autoloads see a half-built `Global`. That await is taken when the asset cache version changed — and 1.13.0 bumped `LOCAL_ASSETS_CACHE_VERSION` 4 → 5 (#2647). `config.local_assets_cache_version` is written only after the clear resolves (global.gd:879), so the crash leaves the marker untouched and every relaunch repeats it.

The self-retry dates from #1874 (April); #2647 is what pulled the trigger, which matches the issue's first-seen — 25 Aug, one day after that commit hit staging.

Fix: wait on `get_tree().process_frame`, which is emitted from `SceneTree::process()` **before and outside** the flush (scene_tree.cpp:702 vs 704), so the whole frame runs between retries and `Global._ready()` can actually resume. `calendar_button` had the same antipattern on `is_node_ready()` and now waits for the `ready` signal.

Not observed on Android (355 users / 995 sessions on `1.13.0.1736`) and the Sentry group is 100% iOS. Unverified hypothesis for the asymmetry: iOS ships an `export_debug` build, so `OS.is_debug_build()` is true and the scene-inspector boot dial plus early log capture shift the timing of the first flush.

### Dev scene-inspector endpoint baked into App Store builds

The same crash reports show what every shipped iOS build carries:

```
godot_engine.command_line_arguments = ["--scene-inspector=ws://192.168.64.5:9231"]
godot_engine.debug_build = true      godot_engine.mode = "export_debug"
app.build_type = "app store"         environment = production
```

`192.168.64.5` is the CI runner's LAN address. Users dial it on every launch, and it is what makes iOS ask for Local Network access. The build also declares `NSLocalNetworkUsageDescription` and `NSAllowsLocalNetworking` — which the plugin's own docstring says release builds must not ("Release / TestFlight / App Store exports stay clean, keeping the App-Review scrutinized local-network keys out of production").

`_export_begin` gated on `is_debug`, which is not a dev signal: CI runs `cargo run -- export --target ios` with no `--release`, and `src/export.rs:366` picks the export mode from that flag, so the store build is a debug export. Present since #2342 (1 Jul), so 1.11.x onwards.

Fix: require an explicit developer signal on top of `is_debug` — either `DCL_IOS_GODOT_CMDLINE` is set, or the editor passed the remote-debug flag. CI sets neither, so store exports carry nothing. `cargo run -- run --target ios` now sets `DCL_IOS_GODOT_CMDLINE=auto`, keeping today's LAN auto-dial; `--no-hub` still sets `none`.

Developer-facing change: a plain editor deploy **without** remote debug no longer auto-dials the hub. Use `cargo run -- run --target ios`, or set the env.

## Deliberately not here

- **CI exports iOS with the debug template.** That is the root cause of the second item, and it flips gates well beyond this plugin (debug chat commands, early log capture, the IAP StoreKit environment switch — see #2829). Passing `--release` changes templates, symbols and all those gates at once; it needs its own PR and its own QA pass.
- **`Global._ready()` awaiting halfway through building its components.** Every autoload after `ConnectionQualityMonitor` is exposed to the same half-built `Global`. Worth fixing, not under hotfix pressure.
- **Writing `local_assets_cache_version` before the clear**, so a future crash in that window can't be permanent.

## Test plan

**Build:** `v1.13.2.<build>-<hash>-prod` · one Android + one iPhone.

Everything QA'd for 1.13.1 (#2797) carries over unchanged.

- [ ] **Version** — login screen and **Settings → About** read `v1.13.2.<build>-<hash>-prod`
- [ ] **Repro first** — iOS `1.13.0+1834` from the App Store on a device whose `local_assets_cache_version` is 4: the app dies on the splash and keeps dying on every relaunch
- [ ] **Fixed** — same device state on this build: boots to the lobby, and `[Startup] global._async_clear_cache end:` appears in the log
- [ ] **Connection monitor still works** — pull the network in-world: the connection-lost modal appears, reconnecting dismisses it
- [ ] **Store export is clean** — in the exported `Info.plist`: no `godot_cmdline`, no `NSLocalNetworkUsageDescription`, no `NSAppTransportSecurity`; a first launch raises no Local Network prompt and the Sentry `command_line_arguments` context is empty
- [ ] **Dev deploy still works** — `cargo run -- run --target ios` with the hub up connects and streams; `--no-hub` streams over `--console` as before
- [ ] **Regression** — enter a few scenes, chat, change a wearable, play an emote: no crashes
