### PR TITLE
chore: sync release into main (v1.13.3)

### DIFF
--- a/godot/addons/dcl-ios-devtools/export_plugin.gd
+++ b/godot/addons/dcl-ios-devtools/export_plugin.gd
@@ -56,10 +56,14 @@ class DclIosDevExportPlugin:
 		return platform is EditorExportPlatformIOS
 
 	func _export_begin(_features, is_debug, _path, flags):
-		# Only debug builds declare local networking / inject launch args. The relay
-		# and log-stream are themselves gated to OS.is_debug_build(), so release
-		# builds neither use nor declare it — which is what keeps App Review happy.
+		# `is_debug` alone is not a dev signal: CI exports the store build with
+		# --export-debug too, which shipped the local-network keys and a
+		# --scene-inspector pointed at the builder's LAN IP to every App Store user.
+		# Require an explicit dev signal on top — the xtask env or an editor deploy
+		# with remote debug. CI sets neither.
 		if not is_debug:
+			return
+		if _cmdline_env().is_empty() and (flags & REMOTE_DEBUG_FLAG) == 0:
 			return
 		var lines: Array = DEV_PLIST_LINES.duplicate()
 		lines.append_array(_godot_cmdline_lines(flags))
@@ -72,26 +76,19 @@ class DclIosDevExportPlugin:
 	## `--scene-inspector=ws://…` / `--log-stream=…` to a device build (an iOS app
 	## has no real CLI).
 	##
-	## Precedence: an explicit `DCL_IOS_GODOT_CMDLINE` env (set by the xtask for full
-	## control) wins. Otherwise the build is auto-pointed at the dev hub on this
-	## machine's LAN, so the app "phones home" however it was launched — including a
-	## plain Godot-editor deploy, which never sets the env. Harmless when no hub is
-	## up: the scene-inspector client just retries with backoff and (being
-	## connection-gated) captures nothing until a consumer subscribes.
+	## `DCL_IOS_GODOT_CMDLINE`: "none"/"-" injects nothing, "auto" (or an editor
+	## deploy, which sets no env) points at the dev hub on this machine's LAN,
+	## anything else is used verbatim.
 	func _godot_cmdline_lines(flags: int) -> Array:
 		var args: Array = []
-		var raw := OS.get_environment("DCL_IOS_GODOT_CMDLINE").strip_edges()
-		# Sentinel: an explicit "none"/"-" injects nothing (the xtask sets this for
-		# `run --target ios --no-hub` → plain `--console` log streaming, no hub).
+		var raw := _cmdline_env()
 		if raw.to_lower() == "none" or raw == "-":
 			return []
-		if raw.is_empty():
-			# Plain editor deploy: auto-point at the dev hub on this machine's LAN.
+		if raw.is_empty() or raw.to_lower() == "auto":
 			var host := _lan_ip()
 			if not host.is_empty():
 				args.append("--scene-inspector=ws://%s:%d" % [host, HUB_DEVICE_PORT])
 		else:
-			# Explicit override from the xtask — full control of the cmdline.
 			args.append_array(raw.split(" ", false))
 		# Remote debugger: an iOS app has no argv, so the ONLY way the editor's
 		# remote debugger can attach is to bake `--remote-debug <uri>` in here. The
@@ -142,6 +139,9 @@ class DclIosDevExportPlugin:
 		if host.is_empty():
 			return ""
 		return "tcp://%s:%d" % [host, port]
+
+	static func _cmdline_env() -> String:
+		return OS.get_environment("DCL_IOS_GODOT_CMDLINE").strip_edges()
 
 	## This machine's private-LAN IPv4 (the address a device on the same network
 	## can reach). Skips loopback, link-local and IPv6. Empty if none found.

--- a/godot/export_presets.cfg
+++ b/godot/export_presets.cfg
@@ -42,7 +42,7 @@ architectures/x86=false
 architectures/x86_64=true
 ; placeholder — the real store versionCode is stamped at export time from DCL_BUILD_NUMBER (Cloudflare Worker allocator); this committed value never ships
 version/code=1
-version/name="1.13.1"
+version/name="1.13.2"
 package/unique_name="org.decentraland.godotexplorer"
 package/name="Decentraland"
 package/signed=true
@@ -295,7 +295,7 @@ application/provisioning_profile_specifier_release=""
 application/export_method_release=1
 application/bundle_identifier="org.decentraland.godotexplorer"
 application/signature=""
-application/short_version="1.13.1"
+application/short_version="1.13.2"
 ; placeholder — the real CFBundleVersion is stamped at export time from DCL_BUILD_NUMBER (Cloudflare Worker allocator); this committed value never ships
 application/version="1"
 application/additional_plist_content="	<key>CFBundleURLTypes</key>

--- a/godot/src/connection_quality_monitor.gd
+++ b/godot/src/connection_quality_monitor.gd
@@ -80,16 +80,17 @@ func _ready() -> void:
 	_poll_timer.wait_time = FAST_POLL_SECONDS
 	_poll_timer.timeout.connect(_on_poll_timeout)
 	add_child(_poll_timer)
-	# Timer is started in _connect_signals after Global is fully initialized.
+	# Timer is started in _async_connect_signals after Global is fully initialized.
 
-	_connect_signals.call_deferred()
+	_async_connect_signals()
 
 
-func _connect_signals() -> void:
-	if Global.modal_manager == null:
-		# modal_manager not ready yet; retry next frame
-		_connect_signals.call_deferred()
-		return
+## Global._ready() awaits the startup cache clear before creating modal_manager, so
+## it can still be null here. Must yield on a real frame: a call_deferred self-retry
+## is re-entered by the same MessageQueue flush and spins until the queue overflows.
+func _async_connect_signals() -> void:
+	while Global.modal_manager == null:
+		await get_tree().process_frame
 	Global.modal_manager.connection_lost_retry.connect(_on_retry)
 	Global.modal_manager.connection_lost_exit.connect(_on_exit)
 

--- a/godot/src/ui/components/atoms/buttons/calendar_button/calendar_button.gd
+++ b/godot/src/ui/components/atoms/buttons/calendar_button/calendar_button.gd
@@ -93,7 +93,10 @@ func _get_start_iso() -> String:
 
 func _update_labels() -> void:
 	if not is_node_ready():
-		call_deferred("_update_labels")
+		# Not call_deferred: a deferred self-retry is re-entered by the same flush
+		# and spins until the message queue overflows.
+		if not ready.is_connected(_update_labels):
+			ready.connect(_update_labels, CONNECT_ONE_SHOT)
 		return
 	if not label_day or not label_time or not h_box_container_text:
 		return

--- a/lib/Cargo.lock
+++ b/lib/Cargo.lock
@@ -861,7 +861,7 @@ dependencies = [
 
 [[package]]
 name = "dclgodot"
-version = "1.13.1"
+version = "1.13.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dclgodot"
-version = "1.13.1"
+version = "1.13.2"
 edition = "2021"
 publish = false
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -694,6 +694,12 @@ fn main() -> Result<(), anyhow::Error> {
                         HUB_CONSUMER_PORT,
                         log_server::HubOutput::Quiet,
                     );
+                    if platform == "ios" {
+                        // Opt the export plugin in to baking the connect-out arg.
+                        // Without it nothing is injected, so CI store builds (which
+                        // never set this) ship no dev endpoint.
+                        std::env::set_var("DCL_IOS_GODOT_CMDLINE", "auto");
+                    }
                     // Default (no --hub-viewer): on iOS attach a background log
                     // viewer so this terminal shows the GDScript/Rust logs os_log
                     // hides from `--console`; Android's logcat already shows


### PR DESCRIPTION
Back-merges `release` (v1.13.2 + v1.13.3) into `main` through an intermediate branch so `main` picks up the three hotfixes that shipped straight to `release` and were never on `main`: the startup deferred-retry loop that crashed the app on every relaunch after updating (#2882), the dev scene-inspector endpoint baked into iOS App Store builds (#2883), and the `WebAssembly` namespace leaking into the scene sandbox (#2893). Version stays `1.14.0` (main's).

## Summary
- The only conflicts were the three version strings (`Cargo.toml`, `Cargo.lock`, `export_presets.cfg`, `1.13.3` vs `1.14.0`) — resolved to `1.14.0`. Everything else auto-merged.
- `git diff origin/main` is exactly the six files those three fixes touch (`connection_quality_monitor.gd`, `calendar_button.gd`, `dcl-ios-devtools/export_plugin.gd`, `src/main.rs`, `js/mod.rs`, `js_modules/main.js`) — no auto-merge leaks, no duplicated `func`/`fn`.
- `release` carries nothing else that `main` lacks (`git cherry` shows only these commits + the two version bumps).

⚠️ Merge with a **merge commit** (not squash / not rebase) to keep `release` and `main` history aligned, consistent with previous sync PRs (#2875, #2820, #2693, #2455).

Verified locally: `cargo check` (xtask + lib), `cargo test scene_sandbox_exposes_no_wasm_api` (passes), `gdformat --check` / `gdlint` on the merged `.gd` files (only pre-existing findings that are identical on `main`), `format_csv.py --check`, `extract_strings.py --check`.

## Test plan
Everything here already passed QA on 1.13.2 / 1.13.3 (#2884, #2894); the merge only has to keep it working on top of main's newer code.

- [ ] **Startup after an update (#2882)** — Install this build over an older one so the local-assets cache gets cleared on first launch. Open the app. Expected: it reaches the lobby / world on the first launch and on a relaunch; no crash loop. Then force a connection drop (airplane mode in-world): the "Connection lost" modal appears and **Retry** works.
- [ ] **iOS store export carries no dev endpoint (#2883)** — On the iOS TestFlight build from this branch, force a crash or send a bug report and open the Sentry event. Expected: the `cmdline args` have no `--scene-inspector=ws://…` entry, and iOS never prompts for **Local Network** access on launch.
- [ ] **Wasm blocked in scenes (#2893)** — Open the app and enter a scene whose code runs `typeof WebAssembly`. Expected: `"undefined"`; a scene that feature-detects Wasm takes its JS fallback instead of throwing. Any normal scene (Genesis Plaza) still loads and runs.
- [ ] **Regression** — `cargo run -- run --target ios` still auto-dials the local debug hub (`DCL_IOS_GODOT_CMDLINE=auto` is set by the xtask), so the on-device scene-inspector workflow keeps working for developers.
